### PR TITLE
Fix firefox not showing Frequency Count when clicking on freq dict tag

### DIFF
--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -848,7 +848,7 @@ export class DisplayGenerator {
      * @returns {HTMLElement}
      */
     _createFrequencyGroup(details, kanji) {
-        const {dictionary, dictionaryAlias, frequencies} = details;
+        const {dictionary, dictionaryAlias, frequencies, freqCount} = details;
 
         const node = this._instantiate('frequency-group-item');
         const body = this._querySelector(node, '.tag-body-content');
@@ -863,8 +863,8 @@ export class DisplayGenerator {
             const item = frequencies[i];
             const itemNode = (
                 kanji ?
-                this._createKanjiFrequency(/** @type {import('dictionary-data-util').KanjiFrequency} */ (item), dictionary, dictionaryAlias) :
-                this._createTermFrequency(/** @type {import('dictionary-data-util').TermFrequency} */ (item), dictionary, dictionaryAlias)
+                this._createKanjiFrequency(/** @type {import('dictionary-data-util').KanjiFrequency} */ (item), dictionary, dictionaryAlias, freqCount?.toString()) :
+                this._createTermFrequency(/** @type {import('dictionary-data-util').TermFrequency} */ (item), dictionary, dictionaryAlias, freqCount?.toString())
             );
             itemNode.dataset.index = `${i}`;
             body.appendChild(itemNode);
@@ -873,7 +873,7 @@ export class DisplayGenerator {
         body.dataset.count = `${ii}`;
         node.dataset.count = `${ii}`;
         node.dataset.details = dictionary;
-        tag.dataset.details = dictionary + '\nFrequency Count: ' + details.freqCount?.toString();
+        tag.dataset.details = dictionary + '\nFrequency Count: ' + freqCount?.toString();
         return node;
     }
 
@@ -881,9 +881,10 @@ export class DisplayGenerator {
      * @param {import('dictionary-data-util').TermFrequency} details
      * @param {string} dictionary
      * @param {string} dictionaryAlias
+     * @param {string} freqCount
      * @returns {HTMLElement}
      */
-    _createTermFrequency(details, dictionary, dictionaryAlias) {
+    _createTermFrequency(details, dictionary, dictionaryAlias, freqCount) {
         const {term, reading, values} = details;
         const node = this._instantiate('term-frequency-item');
         const tagLabel = this._querySelector(node, '.tag-label-content');
@@ -905,7 +906,7 @@ export class DisplayGenerator {
         node.dataset.readingIsSame = `${reading === term}`;
         node.dataset.dictionary = dictionary;
         node.dataset.details = dictionary;
-        tag.dataset.details = dictionary;
+        tag.dataset.details = dictionary + '\nFrequency Count: ' + freqCount;
         return node;
     }
 
@@ -913,9 +914,10 @@ export class DisplayGenerator {
      * @param {import('dictionary-data-util').KanjiFrequency} details
      * @param {string} dictionary
      * @param {string} dictionaryAlias
+     * @param {string} freqCount
      * @returns {HTMLElement}
      */
-    _createKanjiFrequency(details, dictionary, dictionaryAlias) {
+    _createKanjiFrequency(details, dictionary, dictionaryAlias, freqCount) {
         const {character, values} = details;
         const node = this._instantiate('kanji-frequency-item');
         const tagLabel = this._querySelector(node, '.tag-label-content');
@@ -928,7 +930,7 @@ export class DisplayGenerator {
         node.dataset.character = character;
         node.dataset.dictionary = dictionary;
         node.dataset.details = dictionary;
-        tag.dataset.details = dictionary;
+        tag.dataset.details = dictionary + '\nFrequency Count: ' + freqCount;
 
         return node;
     }


### PR DESCRIPTION
Due to Firefox not allowing click events to fire for elements that are not visible, this wasn't working.

For freq tags there are two `tag-label` elements at different spots in the hierarchy where events are attached. One is visible, one is hidden. The parent element of these contains the tag details data. Firefox gets the one which is visible and fails to find the correct tag details to display in the notification. For whatever insane reason, Chromium does send through click events on invisible elements so it ends up getting the other `tag-label` element which did have the frequency count data on it. I'm also not sure why we have two tag labels to begin with and why theres one that is hidden but I'm not going to dig into that here.

This PR just makes it so the data appears in both places.