### PR TITLE
Allow queueing dictionary update & delete together

### DIFF
--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -889,11 +889,11 @@ export class DictionaryController {
     }
 
     /**
-     * @param {string} title
+     * @param {string} dictionaryTitle
      */
-    _hideUpdatesAvailableButton(title) {
+    _hideUpdatesAvailableButton(dictionaryTitle) {
         for (const entry of this._dictionaryEntries) {
-            if (entry.dictionaryTitle === title) {
+            if (entry.dictionaryTitle === dictionaryTitle) {
                 entry.hideUpdatesAvailableButton();
             }
         }

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -870,13 +870,13 @@ export class DictionaryController {
         const modal = /** @type {import('./modal.js').Modal} */ (this._updateDictionaryModal);
         modal.setVisible(false);
 
-        const title = modal.node.dataset.dictionaryTitle;
+        const dictionaryTitle = modal.node.dataset.dictionaryTitle;
         const downloadUrl = modal.node.dataset.downloadUrl;
-        if (typeof title !== 'string') { return; }
+        if (typeof dictionaryTitle !== 'string') { return; }
         delete modal.node.dataset.dictionaryTitle;
 
-        void this._enqueueTask({type: 'update', dictionaryTitle: title, downloadUrl});
-        this._hideUpdatesAvailableButton(title);
+        void this._enqueueTask({type: 'update', dictionaryTitle, downloadUrl});
+        this._hideUpdatesAvailableButton(dictionaryTitle);
     }
 
     /**

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -1105,7 +1105,6 @@ export class DictionaryController {
             } else if (task.type === 'update') {
                 await this._updateDictionary(task.dictionaryTitle, task.downloadUrl);
             }
-            console.log('Task done');
             void this._dictionaryTaskQueue.shift();
         }
         this._isTaskQueueRunning = false;

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -1231,7 +1231,7 @@ export class DictionaryController {
         /** @type {Promise<void>} */
         const importPromise = new Promise((resolve) => {
             this._settingsController.trigger('importDictionaryFromUrl', {url: downloadUrl, profilesDictionarySettings, onImportDone: resolve});
-        })
+        });
         await importPromise;
         this._isUpdating = false;
     }

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -1102,7 +1102,6 @@ export class DictionaryController {
             } else if (task.type === 'update') {
                 await this._updateDictionary(task.dictionaryTitle, task.downloadUrl);
             }
