### PR TITLE
Refactor search page `onPaste`

### DIFF
--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -295,7 +295,7 @@ export class SearchDisplayController {
         if (this._queryInput.value !== text) {
             this._queryInput.value = text;
             this._updateSearchHeight(true);
-            this._searchButton.click();
+            this._search(true, 'new', true, null);
         }
     }
 


### PR DESCRIPTION
Call `_search` function instead of triggering click on search button.