### PR TITLE
Fix UTF16 and UTF32 characters breaking cloze data due to the use of substring

### DIFF
--- a/ext/js/data/anki-note-data-creator.js
+++ b/ext/js/data/anki-note-data-creator.js
@@ -968,18 +968,19 @@ function getCloze(dictionaryEntry, context) {
     }
     if (typeof text !== 'string') { text = ''; }
     if (typeof offset !== 'number') { offset = 0; }
+    text = [...text];
 
     const textSegments = [];
-    for (const {text: text2, reading: reading2} of distributeFuriganaInflected(term, reading, [...text].slice(offset, offset + originalText.length).join(''))) {
+    for (const {text: text2, reading: reading2} of distributeFuriganaInflected(term, reading, text.slice(offset, offset + originalText.length).join(''))) {
         textSegments.push(reading2.length > 0 ? reading2 : text2);
     }
 
     return {
-        sentence: text,
-        prefix: [...text].slice(0, offset).join(''),
-        body: [...text].slice(offset, offset + originalText.length).join(''),
+        sentence: text.join(''),
+        prefix: text.slice(0, offset).join(''),
+        body: text.slice(offset, offset + originalText.length).join(''),
         bodyKana: textSegments.join(''),
-        suffix: [...text].slice(offset + originalText.length).join(''),
+        suffix: text.slice(offset + originalText.length).join(''),
     };
 }
 

--- a/ext/js/data/anki-note-data-creator.js
+++ b/ext/js/data/anki-note-data-creator.js
@@ -968,19 +968,19 @@ function getCloze(dictionaryEntry, context) {
     }
     if (typeof text !== 'string') { text = ''; }
     if (typeof offset !== 'number') { offset = 0; }
-    text = [...text];
+    const textChars = [...text];
 
     const textSegments = [];
-    for (const {text: text2, reading: reading2} of distributeFuriganaInflected(term, reading, text.slice(offset, offset + originalText.length).join(''))) {
+    for (const {text: text2, reading: reading2} of distributeFuriganaInflected(term, reading, textChars.slice(offset, offset + originalText.length).join(''))) {
         textSegments.push(reading2.length > 0 ? reading2 : text2);
     }
 
     return {
-        sentence: text.join(''),
-        prefix: text.slice(0, offset).join(''),
-        body: text.slice(offset, offset + originalText.length).join(''),
+        sentence: textChars.join(''),
+        prefix: textChars.slice(0, offset).join(''),
+        body: textChars.slice(offset, offset + originalText.length).join(''),
         bodyKana: textSegments.join(''),
-        suffix: text.slice(offset + originalText.length).join(''),
+        suffix: textChars.slice(offset + originalText.length).join(''),
     };
 }
 

--- a/ext/js/data/anki-note-data-creator.js
+++ b/ext/js/data/anki-note-data-creator.js
@@ -970,16 +970,16 @@ function getCloze(dictionaryEntry, context) {
     if (typeof offset !== 'number') { offset = 0; }
 
     const textSegments = [];
-    for (const {text: text2, reading: reading2} of distributeFuriganaInflected(term, reading, text.substring(offset, offset + originalText.length))) {
+    for (const {text: text2, reading: reading2} of distributeFuriganaInflected(term, reading, [...text].slice(offset, offset + originalText.length).join(''))) {
         textSegments.push(reading2.length > 0 ? reading2 : text2);
     }
 
     return {
         sentence: text,
-        prefix: text.substring(0, offset),
-        body: text.substring(offset, offset + originalText.length),
+        prefix: [...text].slice(0, offset).join(''),
+        body: [...text].slice(offset, offset + originalText.length).join(''),
         bodyKana: textSegments.join(''),
-        suffix: text.substring(offset + originalText.length),
+        suffix: [...text].slice(offset + originalText.length).join(''),
     };
 }
 


### PR DESCRIPTION
Nearly the same fix as #1452.