### PR TITLE
Fix No Dictionary Enabled settings link opening in a new tab (#1343)

### DIFF
--- a/ext/popup.html
+++ b/ext/popup.html
@@ -48,7 +48,7 @@
                     <div id="no-dictionaries" hidden>
                         <div class="entry">
                             <p>No dictionaries have been installed or enabled yet.</p>
-                            <p><a href="/settings.html#!dictionaries" target="_blank">Go to Dictionaries settings.</a></p>
+                            <p><a href="/settings.html#!dictionaries" target="_top">Go to Dictionaries settings.</a></p>
                         </div>
                     </div>
                     <div id="error-extension-unloaded" hidden>


### PR DESCRIPTION
Fix #1343

Change anchor element target to navigate to the dictionaries settings without opening a new tab.