### PR TITLE
Fix "Import dictionaries from URLs" textarea not showing newlines on firefox

### DIFF
--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -2414,7 +2414,7 @@ input[type=number].dictionary-priority {
 #dictionary-import-url-text {
     width: 100%;
     height: 4em;
-    white-space: nowrap;
+    text-wrap: nowrap;
     resize: none;
 }
 


### PR DESCRIPTION
`white-space: nowrap` is the equivalent of `white-space-collapse: collapse` and `text-wrap-mode: nowrap`. 

`white-space-collapse: collapse` is not needed here and on firefox, causes newlines to display as spaces.