### PR TITLE
Improve playwright comments

### DIFF
--- a/.github/workflows/playwright_comment.yml
+++ b/.github/workflows/playwright_comment.yml
@@ -52,7 +52,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_id: ${{ github.event.workflow_run.id }}
           name: playwright-report
-          dry-run: true
+          dry_run: true
 
       - name: Store playwright-report ID
         id: playwright-report-artifact-id

--- a/.github/workflows/playwright_comment.yml
+++ b/.github/workflows/playwright_comment.yml
@@ -106,7 +106,7 @@ jobs:
             | if (.number == null) then error("Could not find PR number") end
             | "pullRequestNumber=\(.number)"
         run: |
-          gh api graphql --field "filter=$SEARCH_QUERY" --raw-field "query=$GQL" --jq "$JQ_GQL" >> "${GITHUB_OUTPUT}"
+          gh api graphql --field "filter=$SEARCH_QUERY" --raw-field "query=$GQL" --jq "$JQ_FILTER" >> "${GITHUB_OUTPUT}"
 
       - name: "[Comment] Couldn't download screenshots from master branch"
         uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2

--- a/.github/workflows/playwright_comment.yml
+++ b/.github/workflows/playwright_comment.yml
@@ -54,6 +54,14 @@ jobs:
           name: playwright-report
           dry-run: true
 
+      - name: Store playwright-report ID
+        id: playwright-report-artifact-id
+        env:
+          ARTIFACTS_JSON: ${{ steps.playwright-report.outputs.artifacts }}
+        run: |
+          ID=$(echo "$ARTIFACTS_JSON" | jq -r '.[0].id');
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+
       - name: Generate summary from playwright-results.json (expected to fail to comment)
         id: playwright-summary
         uses: daun/playwright-report-summary@v3
@@ -114,7 +122,7 @@ jobs:
         with:
           issue: ${{ steps.source-run-info.outputs.pullRequestNumber }}
           message: |
-            :warning: <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts/${{ steps.playwright-report.outputs.artifacts[0].id}}">Visual changes detected by playwright; please check the report to verify if they are desirable.</a>
+            :warning: <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts/${{ steps.playwright-report-artifact-id.outputs.id }}">Visual changes detected by playwright; please check the report to verify if they are desirable.</a>
 
       - name: "[Comment] Success (but flaky): No visual differences introduced by this PR (but flaky tests detected)"
         uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
@@ -122,7 +130,7 @@ jobs:
         with:
           issue: ${{ steps.source-run-info.outputs.pullRequestNumber }}
           message: |
-            :heavy_check_mark: <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts/${{ steps.playwright-report.outputs.artifacts[0].id}}">No visual changes detected by playwright, but flaky tests were detected; please try to fix the tests.</a>
+            :heavy_check_mark: <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts/${{ steps.playwright-report-artifact-id.outputs.id }}">No visual changes detected by playwright, but flaky tests were detected; please try to fix the tests.</a>
 
       - name: "[Comment] Success: No visual differences introduced by this PR"
         uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
@@ -130,5 +138,5 @@ jobs:
         with:
           issue: ${{ steps.source-run-info.outputs.pullRequestNumber }}
           message: |
-            :heavy_check_mark: <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts/${{ steps.playwright-report.outputs.artifacts[0].id}}">No visual changes detected by playwright.</a>
+            :heavy_check_mark: <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts/${{ steps.playwright-report-artifact-id.outputs.id }}">No visual changes detected by playwright.</a>
           update-only: true

--- a/.github/workflows/playwright_comment.yml
+++ b/.github/workflows/playwright_comment.yml
@@ -21,7 +21,7 @@ jobs:
           egress-policy: audit
 
       - name: Grab playwright-output from PR run
-        uses: dawidd6/action-download-artifact@80620a5d27ce0ae443b965134db88467fc607b43 # pin@v2
+        uses: dawidd6/action-download-artifact@80620a5d27ce0ae443b965134db88467fc607b43 # v7
         continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -29,19 +29,30 @@ jobs:
           name: playwright-output
 
       - name: Grab master-screenshots-outcome from PR run
-        uses: dawidd6/action-download-artifact@80620a5d27ce0ae443b965134db88467fc607b43 # pin@v2
+        uses: dawidd6/action-download-artifact@80620a5d27ce0ae443b965134db88467fc607b43 # v7
         continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_id: ${{ github.event.workflow_run.id }}
           name: master-screenshots-outcome
+
       - name: Grab playwright-results-json from PR run
-        uses: dawidd6/action-download-artifact@80620a5d27ce0ae443b965134db88467fc607b43 # pin@v2
+        uses: dawidd6/action-download-artifact@80620a5d27ce0ae443b965134db88467fc607b43 # v7
         continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_id: ${{ github.event.workflow_run.id }}
           name: playwright-results-json
+
+      - name: Dry-run grab playwright-report from PR run so we have its ID
+        uses: dawidd6/action-download-artifact@80620a5d27ce0ae443b965134db88467fc607b43 # v7
+        id: playwright-report
+        continue-on-error: true
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: playwright-report
+          dry-run: true
 
       - name: Generate summary from playwright-results.json (expected to fail to comment)
         id: playwright-summary
