### PR TITLE
Change Polish Example to an Infinitive

### DIFF
--- a/ext/js/language/language-descriptors.js
+++ b/ext/js/language/language-descriptors.js
@@ -261,7 +261,7 @@ const languageDescriptors = [
         iso: 'pl',
         iso639_3: 'pol',
         name: 'Polish',
-        exampleText: 'czytacie',
+        exampleText: 'czytać',
         textPreprocessors: capitalizationPreprocessors,
     },
     {


### PR DESCRIPTION
Replaced the 2nd. person plural indicative (czytacie) with an infinitive (czytać) in Polish example.