### PR TITLE
Allow scanning without moving mouse from clicking

### DIFF
--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -2011,8 +2011,6 @@ export class Display extends EventDispatcher {
                 getSearchContext: this._getSearchContext.bind(this),
                 searchTerms: true,
                 searchKanji: false,
-                searchOnClick: true,
-                searchOnClickOnly: true,
                 textSourceGenerator: this._textSourceGenerator,
             });
             this._contentTextScanner.includeSelector = '.click-scannable,.click-scannable *';

--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -66,7 +66,6 @@ export class QueryParser extends EventDispatcher {
             getSearchContext,
             searchTerms: true,
             searchKanji: false,
-            searchOnClick: true,
             textSourceGenerator,
         });
         /** @type {?(import('../language/ja/japanese-wanakana.js'))} */

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -39,8 +39,6 @@ export class TextScanner extends EventDispatcher {
         ignorePoint = null,
         searchTerms = false,
         searchKanji = false,
-        searchOnClick = false,
-        searchOnClickOnly = false,
         textSourceGenerator,
     }) {
         super();
@@ -58,10 +56,6 @@ export class TextScanner extends EventDispatcher {
         this._searchTerms = searchTerms;
         /** @type {boolean} */
         this._searchKanji = searchKanji;
-        /** @type {boolean} */
-        this._searchOnClick = searchOnClick;
-        /** @type {boolean} */
-        this._searchOnClickOnly = searchOnClickOnly;
         /** @type {import('../dom/text-source-generator').TextSourceGenerator} */
         this._textSourceGenerator = textSourceGenerator;
 
@@ -660,20 +654,7 @@ export class TextScanner extends EventDispatcher {
             return false;
         }
 
-        switch (e.button) {
-            case 0: // Primary
-                if (this._searchOnClick) { this._resetPreventNextClickScan(); }
-                this._scanTimerClear();
-                this._triggerClear('mousedown');
-                break;
-            case 1: // Middle
-                if (this._preventMiddleMouse) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    return false;
-                }
-                break;
-        }
+        this._onMouseMove(e);
     }
 
     /** */
@@ -694,28 +675,7 @@ export class TextScanner extends EventDispatcher {
             return false;
         }
 
-        if (this._searchOnClick) {
-            this._onSearchClick(e);
-        }
-    }
-
-    /**
-     * @param {MouseEvent} e
-     */
-    _onSearchClick(e) {
-        const preventNextClickScan = this._preventNextClickScan;
-        this._preventNextClickScan = false;
-        if (this._preventNextClickScanTimer !== null) {
-            clearTimeout(this._preventNextClickScanTimer);
-            this._preventNextClickScanTimer = null;
-        }
-
-        if (preventNextClickScan) { return; }
-
-        const modifiers = getActiveModifiersAndButtons(e);
-        const modifierKeys = getActiveModifiers(e);
-        const inputInfo = this._createInputInfo(null, 'mouse', 'click', false, modifiers, modifierKeys);
-        void this._searchAt(e.clientX, e.clientY, inputInfo);
+        this._onMouseMove(e);
     }
 
     /** */
@@ -1141,9 +1101,7 @@ export class TextScanner extends EventDispatcher {
         const capture = true;
         /** @type {import('event-listener-collection').AddEventListenerArgs[]} */
         let eventListenerInfos;
-        if (this._searchOnClickOnly) {
-            eventListenerInfos = this._getMouseClickOnlyEventListeners(capture);
-        } else if (this._arePointerEventsSupported()) {
+        if (this._arePointerEventsSupported()) {
             eventListenerInfos = this._getPointerEventListeners(capture);
         } else {
             eventListenerInfos = [...this._getMouseEventListeners(capture)];
@@ -1153,9 +1111,6 @@ export class TextScanner extends EventDispatcher {
             if (this._touchInputEnabled) {
                 eventListenerInfos.push(...this._getTouchEventListeners(capture));
             }
-        }
-        if (this._searchOnClick) {
-            eventListenerInfos.push(...this._getMouseClickOnlyEventListeners2(capture));
         }
 
         eventListenerInfos.push(this._getSelectionChangeCheckUserSelectionListener());
@@ -1221,35 +1176,6 @@ export class TextScanner extends EventDispatcher {
             [this._node, 'touchmove', this._onTouchMove.bind(this), {passive: false, capture}],
             [this._node, 'contextmenu', this._onContextMenu.bind(this), capture],
         ];
-    }
-
-    /**
-     * @param {boolean} capture
-     * @returns {import('event-listener-collection').AddEventListenerArgs[]}
-     */
-    _getMouseClickOnlyEventListeners(capture) {
-        return [
-            [this._node, 'click', this._onClick.bind(this), capture],
-        ];
-    }
-
-    /**
-     * @param {boolean} capture
-     * @returns {import('event-listener-collection').AddEventListenerArgs[]}
-     */
-    _getMouseClickOnlyEventListeners2(capture) {
-        const {documentElement} = document;
-        /** @type {import('event-listener-collection').AddEventListenerArgs[]} */
-        const entries = [
-            [document, 'selectionchange', this._onSelectionChange.bind(this)],
-        ];
-        if (documentElement !== null) {
-            entries.push([documentElement, 'mousedown', this._onSearchClickMouseDown.bind(this), capture]);
-            if (this._touchInputEnabled) {
-                entries.push([documentElement, 'touchstart', this._onSearchClickTouchStart.bind(this), {passive: true, capture}]);
-            }
-        }
-        return entries;
     }
 
     /**

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -654,6 +654,20 @@ export class TextScanner extends EventDispatcher {
             return false;
         }
 
+        switch (e.button) {
+            case 0: // Primary
+                this._scanTimerClear();
+                this._triggerClear('mousedown');
+                break;
+            case 1: // Middle
+                if (this._preventMiddleMouse) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    return false;
+                }
+                break;
+        }
+
         this._onMouseMove(e);
     }
 

--- a/types/ext/text-scanner.d.ts
+++ b/types/ext/text-scanner.d.ts
@@ -154,8 +154,6 @@ export type ConstructorDetails = {
     ignorePoint?: ((x: number, y: number) => Promise<boolean>) | null;
     searchTerms?: boolean;
     searchKanji?: boolean;
-    searchOnClick?: boolean;
-    searchOnClickOnly?: boolean;
     textSourceGenerator: TextSourceGenerator;
 };
 


### PR DESCRIPTION
Fixes #1280.

Needs more testing and probably some cleanup. This should also allow removing the option for scanning with middle click in favor of the user adding a scanning input option containing middle click (or any mouse button they want).