### PR TITLE
Add quick start and wiki links to info.html

### DIFF
--- a/ext/info.html
+++ b/ext/info.html
@@ -26,6 +26,26 @@
 
     <h1>Yomitan Info</h1>
 
+    <h2>Need help?</h2>
+    <div class="settings-group">
+        <a href="/quick-start-guide.html" rel="noopener" class="settings-item settings-item-button"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label">Check out the Quick Start Guide</div>
+            </div>
+            <div class="settings-item-right open-panel-button-container">
+                <button type="button" class="icon-button"><span class="icon-button-inner"><span class="icon" data-icon="material-right-arrow"></span></span></button>
+            </div>
+        </div></a>
+        <a href="https://yomitan.wiki/" rel="noopener noreferrer" class="settings-item settings-item-button"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label">Read the wiki for more information</div>
+            </div>
+            <div class="settings-item-right open-panel-button-container">
+                <button type="button" class="icon-button"><span class="icon-button-inner"><span class="icon" data-icon="material-right-arrow"></span></span></button>
+            </div>
+        </div></a>
+    </div>
+
     <h2 id="general">General</h2>
     <div class="settings-group">
         <div class="settings-item"><div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">

--- a/ext/quick-start-guide.html
+++ b/ext/quick-start-guide.html
@@ -88,7 +88,15 @@
         </div>
         <a href="/welcome.html" rel="noopener" class="settings-item settings-item-button"><div class="settings-item-inner">
             <div class="settings-item-left">
-                <div class="settings-item-label">Back to Welcome page</div>
+                <div class="settings-item-label">Go to Welcome page</div>
+            </div>
+            <div class="settings-item-right open-panel-button-container">
+                <button type="button" class="icon-button"><span class="icon-button-inner"><span class="icon" data-icon="material-right-arrow"></span></span></button>
+            </div>
+        </div></a>
+        <a href="/info.html" rel="noopener" class="settings-item settings-item-button"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label">Go to Info page</div>
             </div>
             <div class="settings-item-right open-panel-button-container">
                 <button type="button" class="icon-button"><span class="icon-button-inner"><span class="icon" data-icon="material-right-arrow"></span></span></button>

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -118,6 +118,14 @@
                 <button type="button" class="icon-button"><span class="icon-button-inner"><span class="icon" data-icon="material-right-arrow"></span></span></button>
             </div>
         </div></a>
+        <a href="https://yomitan.wiki/" rel="noopener noreferrer" class="settings-item settings-item-button"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label">Read the wiki for more information</div>
+            </div>
+            <div class="settings-item-right open-panel-button-container">
+                <button type="button" class="icon-button"><span class="icon-button-inner"><span class="icon" data-icon="material-right-arrow"></span></span></button>
+            </div>
+        </div></a>
     </div>
 
     <h2>Basic customization</h2>


### PR DESCRIPTION
Add wiki link to welcome.html
Change text to welcome on quick-start and add info page link

closes #1508

1) Info.html now has a link to the quick start and wiki

![image](https://github.com/user-attachments/assets/61573bce-5ff2-4a73-9a49-67cd654ccb04)

2) welcome.html now has a link to the wiki

![image](https://github.com/user-attachments/assets/76f47b83-1087-4271-96b6-39902545b4b8)

3) quick-start-guide.html now has a link to info and changed the text to the welcome page to be consistent. This is in order for the user to be able to navigate back to the info.html page

![image](https://github.com/user-attachments/assets/a3674629-b0ae-4d30-8b9d-57eede4f9f6b)

 