@@ -65,32 +76,59 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       # this is required because github.event.workflow_run.pull_requests is not available for PRs from forks
-      - name: "Get PR information"
-        uses: potiuk/get-workflow-origin@e2dae063368361e4cd1f510e8785cd73bca9352e # pin@v1_5
+      - name: Get PR context
         id: source-run-info
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sourceRunId: ${{ github.event.workflow_run.id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Find the most recently updated open PR at the repo with the requested commit:
+          SEARCH_QUERY: >-
+            type:pr state:open sort:updated-desc
+            repo:${{ github.repository }}
+            ${{ github.event.workflow_run.head_sha }}
+          # Minimal graphql search query to fetch the PR `number` field:
+          GQL: |-
+            query($filter: String!) {
+              search( query: $filter, type: ISSUE, first: 1) {
+                nodes { ... on PullRequest { number } }
+              }
+            }
+          # Formats the GQL response into a `key=value` string + basic error handling
+          JQ_FILTER: >-
+            .data.search.nodes[0]
+            | if (.number == null) then error("Could not find PR number") end
+            | "pullRequestNumber=\(.number)"
+        run: |
+          gh api graphql --field "filter=$SEARCH_QUERY" --raw-field "query=$GQL" --jq "$JQ_GQL" >> "${GITHUB_OUTPUT}"
 
       - name: "[Comment] Couldn't download screenshots from master branch"
-        uses: mshick/add-pr-comment@dd126dd8c253650d181ad9538d8b4fa218fc31e8 # pin@v2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
         if: steps.playwright.outputs.MASTER_SCREENSHOTS_OUTCOME == 'failure'
         with:
           issue: ${{ steps.source-run-info.outputs.pullRequestNumber }}
           message: |
             :heavy_exclamation_mark: Could not fetch screenshots from master branch, so had nothing to make a visual comparison against; please check the "master-screenshots" step in the workflow run and rerun it before merging.
 
-      - name: "[Comment] Warning: Flaky tests or visual differences caused by this PR; please check the playwright report"
-        uses: mshick/add-pr-comment@dd126dd8c253650d181ad9538d8b4fa218fc31e8 # pin@v2
-        if: steps.playwright.outputs.MASTER_SCREENSHOTS_OUTCOME != 'failure' && (steps.playwright.outputs.FLAKY != 0 || steps.playwright.outputs.FAILED != 0)
+      - name: "[Comment] Warning: Visual differences caused by this PR; please check the playwright report"
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
+        if: steps.playwright.outputs.MASTER_SCREENSHOTS_OUTCOME != 'failure' && steps.playwright.outputs.FAILED != 0
         with:
           issue: ${{ steps.source-run-info.outputs.pullRequestNumber }}
-          message: ${{ steps.playwright-summary.outputs.summary }}
+          message: |
+            :warning: <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts/${{ steps.playwright-report.outputs.artifacts[0].id}}">Visual changes detected by playwright; please check the report to verify if they are desirable.</a>
+
+      - name: "[Comment] Success (but flaky): No visual differences introduced by this PR (but flaky tests detected)"
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
+        if: steps.playwright.outputs.MASTER_SCREENSHOTS_OUTCOME != 'failure' && steps.playwright.outputs.FLAKY != 0 && steps.playwright.outputs.FAILED == 0
+        with:
+          issue: ${{ steps.source-run-info.outputs.pullRequestNumber }}
+          message: |
+            :heavy_check_mark: <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts/${{ steps.playwright-report.outputs.artifacts[0].id}}">No visual changes detected by playwright, but flaky tests were detected; please try to fix the tests.</a>
 
       - name: "[Comment] Success: No visual differences introduced by this PR"
-        uses: mshick/add-pr-comment@dd126dd8c253650d181ad9538d8b4fa218fc31e8 # pin@v2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
         if: steps.playwright.outputs.MASTER_SCREENSHOTS_OUTCOME != 'failure' && steps.playwright.outputs.FLAKY == 0 && steps.playwright.outputs.FAILED == 0
         with:
           issue: ${{ steps.source-run-info.outputs.pullRequestNumber }}
-          message: ${{ steps.playwright-summary.outputs.summary }}
+          message: |
+            :heavy_check_mark: <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts/${{ steps.playwright-report.outputs.artifacts[0].id}}">No visual changes detected by playwright.</a>
           update-only: true


### PR DESCRIPTION
In https://github.com/yomidevs/yomitan/pull/1676 we merged a change that completely broke all popups.

Our E2E testing (playwright) did detect the issue, but its output was ignored.

My analysis is that it was ignored because the output of `playwright-report-summary`:
1. does not make a clear visual differentiation between flaky tests and failures, requiring the user to carefully analyze the output
2. does not link to the report artifact, making it high friction for the user to actually check the report to see what changed
3. does not have a clear call to action instructing the user what they should do

I believe it is better to have our own custom comments (basically revert https://github.com/yomidevs/yomitan/pull/1543 and improve the original comments a bit to properly differentiate between flaky and failure). That is what this PR does.

This achieves:
* Very small comment size, with just a single icon, making it easy to read and interpret
* Clear call to action to user instructing them what to do based on results
* Low friction via a direct link to the playwright-report (made possible by the new v4 artifact system on GitHub)
* Proper differentiate between flaky and failure, choosing to interpret flaky as :heavy_check_mark: (but still comment to instruct user to improve tests) and failure as :warning: so it's hard to miss.