### PR TITLE
Add actionlint & fix detected issues

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "actionlint",
+            "pattern": [
+                {
+                    "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "message": 4,
+                    "code": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,14 @@
+name: Lint GitHub Actions workflows
+on: [push, pull_request]
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check workflow files
+        run: |
+            echo "::add-matcher::.github/actionlint-matcher.json"
+            bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.7.4/scripts/download-actionlint.bash)
+            ./actionlint -color
+        shell: bash

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -9,7 +9,7 @@ jobs:
         shell: bash
         env:
           PR_NUM: ${{ github.event.number }}
-        run: echo $PR_NUM > pr_num.txt
+        run: echo "$PR_NUM" > pr_num.txt
       - name: Upload the PR number
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/create-prerelease-on-tag.yml
+++ b/.github/workflows/create-prerelease-on-tag.yml
@@ -36,7 +36,7 @@ jobs:
         id: hash
         run: |
           cd builds
-          echo "hashes=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"
+          echo "hashes=$(sha256sum -- * | base64 -w0)" >> "$GITHUB_OUTPUT"
 
       - name: Release
         id: release

--- a/.github/workflows/delay.yml
+++ b/.github/workflows/delay.yml
@@ -39,6 +39,5 @@ jobs:
           inputs: |
             {
               "attemptNumber": "${{ github.event.inputs.attemptNumber }}",
-              "maxAttempts": "${{ github.event.inputs.maxAttempts }}",
-              "environment": "${{ github.event.inputs.environment }}"
+              "maxAttempts": "${{ github.event.inputs.maxAttempts }}"
             }

--- a/.github/workflows/playwright_comment.yml
+++ b/.github/workflows/playwright_comment.yml
@@ -53,14 +53,16 @@ jobs:
         id: playwright
         run: |
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "PLAYWRIGHT_OUTPUT<<$EOF" >> $GITHUB_OUTPUT
-          cat ./playwright-output >> $GITHUB_OUTPUT
-          echo "$EOF" >> $GITHUB_OUTPUT
-          echo "MASTER_SCREENSHOTS_OUTCOME<<$EOF" >> $GITHUB_OUTPUT
-          cat ./master-screenshots-outcome >> $GITHUB_OUTPUT
-          echo "$EOF" >> $GITHUB_OUTPUT
-          echo "FAILED=$(grep -c '^ *[0-9] failed$' $GITHUB_OUTPUT)" >> $GITHUB_OUTPUT
-          echo "FLAKY=$(grep -c '^ *[0-9] flaky$' $GITHUB_OUTPUT)" >> $GITHUB_OUTPUT
+          {
+            echo "PLAYWRIGHT_OUTPUT<<$EOF";
+            cat ./playwright-output;
+            echo "$EOF";
+            echo "MASTER_SCREENSHOTS_OUTCOME<<$EOF";
+            cat ./master-screenshots-outcome;
+            echo "$EOF";
+            echo "FAILED=$(grep -c '^ *[0-9] failed$' ./playwright-output)";
+            echo "FLAKY=$(grep -c '^ *[0-9] flaky$' ./playwright-output)"
+          } >> "$GITHUB_OUTPUT"
 
       # this is required because github.event.workflow_run.pull_requests is not available for PRs from forks
       - name: "Get PR information"

--- a/.github/workflows/publish-chrome-development.yml
+++ b/.github/workflows/publish-chrome-development.yml
@@ -21,7 +21,6 @@ jobs:
     environment: cd
     outputs:
       result: ${{ steps.webStorePublish.outcome }}
-      releaseUploadUrl: ${{ steps.getZipAsset.outputs.releaseUploadUrl }}
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/publish-chrome.yml
+++ b/.github/workflows/publish-chrome.yml
@@ -18,7 +18,6 @@ jobs:
     environment: cd
     outputs:
       result: ${{ steps.webStorePublish.outcome }}
-      releaseUploadUrl: ${{ steps.getZipAsset.outputs.releaseUploadUrl }}
     permissions:
       actions: write
     steps:

--- a/test/data/json.json
+++ b/test/data/json.json
@@ -9,6 +9,7 @@
         {"path": ".vscode/settings.json", "ignore": true},
         {"path": ".vscode/extensions.json", "ignore": true},
         {"path": ".vscode/launch.json", "ignore": true},
+        {"path": ".github/actionlint-matcher.json", "ignore": true},
         {"path": "dev/jsconfig.json", "ignore": true},
         {"path": "ext/manifest.json", "ignore": true},
         {"path": "test/data/dictionaries/invalid-dictionary1/index.json", "ignore": true},


### PR DESCRIPTION
GitHub actions workflows are incredibly dangerous from a security perspective, and in particular it's really easy to write vulnerable bash scripts in them. `actionlint` checks a number of things (including running shellcheck on all `run` scripts within the workflows). This will hopefully be a good start to securing our workflows a bit more.