### PR TITLE
Fix search page textbox size not shrinking when clicking clear button

### DIFF
--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -279,6 +279,7 @@ export class SearchDisplayController {
         e.preventDefault();
         this._queryInput.value = '';
         this._queryInput.focus();
+        this._updateSearchHeight(true);
     }
 
     /** */


### PR DESCRIPTION
If there are multiple lines in the search textbox it wouldn't shrink and would look silly with no text in it but a large textbox. This makes it go back to one line when clearing the text.