### PR TITLE
Fix broken dictionary collection import

### DIFF
--- a/ext/js/dictionary/dictionary-database.js
+++ b/ext/js/dictionary/dictionary-database.js
@@ -200,6 +200,10 @@ export class DictionaryDatabase {
         if (this._db.isOpen()) {
             this._db.close();
         }
+        if (this._worker !== null) {
+            this._worker.terminate();
+            this._worker = null;
+        }
         let result = false;
         try {
             await Database.deleteDatabase(this._dbName);

--- a/test/utilities/database.js
+++ b/test/utilities/database.js
@@ -30,6 +30,7 @@ export function setupStubs() {
     function Worker() {
         return {
             addEventListener: () => {},
+            terminate: () => {},
         };
     }
     vi.stubGlobal('Worker', Worker);


### PR DESCRIPTION
The #1487 performance PR introduces a dictionary worker, which means there's an extra open handle to our IndexedDB db. This prevents deletion of the DB as it will result in a blocked event. So we need to clean up the worker here.