### PR TITLE
Show metadata when clicking on term, kanji, and frequency dictionary tags

### DIFF
--- a/ext/js/dictionary/dictionary-data-util.js
+++ b/ext/js/dictionary/dictionary-data-util.js
@@ -51,9 +51,10 @@ export function groupTermTags(dictionaryEntry) {
 
 /**
  * @param {import('dictionary').TermDictionaryEntry} dictionaryEntry
+ * @param {import('dictionary-importer').Summary[]} dictionaryInfo
  * @returns {import('dictionary-data-util').DictionaryFrequency<import('dictionary-data-util').TermFrequency>[]}
  */
-export function groupTermFrequencies(dictionaryEntry) {
+export function groupTermFrequencies(dictionaryEntry, dictionaryInfo) {
     const {headwords, frequencies: sourceFrequencies} = dictionaryEntry;
 
     /** @type {import('dictionary-data-util').TermFrequenciesMap1} */
@@ -92,16 +93,19 @@ export function groupTermFrequencies(dictionaryEntry) {
                 values: [...values.values()],
             });
         }
-        results.push({dictionary, frequencies, dictionaryAlias});
+        const currentDictionaryInfo = dictionaryInfo.find(({title}) => title === dictionary);
+        const freqCount = currentDictionaryInfo?.counts.termMeta.freq ?? 0;
+        results.push({dictionary, frequencies, dictionaryAlias, freqCount});
     }
     return results;
 }
 
 /**
  * @param {import('dictionary').KanjiFrequency[]} sourceFrequencies
+ * @param {import('dictionary-importer').Summary[]} dictionaryInfo
  * @returns {import('dictionary-data-util').DictionaryFrequency<import('dictionary-data-util').KanjiFrequency>[]}
  */
-export function groupKanjiFrequencies(sourceFrequencies) {
+export function groupKanjiFrequencies(sourceFrequencies, dictionaryInfo) {
     /** @type {import('dictionary-data-util').KanjiFrequenciesMap1} */
     const map1 = new Map();
     /** @type {Map<string, string>} */
@@ -133,7 +137,9 @@ export function groupKanjiFrequencies(sourceFrequencies) {
                 values: [...values.values()],
             });
         }