-            // await database update done before running next task
             /** @type {Promise<void>} */
             const databaseUpdatePromise = new Promise((resolve) => {
                 this._onDatabaseUpdateDone = resolve;

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -515,7 +515,7 @@ export class DictionaryController {
         /** @type {boolean} */
         this._isTaskQueueRunning = false;
         /** @type {(() => void) | null} */
-        this._onDatabaseUpdateDone = null;
+        this._onDictionariesUpdate = null;
     }
 
     /** @type {import('./modal-controller.js').ModalController} */
@@ -746,8 +746,9 @@ export class DictionaryController {
         this._dictionaries = dictionaries;
 
         await this._updateEntries();
-        if (this._onDatabaseUpdateDone) {
-            this._onDatabaseUpdateDone();
+
+        if (this._onDictionariesUpdate) {
+            this._onDictionariesUpdate();
         }
     }
 
@@ -1103,11 +1104,11 @@ export class DictionaryController {
                 await this._updateDictionary(task.dictionaryTitle, task.downloadUrl);
             }
             /** @type {Promise<void>} */
-            const databaseUpdatePromise = new Promise((resolve) => {
-                this._onDatabaseUpdateDone = resolve;
+            const dictionariesUpdatePromise = new Promise((resolve) => {
+                this._onDictionariesUpdate = resolve;
             });
-            await databaseUpdatePromise;
-            this._onDatabaseUpdateDone = null;
+            await dictionariesUpdatePromise;
+            this._onDictionariesUpdate = null;
             void this._dictionaryTaskQueue.shift();
         }
         this._isTaskQueueRunning = false;

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -1118,7 +1118,7 @@ export class DictionaryController {
     async _enqueueDictionaryDelete(dictionaryTitle) {
         if (this.isDictionaryInDeleteQueue(dictionaryTitle)) { return; }
         this._dictionaryDeleteQueue.push(dictionaryTitle);
-        if (this._isDeletingOrUpdating()) { return; }
+        if (this._isDeleting) { return; }
         while (this._dictionaryDeleteQueue.length > 0) {
             const title = this._dictionaryDeleteQueue[0];
             if (!title) { continue; }
@@ -1134,7 +1134,7 @@ export class DictionaryController {
     async _enqueueDictionaryUpdate(dictionaryTitle, downloadUrl) {
         if (this.isDictionaryInUpdateQueue(dictionaryTitle)) { return; }
         this._dictionaryUpdateQueue.push(dictionaryTitle);
-        if (this._isDeletingOrUpdating()) { return; }
+        if (this._isUpdating) { return; }
         while (this._dictionaryUpdateQueue.length > 0) {
             const title = this._dictionaryUpdateQueue[0];
             if (!title) { continue; }
@@ -1203,7 +1203,7 @@ export class DictionaryController {
      * @param {string|undefined} downloadUrl
      */
     async _updateDictionary(dictionaryTitle, downloadUrl) {
-        if (this._checkingIntegrity || this._checkingUpdates || this._isDeletingOrUpdating() || this._dictionaries === null) { return; }
+        if (this._checkingIntegrity || this._checkingUpdates || this._isUpdating || this._dictionaries === null) { return; }
 
         this._isUpdating = true;
         const dictionaryInfo = this._dictionaries.find((entry) => entry.title === dictionaryTitle);

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -1103,12 +1103,6 @@ export class DictionaryController {
             } else if (task.type === 'update') {
                 await this._updateDictionary(task.dictionaryTitle, task.downloadUrl);
             }
-            /** @type {Promise<void>} */
-            const dictionariesUpdatePromise = new Promise((resolve) => {
-                this._onDictionariesUpdate = resolve;
-            });
-            await dictionariesUpdatePromise;
-            this._onDictionariesUpdate = null;
             void this._dictionaryTaskQueue.shift();
         }
         this._isTaskQueueRunning = false;
@@ -1154,8 +1148,14 @@ export class DictionaryController {
             for (const label of infoLabels) { label.textContent = 'Deleting dictionary...'; }
             if (statusFooter !== null) { statusFooter.setTaskActive(progressSelector, true); }
 
+            /** @type {Promise<void>} */
+            const dictionariesUpdatePromise = new Promise((resolve) => {
+                this._onDictionariesUpdate = resolve;
+            });
             await this._deleteDictionaryInternal(dictionaryTitle, onProgress);
             await this._deleteDictionarySettings(dictionaryTitle);
+            await dictionariesUpdatePromise;
+            this._onDictionariesUpdate = null;
         } catch (e) {
             log.error(e);
         } finally {

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -253,8 +253,8 @@ export class DictionaryImportController {
     /**
      * @param {import('settings-controller').EventArgument<'importDictionaryFromUrl'>} details
      */
-    async _onEventImportDictionaryFromUrl({url, profilesDictionarySettings, onImportDone}) {
-        await this.importFilesFromURLs(url, profilesDictionarySettings, onImportDone);
+    _onEventImportDictionaryFromUrl({url, profilesDictionarySettings, onImportDone}) {
+        void this.importFilesFromURLs(url, profilesDictionarySettings, onImportDone);
     }
 
     /** */
@@ -443,7 +443,7 @@ export class DictionaryImportController {
 
         const importProgressTracker = new ImportProgressTracker(this._getUrlImportSteps(), urls.length);
         const onProgress = importProgressTracker.onProgress.bind(importProgressTracker);
-        await this._importDictionaries(
+        void this._importDictionaries(
             this._generateFilesFromUrls(urls, onProgress),
             profilesDictionarySettings,
             onImportDone,

--- a/types/ext/dictionary-controller.d.ts
+++ b/types/ext/dictionary-controller.d.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023-2024  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+type DictionaryDeleteTask = {
+    type: 'delete';
+    dictionaryTitle: string;
+};
+
+type DictionaryUpdateTask = {
+    type: 'update';
+    dictionaryTitle: string;
+    downloadUrl: string | undefined;
+};
+
+export type DictionaryTask = DictionaryDeleteTask | DictionaryUpdateTask;

--- a/types/ext/settings-controller.d.ts
+++ b/types/ext/settings-controller.d.ts
@@ -32,6 +32,8 @@ type ProfileDictionarySettings = Settings.DictionaryOptions & {index: number};
 
 export type ProfilesDictionarySettings = {[profileId: string]: ProfileDictionarySettings} | null;
 
+export type ImportDictionaryDoneCallback = (() => void) | null;
+
 export type Events = {
     optionsChanged: {
         options: Settings.ProfileOptions;
@@ -47,6 +49,7 @@ export type Events = {
     importDictionaryFromUrl: {
         url: string;
         profilesDictionarySettings: ProfilesDictionarySettings;
+        onImportDone: ImportDictionaryDoneCallback;
     };
     dictionaryEnabled: Record<string, never>;
     scanInputsChanged: {


### PR DESCRIPTION
Closes #1557
~~When enqueue a dictionary, hide its update button.~~

~~Also refactor dictionary update and delete behavior, only allow 1 queue to run at a time.~~
~~- If update queue is running then disable all delete buttons.~~
~~- If delete queue is running then hide all update buttons.~~