### PR TITLE
Update dictionary will update alias if alias is the same as previous title

### DIFF
--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -676,7 +676,8 @@ export class DictionaryImportController {
             if (profilesDictionarySettings === null || typeof profilesDictionarySettings[profileId] === 'undefined') {
                 targets.push({action: 'push', path: path1, items: [defaultSettings]});
             } else {
-                const {index, ...currentSettings} = profilesDictionarySettings[profileId];
+                const {index, alias, name, ...currentSettings} = profilesDictionarySettings[profileId];
+                const newAlias = alias === name ? title : alias;
                 targets.push({
                     action: 'splice',
                     path: path1,
@@ -684,6 +685,7 @@ export class DictionaryImportController {
                     items: [{
                         ...currentSettings,
                         name: title,
+                        alias: newAlias,
                     }],
                     deleteCount: 0,
                 });


### PR DESCRIPTION
Additional change to #1553.

Since we are preserving the alias when updating dictionaries, for dictionaries which have new title for every new version, the alias does not match the title after updated. For example:

<img width="308" alt="Screenshot 2024-11-05 at 11 52 33" src="https://github.com/user-attachments/assets/4a4cc26d-7b06-4aae-b377-e3f30c39e610">

Therefore, we want to update the alias if it is the same as the title (not yet set by the user), and preserve the alias otherwise.