### PR TITLE
Trim search query strings to prevent newlines expanding search page

### DIFF
--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -304,13 +304,14 @@ export class QueryParser extends EventDispatcher {
             termNode.className = 'query-parser-term';
             termNode.dataset.offset = `${offset}`;
             for (const {text, reading} of term) {
+                const trimmedText = text.trim();
                 if (reading.length === 0) {
-                    termNode.appendChild(document.createTextNode(text));
+                    termNode.appendChild(document.createTextNode(trimmedText));
                 } else {
-                    const reading2 = this._convertReading(text, reading);
-                    termNode.appendChild(this._createSegment(text, reading2, offset));
+                    const reading2 = this._convertReading(trimmedText, reading);
+                    termNode.appendChild(this._createSegment(trimmedText, reading2, offset));
                 }
-                offset += text.length;
+                offset += trimmedText.length;
             }
             fragment.appendChild(termNode);
         }

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -237,7 +237,7 @@ export class SearchDisplayController {
         this._searchBackButton.hidden = !showBackButton;
 
         if (this._queryInput.value !== query) {
-            this._queryInput.value = query;
+            this._queryInput.value = query.trim();
             this._updateSearchHeight(true);
         }
         this._setIntroVisible(!valid, animate);


### PR DESCRIPTION
Fixes #1463

When a pattern that selects newlines is added to the text replacement patterns, it can allow queries with trailing newlines to be accepted as the longest match. This can cause some weird things in the search page UI (#1463).