### PR TITLE
Make mobile styling for action popup more reliable

### DIFF
--- a/ext/css/action-popup.css
+++ b/ext/css/action-popup.css
@@ -526,44 +526,6 @@ select.profile-select {
     overflow-wrap: break-word;
 }
 
-
-/* Fallback mobile overrides */
-
-/* Treat devices that can't hover as mobile devices */
-@media (hover: none) {
-    #full {
-        display: initial;
-    }
-    #mini {
-        display: none;
-    }
-    body {
-        min-width: 95%;
-        width: max-content;
-        font-size: calc(var(--font-size) * 2);
-        text-align: center;
-    }
-    h3 {
-        font-size: calc(var(--font-size) * 3.4);
-    }
-    .toggle-on, .toggle-off {
-        font-size: calc(var(--font-size) * 4);
-    }
-    .toggle-handle {
-        padding-left: 65px;
-        padding-right: 65px;
-        border-radius: 10px;
-    }
-    .toggle {
-        width: 100%;
-        padding-top: 37.7%;
-    }
-    #extension-info {
-        max-width: 95vw;
-        overflow-wrap: break-word;
-    }
-}
-
 /* Dark mode before themes are applied
    DO NOT use this for normal theming */
 @media (prefers-color-scheme: dark) {

--- a/ext/css/action-popup.css
+++ b/ext/css/action-popup.css
@@ -484,12 +484,12 @@ select.profile-select {
 
 /* Action popup size overrides */
 
-:root[data-mode=mini] #mini {
+#mini {
     display: flex;
     flex-flow: column nowrap;
     align-items: center;
 }
-:root[data-mode=mini] #full {
+#full {
     display: none;
 }
 

--- a/ext/css/action-popup.css
+++ b/ext/css/action-popup.css
@@ -526,6 +526,44 @@ select.profile-select {
     overflow-wrap: break-word;
 }
 
+
+/* Fallback mobile overrides */
+
+/* Treat devices that can't hover as mobile devices */
+@media (hover: none) {
+    #full {
+        display: initial;
+    }
+    #mini {
+        display: none;
+    }
+    body {
+        min-width: 95%;
+        width: max-content;
+        font-size: calc(var(--font-size) * 2);
+        text-align: center;
+    }
+    h3 {
+        font-size: calc(var(--font-size) * 3.4);
+    }
+    .toggle-on, .toggle-off {
+        font-size: calc(var(--font-size) * 4);
+    }
+    .toggle-handle {
+        padding-left: 65px;
+        padding-right: 65px;
+        border-radius: 10px;
+    }
+    .toggle {
+        width: 100%;
+        padding-top: 37.7%;
+    }
+    #extension-info {
+        max-width: 95vw;
+        overflow-wrap: break-word;
+    }
+}
+
 /* Dark mode before themes are applied
    DO NOT use this for normal theming */
 @media (prefers-color-scheme: dark) {

--- a/ext/css/action-popup.css
+++ b/ext/css/action-popup.css
@@ -75,21 +75,6 @@ label {
     font-weight: normal;
 }
 
-#mini {
-    display: flex;
-    flex-flow: column nowrap;
-    align-items: center;
-}
-#full {
-    display: none;
-}
-:root[data-mode=full] #mini {
-    display: none;
-}
-:root[data-mode=full] #full {
-    display: initial;
-}
-
 
 /* Icons */
 .icon {
@@ -497,7 +482,52 @@ select.profile-select {
     background-color: var(--warning-color);
 }
 
-/* Mobile overrides */
+/* Action popup size overrides */
+
+:root[data-mode=mini] #mini {
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: center;
+}
+:root[data-mode=mini] #full {
+    display: none;
+}
+
+:root[data-mode=full] #mini {
+    display: none;
+}
+:root[data-mode=full] #full {
+    display: initial;
+}
+
+:root[data-mode=full] body {
+    min-width: 95%;
+    width: max-content;
+    font-size: calc(var(--font-size) * 2);
+    text-align: center;
+}
+:root[data-mode=full] h3 {
+    font-size: calc(var(--font-size) * 3.4);
+}
+:root[data-mode=full] .toggle-on, .toggle-off {
+    font-size: calc(var(--font-size) * 4);
+}
+:root[data-mode=full] .toggle-handle {
+    padding-left: 65px;
+    padding-right: 65px;
+    border-radius: 10px;
+}
+:root[data-mode=full] .toggle {
+    width: 100%;
+    padding-top: 37.7%;
+}
+:root[data-mode=full] #extension-info {
+    max-width: 95vw;
+    overflow-wrap: break-word;
+}
+
+
+/* Fallback mobile overrides */
 
 /* Treat devices that can't hover as mobile devices */
 @media (hover: none) {


### PR DESCRIPTION
Currently, sometimes the styling doesn't work even though Yomitan does detect the correct action popup to use (mini or full). Sometimes the current styling can also detect certain laptops with touchscreens as being mobile devices. But we cannot remove the `@media (hover: none)` selector due to it breaking Firefox support.

Tested on both Firefox and Kiwi but I can't replicate the issue anyways to know 100% if this fixes it, only that it doesn't break anything further. Testers would be appreciated.