### PR TITLE
Fix whitespace trimming in search page

### DIFF
--- a/ext/js/data/string-util.js
+++ b/ext/js/data/string-util.js
@@ -68,3 +68,14 @@ export function readCodePointsBackward(text, position, count) {
     }
     return result;
 }
+
+/**
+ * Trims trailing whitespace and adds a space on the end if it needed trimming.
+ * @param {string} text
+ * @returns {string}
+ */
+export function trimTrailingWhitespaceMinusSpace(text) {
+    const prevTextLength = text.length;
+    const textTrimmed = text.trimEnd();
+    return prevTextLength === textTrimmed.length ? textTrimmed : textTrimmed + ' ';
+}

--- a/ext/js/data/string-util.js
+++ b/ext/js/data/string-util.js
@@ -74,7 +74,7 @@ export function readCodePointsBackward(text, position, count) {
  * @param {string} text
  * @returns {string}
  */
-export function trimTrailingWhitespaceMinusSpace(text) {
+export function trimTrailingWhitespacePlusSpace(text) {
     const prevTextLength = text.length;
     const textTrimmed = text.trimEnd();
     return prevTextLength === textTrimmed.length ? textTrimmed : textTrimmed + ' ';

--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -18,7 +18,7 @@
 
 import {EventDispatcher} from '../core/event-dispatcher.js';
 import {log} from '../core/log.js';
-import {trimTrailingWhitespaceMinusSpace} from '../data/string-util.js';
+import {trimTrailingWhitespacePlusSpace} from '../data/string-util.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
 import {convertHiraganaToKatakana, convertKatakanaToHiragana, isStringEntirelyKana} from '../language/ja/japanese.js';
 import {TextScanner} from '../language/text-scanner.js';
@@ -305,7 +305,7 @@ export class QueryParser extends EventDispatcher {
             termNode.className = 'query-parser-term';
             termNode.dataset.offset = `${offset}`;
             for (const {text, reading} of term) {
-                const trimmedText = trimTrailingWhitespaceMinusSpace(text);
+                const trimmedText = trimTrailingWhitespacePlusSpace(text);
                 if (reading.length === 0) {
                     termNode.appendChild(document.createTextNode(trimmedText));
                 } else {

--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -18,6 +18,7 @@
 
 import {EventDispatcher} from '../core/event-dispatcher.js';
 import {log} from '../core/log.js';
+import {trimTrailingWhitespaceMinusSpace} from '../data/string-util.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
 import {convertHiraganaToKatakana, convertKatakanaToHiragana, isStringEntirelyKana} from '../language/ja/japanese.js';
 import {TextScanner} from '../language/text-scanner.js';
@@ -304,7 +305,7 @@ export class QueryParser extends EventDispatcher {
             termNode.className = 'query-parser-term';
             termNode.dataset.offset = `${offset}`;
             for (const {text, reading} of term) {
-                const trimmedText = text.trim();
+                const trimmedText = trimTrailingWhitespaceMinusSpace(text);
                 if (reading.length === 0) {
                     termNode.appendChild(document.createTextNode(trimmedText));
                 } else {

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -20,7 +20,6 @@ import * as wanakana from '../../lib/wanakana.js';
 import {ClipboardMonitor} from '../comm/clipboard-monitor.js';
 import {createApiMap, invokeApiMapHandler} from '../core/api-map.js';
 import {EventListenerCollection} from '../core/event-listener-collection.js';
-import {trimTrailingWhitespacePlusSpace} from '../data/string-util.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
 
 export class SearchDisplayController {
@@ -238,7 +237,7 @@ export class SearchDisplayController {
         this._searchBackButton.hidden = !showBackButton;
 
         if (this._queryInput.value !== query) {
-            this._queryInput.value = trimTrailingWhitespacePlusSpace(query);
+            this._queryInput.value = query.trimEnd();
             this._updateSearchHeight(true);
         }
         this._setIntroVisible(!valid, animate);

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -20,6 +20,7 @@ import * as wanakana from '../../lib/wanakana.js';
 import {ClipboardMonitor} from '../comm/clipboard-monitor.js';
 import {createApiMap, invokeApiMapHandler} from '../core/api-map.js';
 import {EventListenerCollection} from '../core/event-listener-collection.js';
+import {trimTrailingWhitespaceMinusSpace} from '../data/string-util.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
 
 export class SearchDisplayController {
@@ -237,7 +238,7 @@ export class SearchDisplayController {
         this._searchBackButton.hidden = !showBackButton;
 
         if (this._queryInput.value !== query) {
-            this._queryInput.value = query.trim();
+            this._queryInput.value = trimTrailingWhitespaceMinusSpace(query);
             this._updateSearchHeight(true);
         }
         this._setIntroVisible(!valid, animate);

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -20,7 +20,7 @@ import * as wanakana from '../../lib/wanakana.js';
 import {ClipboardMonitor} from '../comm/clipboard-monitor.js';
 import {createApiMap, invokeApiMapHandler} from '../core/api-map.js';
 import {EventListenerCollection} from '../core/event-listener-collection.js';
-import {trimTrailingWhitespaceMinusSpace} from '../data/string-util.js';
+import {trimTrailingWhitespacePlusSpace} from '../data/string-util.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
 
 export class SearchDisplayController {
@@ -238,7 +238,7 @@ export class SearchDisplayController {
         this._searchBackButton.hidden = !showBackButton;
 
         if (this._queryInput.value !== query) {
-            this._queryInput.value = trimTrailingWhitespaceMinusSpace(query);
+            this._queryInput.value = trimTrailingWhitespacePlusSpace(query);
             this._updateSearchHeight(true);
         }
         this._setIntroVisible(!valid, animate);


### PR DESCRIPTION
#1600 broke display of parsed words for languages with spaces. This should restore it back to how it was.

Trimming function benchmarked at 794M ops/s (compared to regex at 10M ops/s and looping at 28M ops/s).

Naming is hard, `trimTrailingWhitespacePlusSpace` is the best I could come up with... Without making the variable name a whole book.

The value for `queryInput` can be trimmed on the end normally since the only thing it does is modify what is in the search bar and not any of the parsing.