### PR TITLE
Avoid using `URL.canParse` 

### DIFF
--- a/ext/js/data/anki-note-builder.js
+++ b/ext/js/data/anki-note-builder.js
@@ -82,8 +82,13 @@ export class AnkiNoteBuilder {
         }
 
         // Make URL field blank if URL source is Yomitan
-        if (URL.canParse(context.url) && new URL(context.url).protocol === new URL(import.meta.url).protocol) {
-            context.url = '';
+        try {
+            const url = new URL(context.url);
+            if (url.protocol === new URL(import.meta.url).protocol) {
+                context.url = '';
+            }
+        } catch (e) {
+            allErrors.push(new ExtensionError('Failed to parse URL'));
         }
 
         const commonData = this._createData(dictionaryEntry, mode, context, resultOutputMode, glossaryLayoutMode, compactTags, media, dictionaryStylesMap);

--- a/ext/js/data/anki-note-builder.js
+++ b/ext/js/data/anki-note-builder.js
@@ -88,7 +88,7 @@ export class AnkiNoteBuilder {
                 context.url = '';
             }
         } catch (e) {
-            allErrors.push(new ExtensionError('Failed to parse URL'));
+            // Ignore
         }
 
         const commonData = this._createData(dictionaryEntry, mode, context, resultOutputMode, glossaryLayoutMode, compactTags, media, dictionaryStylesMap);


### PR DESCRIPTION
`URL.canParse` is not supported by the Kiwi Browser as late as version `124.0.6327.4` so we need to avoid using the API until then.

A followup for the Kiwi community is here on their discord https://discord.com/channels/494814211579445270/494885738547249153/1322068526047166464