### PR TITLE
Fix collapse dictionary not working

### DIFF
--- a/ext/js/display/element-overflow-controller.js
+++ b/ext/js/display/element-overflow-controller.js
@@ -117,7 +117,6 @@ export class ElementOverflowController {
         this._elements.length = 0;
         this._eventListeners.removeAllEventListeners();
         this._windowEventListeners.removeAllEventListeners();
-        this._dictionaries.clear();
     }
 
     // Private


### PR DESCRIPTION
Fixes #1658
Regression from #1645

Don't need to call `this._dictionaries.clear();` since the number of `this._dictionaries` instances are equal to the deepest level of popup has been spawned. Unlike event listeners, it does not have cumulative effect no matter how many times the user scans.