### PR TITLE
Add annotations and visibility classes to some Japanese-specific settings

### DIFF
--- a/ext/css/visibility-modifiers.css
+++ b/ext/css/visibility-modifiers.css
@@ -13,3 +13,6 @@
 :root:is([data-language=ja], [data-language=zh], [data-language=yue], [data-language=ko]) .not-jpzhyueko {
     display: none;
 }
+:root:not([data-language=ja]) .jp-only {
+    display: none;
+}

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -881,7 +881,7 @@
         <div class="settings-item advanced-only"><div class="settings-item-inner settings-item-inner-wrappable">
             <div class="settings-item-left">
                 <div class="settings-item-label">Reading mode</div>
-                <div class="settings-item-description">Change what type of furigana is displayed for parsed text.</div>
+                <div class="settings-item-description">Change what type of furigana is displayed for parsed text. Japanese only.</div>
             </div>
             <div class="settings-item-right">
                 <select data-setting="parsing.readingMode" lang="ja">
@@ -933,7 +933,10 @@
                 <div class="settings-item-left">
                     <div class="settings-item-label">
                         Pitch accent display styles
-                        <a tabindex="0" class="more-toggle more-only" data-parent-distance="4">(?)</a>
+                    </div>
+                    <div class="settings-item-description">
+                        Japanese only.
+                        <a tabindex="0" class="more-toggle more-only" data-parent-distance="4">More&hellip;</a>
                     </div>
                 </div>
                 <div class="settings-item-right flex-row-wrap">
@@ -1529,7 +1532,7 @@
                         Parse sentences using <a href="https://en.wikipedia.org/wiki/MeCab" target="_blank" rel="noopener noreferrer">MeCab</a>
                     </div>
                     <div class="settings-item-description">
-                        Sentence words are parsed using a third-party program.
+                        Sentence words are parsed using a third-party program. Japanese only.
                         <a tabindex="0" class="more-toggle more-only" data-parent-distance="4">More&hellip;</a>
                     </div>
                 </div>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -878,7 +878,7 @@
                 </select>
             </div>
         </div></div>
-        <div class="settings-item advanced-only"><div class="settings-item-inner settings-item-inner-wrappable">
+        <div class="settings-item advanced-only jp-only"><div class="settings-item-inner settings-item-inner-wrappable">
             <div class="settings-item-left">
                 <div class="settings-item-label">Reading mode</div>
                 <div class="settings-item-description">Change what type of furigana is displayed for parsed text. Japanese only.</div>
@@ -1524,7 +1524,7 @@
                 </p>
             </div>
         </div>
-        <div class="settings-item advanced-only" data-hide-for-browser="firefox-mobile">
+        <div class="settings-item advanced-only jp-only" data-hide-for-browser="firefox-mobile">
             <div class="settings-item-inner">
                 <div class="settings-item-left">
                     <div class="settings-item-invalid-indicator"></div>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -864,7 +864,7 @@
                 <label class="toggle"><input type="checkbox" data-setting="general.debugInfo"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
-        <div class="settings-item advanced-only"><div class="settings-item-inner">
+        <div class="settings-item advanced-only jpzhyue-only"><div class="settings-item-inner">
             <div class="settings-item-left">
                 <div class="settings-item-label">Term display style</div>
                 <div class="settings-item-description">Change how terms and their readings are displayed.</div>


### PR DESCRIPTION
Fixes #1612 

Changes:
- Added a `jp-only` visibility class
- **Term display style**: added the `jpzhyue-only` class
- **Reading mode**: added the "Japanese only" annotation and `jp-only` class
- **Pitch accent display**: added the "Japanese only" annotation, but not the visibility class (so other languages potentially using pitch dictionaries don't lose the setting?)
- **MeCab**: added the "Japanese only" annotation and `jp-only` class

I've kept the visibility stuff in separate commits if it's too much for the scope of this issue.