### PR TITLE
Set editing profile index correctly when deleting profile

### DIFF
--- a/ext/js/pages/settings/profile-controller.js
+++ b/ext/js/pages/settings/profile-controller.js
@@ -259,9 +259,7 @@ export class ProfileController {
         this._updateProfileSelectOptions();
 
         // Update profile index
-        if (settingsProfileIndex === profileIndex) {
-            this._settingsController.profileIndex = profileCurrentNew;
-        } else if (settingsProfileIndex > profileIndex) {
+        if (settingsProfileIndex >= profileIndex) {
             this._settingsController.profileIndex = settingsProfileIndex - 1;
         } else {
             this._settingsController.refreshProfileIndex();

--- a/ext/js/pages/settings/profile-controller.js
+++ b/ext/js/pages/settings/profile-controller.js
@@ -208,50 +208,50 @@ export class ProfileController {
     }
 
     /**
-     * @param {number} profileIndex
+     * @param {number} profileIndexToDelete
      */
-    async deleteProfile(profileIndex) {
-        const profile = this._getProfile(profileIndex);
+    async deleteProfile(profileIndexToDelete) {
+        const profile = this._getProfile(profileIndexToDelete);
         if (profile === null || this.profileCount <= 1) { return; }
 
         // Get indices
-        let profileCurrentNew = this._profileCurrent;
-        const settingsProfileIndex = this._settingsController.profileIndex;
+        let profileIndexToSetDefault = this._profileCurrent;
+        const editingProfileIndex = this._settingsController.profileIndex;
 
         // Construct settings modifications
         /** @type {import('settings-modifications').Modification[]} */
         const modifications = [{
             action: 'splice',
             path: 'profiles',
-            start: profileIndex,
+            start: profileIndexToDelete,
             deleteCount: 1,
             items: [],
         }];
-        if (profileCurrentNew >= profileIndex) {
-            profileCurrentNew = Math.min(profileCurrentNew - 1, this._profiles.length - 1);
+        if (profileIndexToSetDefault >= profileIndexToDelete) {
+            profileIndexToSetDefault = Math.min(profileIndexToSetDefault - 1, this._profiles.length - 1);
             modifications.push({
                 action: 'set',
                 path: 'profileCurrent',
-                value: profileCurrentNew,
+                value: profileIndexToSetDefault,
             });
         }
 
         // Update state
-        this._profileCurrent = profileCurrentNew;
+        this._profileCurrent = profileIndexToSetDefault;
 
-        this._profiles.splice(profileIndex, 1);
+        this._profiles.splice(profileIndexToDelete, 1);
 
-        if (profileIndex < this._profileEntryList.length) {
-            const profileEntry = this._profileEntryList[profileIndex];
+        if (profileIndexToDelete < this._profileEntryList.length) {
+            const profileEntry = this._profileEntryList[profileIndexToDelete];
             profileEntry.cleanup();
-            this._profileEntryList.splice(profileIndex, 1);
+            this._profileEntryList.splice(profileIndexToDelete, 1);
 
-            for (let i = profileIndex, ii = this._profileEntryList.length; i < ii; ++i) {
+            for (let i = profileIndexToDelete, ii = this._profileEntryList.length; i < ii; ++i) {
                 this._profileEntryList[i].index = i;
             }
         }
 
-        const profileEntry2 = this._getProfileEntry(profileCurrentNew);
+        const profileEntry2 = this._getProfileEntry(profileIndexToSetDefault);
         if (profileEntry2 !== null) {
             profileEntry2.setIsDefault(true);
         }
@@ -259,8 +259,8 @@ export class ProfileController {
         this._updateProfileSelectOptions();
 
         // Update profile index
-        if (settingsProfileIndex >= profileIndex) {
-            this._settingsController.profileIndex = settingsProfileIndex - 1;
+        if (editingProfileIndex >= profileIndexToDelete) {
+            this._settingsController.profileIndex = editingProfileIndex - 1;
         } else {
             this._settingsController.refreshProfileIndex();
         }

--- a/ext/js/pages/settings/profile-controller.js
+++ b/ext/js/pages/settings/profile-controller.js
@@ -261,6 +261,10 @@ export class ProfileController {
         // Update profile index
         if (settingsProfileIndex === profileIndex) {
             this._settingsController.profileIndex = profileCurrentNew;
+        } else if (settingsProfileIndex > profileIndex) {
+            this._settingsController.profileIndex = settingsProfileIndex - 1;
+        } else {
+            this._settingsController.refreshProfileIndex();
         }
 
         // Modify settings

--- a/ext/js/pages/settings/profile-controller.js
+++ b/ext/js/pages/settings/profile-controller.js
@@ -208,50 +208,50 @@ export class ProfileController {
     }
 
     /**
-     * @param {number} profileIndexToDelete
+     * @param {number} profileIndex
      */
-    async deleteProfile(profileIndexToDelete) {
-        const profile = this._getProfile(profileIndexToDelete);
+    async deleteProfile(profileIndex) {
+        const profile = this._getProfile(profileIndex);
         if (profile === null || this.profileCount <= 1) { return; }
 
         // Get indices
-        let profileIndexToSetDefault = this._profileCurrent;
-        const editingProfileIndex = this._settingsController.profileIndex;
+        let profileCurrentNew = this._profileCurrent;
+        const settingsProfileIndex = this._settingsController.profileIndex;
 
         // Construct settings modifications
         /** @type {import('settings-modifications').Modification[]} */
         const modifications = [{
             action: 'splice',
             path: 'profiles',
-            start: profileIndexToDelete,
+            start: profileIndex,
             deleteCount: 1,
             items: [],
         }];
-        if (profileIndexToSetDefault >= profileIndexToDelete) {
-            profileIndexToSetDefault = Math.min(profileIndexToSetDefault - 1, this._profiles.length - 1);
+        if (profileCurrentNew >= profileIndex) {
+            profileCurrentNew = Math.min(profileCurrentNew - 1, this._profiles.length - 1);
             modifications.push({
                 action: 'set',
                 path: 'profileCurrent',
-                value: profileIndexToSetDefault,
+                value: profileCurrentNew,
             });
         }
 
         // Update state
-        this._profileCurrent = profileIndexToSetDefault;
+        this._profileCurrent = profileCurrentNew;
 
-        this._profiles.splice(profileIndexToDelete, 1);
+        this._profiles.splice(profileIndex, 1);
 
-        if (profileIndexToDelete < this._profileEntryList.length) {
-            const profileEntry = this._profileEntryList[profileIndexToDelete];
+        if (profileIndex < this._profileEntryList.length) {
+            const profileEntry = this._profileEntryList[profileIndex];
             profileEntry.cleanup();
-            this._profileEntryList.splice(profileIndexToDelete, 1);
+            this._profileEntryList.splice(profileIndex, 1);
 
-            for (let i = profileIndexToDelete, ii = this._profileEntryList.length; i < ii; ++i) {
+            for (let i = profileIndex, ii = this._profileEntryList.length; i < ii; ++i) {
                 this._profileEntryList[i].index = i;
             }
         }
 
-        const profileEntry2 = this._getProfileEntry(profileIndexToSetDefault);
+        const profileEntry2 = this._getProfileEntry(profileCurrentNew);
         if (profileEntry2 !== null) {
             profileEntry2.setIsDefault(true);
         }
@@ -259,8 +259,8 @@ export class ProfileController {
         this._updateProfileSelectOptions();
 
         // Update profile index
-        if (editingProfileIndex >= profileIndexToDelete) {
-            this._settingsController.profileIndex = editingProfileIndex - 1;
+        if (settingsProfileIndex >= profileIndex) {
+            this._settingsController.profileIndex = settingsProfileIndex - 1;
         } else {
             this._settingsController.refreshProfileIndex();
         }

--- a/ext/js/pages/settings/settings-controller.js
+++ b/ext/js/pages/settings/settings-controller.js
@@ -67,6 +67,7 @@ export class SettingsController extends EventDispatcher {
         this._setProfileIndex(value, true);
     }
 
+    /** */
     refreshProfileIndex() {
         this._setProfileIndex(this._profileIndex, true);
     }

--- a/ext/js/pages/settings/settings-controller.js
+++ b/ext/js/pages/settings/settings-controller.js
@@ -67,6 +67,10 @@ export class SettingsController extends EventDispatcher {
         this._setProfileIndex(value, true);
     }
 
+    refreshProfileIndex() {
+        this._setProfileIndex(this._profileIndex, true);
+    }
+
     /** @type {HtmlTemplateCollection} */
     get templates() {
         return this._templates;


### PR DESCRIPTION
Fixes #1556

Let's call editing profile index `x` and deleted profile index `y`

Currently we does not handle:
-  `x < y`: The default profile and editing profile will be reset to the first profile, however when reload the page, it still has the value before reset. Additionally, the radio button does not represent the default profile correctly. Calling `_setProfileIndex` with the same `x` value will resolve this.
- `x > y`: The editing profile index is not shifted up, therefore it moves into below profile. When the editing profile is the last index, it will cause index error, and we cannot add more profiles after that. The issue happens because when we add a profile, the editing profile index is set to last index.

List indexes are also updated correctly after deletion.