-        results.push({dictionary, frequencies, dictionaryAlias});
+        const currentDictionaryInfo = dictionaryInfo.find(({title}) => title === dictionary);
+        const freqCount = currentDictionaryInfo?.counts.kanjiMeta.freq ?? 0;
+        results.push({dictionary, frequencies, dictionaryAlias, freqCount});
     }
     return results;
 }

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -66,9 +66,10 @@ export class DisplayGenerator {
 
     /**
      * @param {import('dictionary').TermDictionaryEntry} dictionaryEntry
+     * @param {import('dictionary-importer').Summary[]} dictionaryInfo
      * @returns {HTMLElement}
      */
-    createTermEntry(dictionaryEntry) {
+    createTermEntry(dictionaryEntry, dictionaryInfo) {
         const node = this._instantiate('term-entry');
 
         const headwordsContainer = this._querySelector(node, '.headword-list');
@@ -143,6 +144,25 @@ export class DisplayGenerator {
                 dictionaryTag.dictionaries.push(dictionary);
                 dictionaryTag.name = dictionaryAlias;
                 dictionaryTag.content = [dictionary];
+
+                const currentDictionaryInfo = dictionaryInfo.find(({title}) => title === dictionary);
+                if (currentDictionaryInfo) {
+                    const dictionaryContentArray = [];
+                    dictionaryContentArray.push(currentDictionaryInfo.title);
+                    if (currentDictionaryInfo.author) {
+                        dictionaryContentArray.push('Author: ' + currentDictionaryInfo.author);
+                    }
+                    if (currentDictionaryInfo.description) {
+                        dictionaryContentArray.push('Description: ' + currentDictionaryInfo.description);
+                    }
+
+                    const totalTerms = currentDictionaryInfo.counts.terms.total;
+                    if (totalTerms > 0) {
+                        dictionaryContentArray.push('Term Count: ' + totalTerms.toString());
+                    }
+
+                    dictionaryTag.content = dictionaryContentArray;
+                }
             }
 
             const node2 = this._createTermDefinition(definition, dictionaryTag, headwords, uniqueTerms, uniqueReadings);

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -155,6 +155,9 @@ export class DisplayGenerator {
                     if (currentDictionaryInfo.description) {
                         dictionaryContentArray.push('Description: ' + currentDictionaryInfo.description);
                     }
+                    if (currentDictionaryInfo.url) {
+                        dictionaryContentArray.push('URL: ' + currentDictionaryInfo.url);
+                    }
 
                     const totalTerms = currentDictionaryInfo.counts.terms.total;
                     if (totalTerms > 0) {
@@ -210,6 +213,9 @@ export class DisplayGenerator {
             }
             if (currentDictionaryInfo.description) {
                 dictionaryContentArray.push('Description: ' + currentDictionaryInfo.description);
+            }
+            if (currentDictionaryInfo.url) {
+                dictionaryContentArray.push('URL: ' + currentDictionaryInfo.url);
             }
 
             const totalKanji = currentDictionaryInfo.counts.kanji.total;

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -82,7 +82,7 @@ export class DisplayGenerator {
         const {headwords, type, inflectionRuleChainCandidates, definitions, frequencies, pronunciations} = dictionaryEntry;
         const groupedPronunciations = getGroupedPronunciations(dictionaryEntry);
         const pronunciationCount = groupedPronunciations.reduce((i, v) => i + v.pronunciations.length, 0);
-        const groupedFrequencies = groupTermFrequencies(dictionaryEntry);
+        const groupedFrequencies = groupTermFrequencies(dictionaryEntry, dictionaryInfo);
         const termTags = groupTermTags(dictionaryEntry);
 
         /** @type {Set<string>} */
@@ -176,9 +176,10 @@ export class DisplayGenerator {
 
     /**
      * @param {import('dictionary').KanjiDictionaryEntry} dictionaryEntry
+     * @param {import('dictionary-importer').Summary[]} dictionaryInfo
      * @returns {HTMLElement}
      */
-    createKanjiEntry(dictionaryEntry) {
+    createKanjiEntry(dictionaryEntry, dictionaryInfo) {
         const node = this._instantiate('kanji-entry');
         node.dataset.dictionary = dictionaryEntry.dictionary;
 
@@ -195,7 +196,7 @@ export class DisplayGenerator {
 
         this._setTextContent(glyphContainer, dictionaryEntry.character, this._language);
         if (this._language === 'ja') { glyphContainer.style.fontFamily = 'kanji-stroke-orders, sans-serif'; }
-        const groupedFrequencies = groupKanjiFrequencies(dictionaryEntry.frequencies);
+        const groupedFrequencies = groupKanjiFrequencies(dictionaryEntry.frequencies, dictionaryInfo);
 
         const dictionaryTag = this._createDictionaryTag('');
         dictionaryTag.name = dictionaryEntry.dictionaryAlias;
@@ -848,7 +849,7 @@ export class DisplayGenerator {
         body.dataset.count = `${ii}`;
         node.dataset.count = `${ii}`;
         node.dataset.details = dictionary;
-        tag.dataset.details = dictionary;
+        tag.dataset.details = dictionary + '\nFrequency Count: ' + details.freqCount?.toString();
         return node;
     }
 

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -201,6 +201,24 @@ export class DisplayGenerator {
         const dictionaryTag = this._createDictionaryTag('');
         dictionaryTag.name = dictionaryEntry.dictionaryAlias;
         dictionaryTag.content = [dictionaryEntry.dictionary];
+        const currentDictionaryInfo = dictionaryInfo.find(({title}) => title === dictionaryEntry.dictionary);
+        if (currentDictionaryInfo) {
+            const dictionaryContentArray = [];
+            dictionaryContentArray.push(currentDictionaryInfo.title);
+            if (currentDictionaryInfo.author) {
+                dictionaryContentArray.push('Author: ' + currentDictionaryInfo.author);
+            }
+            if (currentDictionaryInfo.description) {
+                dictionaryContentArray.push('Description: ' + currentDictionaryInfo.description);
+            }
+
+            const totalKanji = currentDictionaryInfo.counts.kanji.total;
+            if (totalKanji > 0) {
+                dictionaryContentArray.push('Kanji Count: ' + totalKanji.toString());
+            }
+
+            dictionaryTag.content = dictionaryContentArray;
+        }
 
         this._appendMultiple(frequencyGroupListContainer, this._createFrequencyGroup.bind(this), groupedFrequencies, true);
         this._appendMultiple(tagContainer, this._createTag.bind(this), [...dictionaryEntry.tags, dictionaryTag]);

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -196,6 +196,8 @@ export class Display extends EventDispatcher {
         this._themeController = new ThemeController(document.documentElement);
         /** @type {import('language').LanguageSummary[]} */
         this._languageSummaries = [];
+        /** @type {import('dictionary-importer').Summary[]} */
+        this._dictionaryInfo = [];
 
         /* eslint-disable @stylistic/no-multi-spaces */
         this._hotkeyHandler.registerActions([
@@ -321,6 +323,8 @@ export class Display extends EventDispatcher {
         }
 
         this._languageSummaries = await this._application.api.getLanguageSummaries();
+
+        this._dictionaryInfo = await this._application.api.getDictionaryInfo();
 
         // Prepare
         await this._hotkeyHelpController.prepare(this._application.api);
@@ -1415,7 +1419,7 @@ export class Display extends EventDispatcher {
             const dictionaryEntry = dictionaryEntries[i];
             const entry = (
                 dictionaryEntry.type === 'term' ?
-                this._displayGenerator.createTermEntry(dictionaryEntry) :
+                this._displayGenerator.createTermEntry(dictionaryEntry, this._dictionaryInfo) :
                 this._displayGenerator.createKanjiEntry(dictionaryEntry)
             );
             entry.dataset.index = `${i}`;

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1420,7 +1420,7 @@ export class Display extends EventDispatcher {
             const entry = (
                 dictionaryEntry.type === 'term' ?
                 this._displayGenerator.createTermEntry(dictionaryEntry, this._dictionaryInfo) :
-                this._displayGenerator.createKanjiEntry(dictionaryEntry)
+                this._displayGenerator.createKanjiEntry(dictionaryEntry, this._dictionaryInfo)
             );
             entry.dataset.index = `${i}`;
             this._dictionaryEntryNodes.push(entry);

--- a/types/ext/dictionary-data-util.d.ts
+++ b/types/ext/dictionary-data-util.d.ts
@@ -49,6 +49,7 @@ export type DictionaryFrequency<T = unknown> = {
     dictionary: string;
     dictionaryAlias: string;
     frequencies: T[];
+    freqCount: number;
 };
 
 export type TermFrequency = {


### PR DESCRIPTION
Fixes #1484
Fixes #570

Didn't do pitch dicts since I couldn't think of what metadata would be useful there. That can be in another PR if needed.

Term dict:
![image](https://github.com/user-attachments/assets/e0eca646-a0d4-4b6c-9dc0-dd56575fa815)

Kanji dict (if kanjidic had a description it would be shown here...):
![image](https://github.com/user-attachments/assets/09188994-0d26-4cf9-8d9d-6eedf0404a40)

Frequency dict:
![image](https://github.com/user-attachments/assets/4a39ec85-661a-4bb1-8ab5-354cc1c2673e)
