### PR TITLE
Make dict moving faster and save scroll location

### DIFF
--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -832,9 +832,7 @@ export class DictionaryController {
         const dictionaries = this._dictionaries;
         if (dictionaries === null) { return; }
 
-        for (const entry of this._dictionaryEntries) {
-            entry.cleanup();
-        }
+        this._dictionaryEntries.map((dictionaryEntry) => dictionaryEntry.cleanup());
 
         const dictionaryOptionsArray = options.dictionaries;
         for (let i = 0, ii = dictionaryOptionsArray.length; i < ii; ++i) {

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -835,7 +835,7 @@ export class DictionaryController {
         this._dictionaryEntries.map((dictionaryEntry) => dictionaryEntry.cleanup());
 
         const dictionaryOptionsArray = options.dictionaries;
-        for (let i = 0, ii = dictionaryOptionsArray.length; i < ii; ++i) {
+        for (let i = 0; i < dictionaryOptionsArray.length; i++) {
             const {name} = dictionaryOptionsArray[i];
             /** @type {import('dictionary-importer').Summary | undefined} */
             const dictionaryInfo = dictionaries.find((dictionary) => dictionary.title === name);

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -836,17 +836,11 @@ export class DictionaryController {
             entry.cleanup();
         }
 
-        /** @type {Map<string, import('dictionary-importer').Summary>} */
-        const dictionaryInfoMap = new Map();
-        for (const dictionary of dictionaries) {
-            dictionaryInfoMap.set(dictionary.title, dictionary);
-        }
-
         const dictionaryOptionsArray = options.dictionaries;
         for (let i = 0, ii = dictionaryOptionsArray.length; i < ii; ++i) {
             const {name} = dictionaryOptionsArray[i];
             /** @type {import('dictionary-importer').Summary | undefined} */
-            const dictionaryInfo = dictionaryInfoMap.get(name);
+            const dictionaryInfo = dictionaries.find((dictionary) => dictionary.title === name);
             if (typeof dictionaryInfo === 'undefined') { continue; }
             const updateDownloadUrl = dictionaryInfo.downloadUrl ?? null;
             this._createDictionaryEntry(i, dictionaryInfo, updateDownloadUrl);

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -494,6 +494,8 @@ export class DictionaryController {
         this._settingsController = settingsController;
         /** @type {import('./modal-controller.js').ModalController} */
         this._modalController = modalController;
+        /** @type {HTMLElement} */
+        this._dictionaryModalBody = querySelectorNotNull(document, '#dictionaries-modal-body');
         /** @type {import('./status-footer.js').StatusFooter} */
         this._statusFooter = statusFooter;
         /** @type {?import('dictionary-importer').Summary[]} */
@@ -643,7 +645,7 @@ export class DictionaryController {
         const event = {source: this};
         this._settingsController.trigger('dictionarySettingsReordered', event);
 
-        await this._updateEntries();
+        this._updateCurrentEntries(options);
     }
 
     /**
@@ -820,6 +822,36 @@ export class DictionaryController {
             if (typeof dictionaryInfo === 'undefined') { continue; }
             this._createDictionaryEntry(i, dictionaryInfo, updateDownloadUrl);
         }
+    }
+
+    /**
+     * @param {import('settings').ProfileOptions} options
+     */
+    _updateCurrentEntries(options) {
+        const dictionariesModalBodyScrollY = this._dictionaryModalBody.scrollTop;
+        const dictionaries = this._dictionaries;
+        if (dictionaries === null) { return; }
+
+        for (const entry of this._dictionaryEntries) {
+            entry.cleanup();
+        }
+
+        /** @type {Map<string, import('dictionary-importer').Summary>} */
+        const dictionaryInfoMap = new Map();
+        for (const dictionary of dictionaries) {
+            dictionaryInfoMap.set(dictionary.title, dictionary);
+        }
+
+        const dictionaryOptionsArray = options.dictionaries;
+        for (let i = 0, ii = dictionaryOptionsArray.length; i < ii; ++i) {
+            const {name} = dictionaryOptionsArray[i];
+            /** @type {import('dictionary-importer').Summary | undefined} */
+            const dictionaryInfo = dictionaryInfoMap.get(name);
+            if (typeof dictionaryInfo === 'undefined') { continue; }
+            const updateDownloadUrl = dictionaryInfo.downloadUrl ?? null;
+            this._createDictionaryEntry(i, dictionaryInfo, updateDownloadUrl);
+        }
+        this._dictionaryModalBody.scroll({top: dictionariesModalBodyScrollY});
     }
 
     /**

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -11,7 +11,7 @@
                 </div>
             </div>
         </div>
-        <div class="modal-body">
+        <div id="dictionaries-modal-body" class="modal-body">
             <div class="settings-item">
                 <div class="settings-item-inner">
                     <div class="settings-item-left">


### PR DESCRIPTION
Somewhat of a fix for #1092.

Adds a stripped down synchronous version of `_updateEntries` that also resets the scroll position. 

Moving dicts doesn't require all of what `_updateEntries` uses since the number of dicts, dict names, dict contents, etc should never be changed in a move.

Intentionally not adding the scroll position reset to `_updateEntries` since during other operations there can be other errors that the user needs to see at the top of the modal body.