### PR TITLE
Fix example text popup not updating correctly when scan resolution is set to `word`

### DIFF
--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -224,7 +224,7 @@ export class Frontend {
      */
     async setTextSource(textSource) {
         this._textScanner.setCurrentTextSource(null);
-        await this._textScanner.search(textSource);
+        await this._textScanner.search(textSource, null, false, true);
     }
 
     /**

--- a/ext/js/dom/dom-text-scanner.js
+++ b/ext/js/dom/dom-text-scanner.js
@@ -137,11 +137,11 @@ export class DOMTextScanner {
 
             if (nodeType === TEXT_NODE) {
                 lastNode = node;
-                if (!(
-                    forward ?
+                const shouldContinueScanning = forward ?
                     this._seekTextNodeForward(/** @type {Text} */ (node), resetOffset) :
-                    this._seekTextNodeBackward(/** @type {Text} */ (node), resetOffset)
-                )) {
+                    this._seekTextNodeBackward(/** @type {Text} */ (node), resetOffset);
+
+                if (!shouldContinueScanning) {
                     // Length reached
                     break;
                 }

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -166,7 +166,8 @@ export class TextSourceRange {
      */
     setStartOffset(length, layoutAwareScan, stopAtWordBoundary = false) {
         if (this._disallowExpandSelection) { return 0; }
-        const state = new DOMTextScanner(this._range.startContainer, this._range.startOffset, !layoutAwareScan, layoutAwareScan, stopAtWordBoundary).seek(-length);
+        let state = new DOMTextScanner(this._range.startContainer, this._range.startOffset, !layoutAwareScan, layoutAwareScan, stopAtWordBoundary);
+        state = state.seek(-length);
         this._range.setStart(state.node, state.offset);
         this._rangeStartOffset = this._range.startOffset;
         this._content = state.content + this._content;

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -1499,7 +1499,7 @@ export class TextScanner extends EventDispatcher {
      * @param {boolean} passive
      * @param {import('input').Modifier[]} modifiers
      * @param {import('input').ModifierKey[]} modifierKeys
-     * @param {import('text-scanner').InputInfoDetail} [detail]
+     * @param {import('text-scanner').InputInfoDetail?} [detail]
      * @returns {import('text-scanner').InputInfo}
      */
     _createInputInfo(input, pointerType, eventType, passive, modifiers, modifierKeys, detail) {

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -425,12 +425,13 @@ export class TextScanner extends EventDispatcher {
 
     /**
      * @param {import('text-source').TextSource} textSource
-     * @param {import('text-scanner').InputInfoDetail} [inputDetail]
-     * @param {boolean} showEmpty
+     * @param {import('text-scanner').InputInfoDetail?} [inputDetail]
+     * @param {boolean} showEmpty shows a "No results found" popup if no results are found
+     * @param {boolean} disallowExpandStartOffset disallows expanding the start offset of the range
      */
-    async search(textSource, inputDetail, showEmpty = false) {
+    async search(textSource, inputDetail, showEmpty = false, disallowExpandStartOffset = false) {
         const inputInfo = this._createInputInfo(null, 'script', 'script', true, [], [], inputDetail);
-        await this._search(textSource, this._searchTerms, this._searchKanji, inputInfo, showEmpty);
+        await this._search(textSource, this._searchTerms, this._searchKanji, inputInfo, showEmpty, disallowExpandStartOffset);
     }
 
     // Private
@@ -455,8 +456,9 @@ export class TextScanner extends EventDispatcher {
      * @param {boolean} searchKanji
      * @param {import('text-scanner').InputInfo} inputInfo
      * @param {boolean} showEmpty shows a "No results found" popup if no results are found
+     * @param {boolean} disallowExpandStartOffset disallows expanding the start offset of the range
      */
-    async _search(textSource, searchTerms, searchKanji, inputInfo, showEmpty = false) {
+    async _search(textSource, searchTerms, searchKanji, inputInfo, showEmpty = false, disallowExpandStartOffset = false) {
         try {
             const isAltText = textSource instanceof TextSourceElement;
             if (inputInfo.pointerType === 'touch') {
@@ -479,7 +481,7 @@ export class TextScanner extends EventDispatcher {
                 null
             );
 
-            if (this._scanResolution === 'word') {
+            if (this._scanResolution === 'word' && !disallowExpandStartOffset) {
                 // Move the start offset to the beginning of the word
                 textSource.setStartOffset(this._scanLength, this._layoutAwareScan, true);
             }

--- a/types/ext/text-scanner.d.ts
+++ b/types/ext/text-scanner.d.ts
@@ -104,7 +104,7 @@ export type InputInfo = {
     passive: boolean;
     modifiers: Input.Modifier[];
     modifierKeys: Input.ModifierKey[];
-    detail: InputInfoDetail | undefined;
+    detail: InputInfoDetail | undefined | null;
 };
 
 export type InputInfoDetail = {


### PR DESCRIPTION
Fixes #1526 

The html for the example text upon loading the settings page
```html
<div class="example-text-container">
    <input type="text" class="example-text example-text-input" id="example-text-input" lang="en" hidden>
    <span class="example-text" id="example-text">rea</span>
</div>
```

In a normal operations, when a user clicks on the example text, the `<span>` becomes hidden and the `<input>` becomes visible. However, all search is done _through_ the value set in the `<span>` class.

We have the class `PopupPreviewFrame` (plus an obscure css rule) that manages the state between the `<input>` and the `<span>` elements.

When search is triggered, Yomitan searches for value inside `<span>`. Since the span is hidden while editing the example text, the element would normally be skipped to scanning in DOMTextScanner. But since the initial node of the text source range IS the span text, the first node value in DOMTextScanner is processed no matter what 

```js
const textNode = this._exampleText.firstChild;
const range = document.createRange();
range.selectNodeContents(textNode);
const source = TextSourceRange.create(range);
```

**In the case of the `scanResolution` set to `word`**, upon initiating the scan, we try to expand the beginning of the initial range to encompass the entire word by looking backwards to find the word boundary. In the case of example text, we exit the `<span>` text to find a space ` ` to determine we've reached a word boundary. HOWEVER, this causes a search that starts outside the `visibility: none` `<span>` element to be skipped due to how `DOMTextScanner` skips hidden elements.

**Why didn't this break in other UX flows?**
In the case of a `scanResolution = 'character'`, we don't try to change the initial range startOffset, so the initial starting node for the search is within the hidden `<span>`
In the case of a `scanResolution = 'word'` page load, the `<input>` value is hidden while `<span>` is visible, so moving the startOffset of the initial range doesn't affect the scanability of the span text.

### Solutions considered
So in terms of fixes I had two potential options that I've explored. The first is to fix the behavior of the visibility of `<input>` and `<span>` to update correctly BEFORE the search begins since. This might be weird UX though since I'm not sure what would happen when you update the visibility of an input element while still in focus.

The second potential fix is to prevent the DOMTextScanner from leaving the `<span>` element. I tried implementing this earlier and it does complicate the DOMTextScanner a bit by forcing the scanner to peek at the contents of the previous DOM node before traversing it, which I feel like violates some abstraction boundaries of how DOMTextScanner is currently implemented.


### Solution proposed
I figured the easiest solution is to just add an extra option `disallowExpandStartOffset` that is set to `true` only in the example text popup frame. This prevents the startOffset from leaving the initial hidden `<span>`, thereby allowing scan to successfully work. This fixes our problem "cleanly" without changing too much of how we manage the popup-preview or the DOMTextScanner

