### PR TITLE
Add chrome dev crx to releases

### DIFF
--- a/.github/workflows/publish-chrome-development.yml
+++ b/.github/workflows/publish-chrome-development.yml
@@ -21,6 +21,7 @@ jobs:
       releaseUploadUrl: ${{ steps.getZipAsset.outputs.releaseUploadUrl }}
     permissions:
       actions: write
+      contents: write
     steps:
       - name: Get the next attempt number
         id: getNextAttemptNumber

--- a/.github/workflows/publish-chrome-development.yml
+++ b/.github/workflows/publish-chrome-development.yml
@@ -95,3 +95,20 @@ jobs:
         with:
           extensionId: ${{ secrets.G_DEVELOPMENT_EXTENSION_ID }}
           apiAccessToken: ${{ steps.fetchAccessToken.outputs.accessToken }}
+
+      - name: Sign Chrome crx for offline distribution
+        uses: cardinalby/webext-buildtools-chrome-crx-action@v2
+        with:
+          zipFilePath: 'yomitan-chrome-dev.zip'
+          crxFilePath: 'yomitan-chrome-dev.crx'
+          privateKey: ${{ secrets.CHROME_CRX_PRIVATE_KEY }}
+
+      - name: Upload offline crx release asset
+        id: uploadReleaseAsset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: yomitan-chrome-dev.crx
+          asset_name: yomitan-chrome-dev.crx


### PR DESCRIPTION
Chromium can already install extensions from zip files offline without issue but updating extensions installed that way is essentially impossible. With a consistently signed crx it is possible for users to both install and update the extension without using the store.

We can't sign the crx with the same key as google does on the store so users wont be able to update their extension with this crx file if they previously downloaded from the store. Only the store can update the store version and only the release crx will be able to update the release crx.

It also isn't reasonable to make an action that downloads the chrome store crx and uploads that since there's no way to know when the chrome store will be updated and allow downloading the new version.

This will require adding a new secret named `CHROME_CRX_PRIVATE_KEY`. How to generate this key is noted here: https://github.com/cardinalby/webext-buildtools-chrome-crx-action?tab=readme-ov-file#-privatekey-required.