### PR TITLE
skip bench on merge_group as it's not supported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
   bench:
     name: Benchmarks
     runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup


### PR DESCRIPTION
Example failure: https://github.com/yomidevs/yomitan/actions/runs/12527643958/job/34941425160

Not a real issue, just makes the CI look broken on master