### PR TITLE
Add helper text & link for Non-English dictionaries (#1428)

### DIFF
--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -298,6 +298,10 @@
             </div>
         </div>
         <div class="modal-body">
+            <p>
+                For non-English dictionaries, please refer to the list of available 
+                <a href="https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md#downloads" target="_blank">Kaikki dictionaries</a>.
+            </p>
             <div id="recommended-term-dictionaries" hidden>
                 <h1 class="modal-title">Term Dictionaries</h1>
                 <div class="recommended-dictionary-list"></div>

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -299,8 +299,8 @@
         </div>
         <div class="modal-body">
             <p>
-                For non-English dictionaries, please refer to the list of available 
-                <a href="https://github.com/themoeway/kaikki-to-yomitan/blob/master/downloads.md#downloads" target="_blank">Kaikki dictionaries</a>.
+                For non-English dictionaries, please refer to the list of available
+                <a href="https://github.com/yomidevs/kaikki-to-yomitan/blob/master/downloads.md#downloads" target="_blank"> Kaikki dictionaries</a>.
             </p>
             <div id="recommended-term-dictionaries" hidden>
                 <h1 class="modal-title">Term Dictionaries</h1>


### PR DESCRIPTION
Add helper text to the Recommended Dictionaries modal that links to kaikki-to-yomitan, for users that don't want English dictionaries. #1428

After:
![image](https://github.com/user-attachments/assets/10e632ca-5cde-4106-a089-3e90bae2a542)
