### PR TITLE
Add build instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ If you want to add or improve support for a language, read the documentation on 
 
 Feel free to join us on the [Yomitan Discord](https://discord.gg/YkQrXW6TXF).
 
+## Building Yomitan
+
+1. Install [Node.js](https://nodejs.org/) and [npm](https://www.npmjs.com/).
+
+2. Run `npm ci` and `npm run build`.
+
+3. The builds for each browser and release branch can be found in the `builds` directory.
+
+For more information, see [Contributing](./CONTRIBUTING.md#setup).
+
 ## Third-Party Libraries
 
 Yomitan uses several third-party libraries to function.

--- a/README.md
+++ b/README.md
@@ -100,9 +100,11 @@ Feel free to join us on the [Yomitan Discord](https://discord.gg/YkQrXW6TXF).
 
 1. Install [Node.js](https://nodejs.org/) and [npm](https://www.npmjs.com/).
 
-2. Run `npm ci` and `npm run build`.
+2. Run `npm ci` to set up the environment.
 
-3. The builds for each browser and release branch can be found in the `builds` directory.
+3. Run `npm run build` for a plain testing build or `npm run-script build -- --all --version {version}` for a release build (replacing `{version}` with a version number).
+
+4. The builds for each browser and release branch can be found in the `builds` directory.
 
 For more information, see [Contributing](./CONTRIBUTING.md#setup).
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ Feel free to join us on the [Yomitan Discord](https://discord.gg/YkQrXW6TXF).
 
 2. Run `npm ci` to set up the environment.
 
-3. Run `npm run build` for a plain testing build or `npm run-script build -- --all --version {version}` for a release build (replacing `{version}` with a version number).
+3. Run `npm run license-report:html` to generate any missing or changed license information.
 
-4. The builds for each browser and release branch can be found in the `builds` directory.
+4. Run `npm run build` for a plain testing build or `npm run-script build -- --all --version {version}` for a release build (replacing `{version}` with a version number).
+
+5. The builds for each browser and release branch can be found in the `builds` directory.
 
 For more information, see [Contributing](./CONTRIBUTING.md#setup).
 


### PR DESCRIPTION
As straightforward and simple as possible to address Mozilla's concerns.