### PR TITLE
Search page displays queried sentence even when parser is off.

### DIFF
--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -131,7 +131,7 @@ export class QueryParser extends EventDispatcher {
      */
     async setText(text) {
         this._text = text;
-        this._setPreview(text); // this sets the text as the original, queried sentence
+        this._setPreview(text);
 
         if (this._useInternalParser === false && this._useMecabParser === false) {
             return;
@@ -139,7 +139,7 @@ export class QueryParser extends EventDispatcher {
         /** @type {?import('core').TokenObject} */
         const token = {};
         this._setTextToken = token;
-        this._parseResults = await this._api.parseText(text, this._getOptionsContext(), this._scanLength, this._useInternalParser, this._useMecabParser); // everything below parses the queried sentence and puts spaces between them
+        this._parseResults = await this._api.parseText(text, this._getOptionsContext(), this._scanLength, this._useInternalParser, this._useMecabParser);
         if (this._setTextToken !== token) { return; }
 
         this._refreshSelectedParser();

--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -131,12 +131,15 @@ export class QueryParser extends EventDispatcher {
      */
     async setText(text) {
         this._text = text;
-        this._setPreview(text);
+        this._setPreview(text); // this sets the text as the original, queried sentence
 
+        if (this._useInternalParser === false && this._useMecabParser === false) {
+            return;
+        }
         /** @type {?import('core').TokenObject} */
         const token = {};
         this._setTextToken = token;
-        this._parseResults = await this._api.parseText(text, this._getOptionsContext(), this._scanLength, this._useInternalParser, this._useMecabParser);
+        this._parseResults = await this._api.parseText(text, this._getOptionsContext(), this._scanLength, this._useInternalParser, this._useMecabParser); // everything below parses the queried sentence and puts spaces between them
         if (this._setTextToken !== token) { return; }
 
         this._refreshSelectedParser();


### PR DESCRIPTION
Addresses https://github.com/yomidevs/yomitan/issues/1370. When a parser is on, it will still parse words putting spaces in-between, which is not good for the user, but the result we expect. When all parsers are off, it will now only update text and not parse.

Before, Parser On:
<img width="1680" alt="Screenshot 2024-10-20 at 11 22 38 PM" src="https://github.com/user-attachments/assets/93efb539-81e3-4f5b-8446-fd33b75933d6">

Before, Parser Off:
<img width="1680" alt="Screenshot 2024-10-20 at 11 24 49 PM" src="https://github.com/user-attachments/assets/58d5a968-0119-434a-b373-15bb0c782e5d">

New Code, Parser On:
<img width="1680" alt="Screenshot 2024-10-20 at 11 24 12 PM" src="https://github.com/user-attachments/assets/15408e40-193a-4c44-9e4a-ddcb00f57104">

New Code, Parser Off:
<img width="1680" alt="Screenshot 2024-10-20 at 11 25 13 PM" src="https://github.com/user-attachments/assets/071cd41d-8272-4980-9302-1239361a6b50">
