### PR TITLE
Update title

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -186,7 +186,7 @@
                     "path": [
                         "author"
                     ],
-                    "value": "TheMoeWay"
+                    "value": "Yomitan"
                 },
                 {
                     "action": "delete",
@@ -332,7 +332,7 @@
                     "path": [
                         "author"
                     ],
-                    "value": "TheMoeWay"
+                    "value": "Yomitan"
                 },
                 {
                     "action": "remove",

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -186,7 +186,7 @@
                     "path": [
                         "author"
                     ],
-                    "value": "Yomitan"
+                    "value": "Yomidevs"
                 },
                 {
                     "action": "delete",
@@ -332,7 +332,7 @@
                     "path": [
                         "author"
                     ],
-                    "value": "Yomitan"
+                    "value": "Yomidevs"
                 },
                 {
                     "action": "remove",

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -1,7 +1,7 @@
 {
     "manifest": {
         "manifest_version": 3,
-        "name": "Yomitan - Popup Dictionary",
+        "name": "Yomitan Popup Dictionary",
         "version": "$YOMITAN_VERSION",
         "description": "Popup dictionary for language learning",
         "author": {

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -1,9 +1,9 @@
 {
     "manifest": {
         "manifest_version": 3,
-        "name": "Yomitan",
+        "name": "Yomitan - Popup Dictionary",
         "version": "$YOMITAN_VERSION",
-        "description": "Japanese dictionary with Anki integration",
+        "description": "Popup dictionary for language learning",
         "author": {
             "email": "themoeway@googlegroups.com"
         },


### PR DESCRIPTION
This should update the title in Chrome and Edge. This makes it more clear what Yomitan is.

I wanted to use a longer name like "Yomitan - Popup Dictionary for Language Learning", but I don't see any real precedent for this type of description in the chrome web store so I'm worried it would not be approved. Please let me know if you feel otherwise.