### PR TITLE
Sanitize css before sending to Anki

### DIFF
--- a/ext/js/core/utilities.js
+++ b/ext/js/core/utilities.js
@@ -276,10 +276,10 @@ export function sanitizeCSS(css) {
     try {
         sanitizer = new CSSStyleSheet();
     } catch (e) {
-        log.log("Failed to sanitize dictionary styles")
+        log.log('Failed to sanitize dictionary styles');
         log.warn(e);
         return css;
     }
     sanitizer.replaceSync(css);
-    return Array.from(sanitizer.cssRules).map(rule => rule.cssText || '').join('\n');
+    return [...sanitizer.cssRules].map((rule) => rule.cssText || '').join('\n');
 }

--- a/ext/js/core/utilities.js
+++ b/ext/js/core/utilities.js
@@ -262,3 +262,13 @@ export function deferPromise() {
 export function promiseTimeout(delay) {
     return delay <= 0 ? Promise.resolve() : new Promise((resolve) => { setTimeout(resolve, delay); });
 }
+
+/**
+ * @param {string} css
+ * @returns {string}
+ */
+export function sanitizeCSS(css) {
+    const sanitizer = new CSSStyleSheet();
+    sanitizer.replaceSync(css);
+    return Array.from(sanitizer.cssRules).map(rule => rule.cssText || '').join('\n');
+}

--- a/ext/js/core/utilities.js
+++ b/ext/js/core/utilities.js
@@ -16,6 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import {log} from './log.js';
+
+
 /**
  * Converts any string into a form that can be passed into the RegExp constructor.
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
@@ -268,7 +271,15 @@ export function promiseTimeout(delay) {
  * @returns {string}
  */
 export function sanitizeCSS(css) {
-    const sanitizer = new CSSStyleSheet();
+    let sanitizer;
+    // As of 2023/03/xx, all latest browser versions support this but some forks may lag behind
+    try {
+        sanitizer = new CSSStyleSheet();
+    } catch (e) {
+        log.log("Failed to sanitize dictionary styles")
+        log.warn(e);
+        return css;
+    }
     sanitizer.replaceSync(css);
     return Array.from(sanitizer.cssRules).map(rule => rule.cssText || '').join('\n');
 }

--- a/ext/js/data/anki-note-builder.js
+++ b/ext/js/data/anki-note-builder.js
@@ -17,7 +17,7 @@
  */
 
 import {ExtensionError} from '../core/extension-error.js';
-import {deferPromise} from '../core/utilities.js';
+import {deferPromise, sanitizeCSS} from '../core/utilities.js';
 import {convertHiraganaToKatakana, convertKatakanaToHiragana} from '../language/ja/japanese.js';
 import {cloneFieldMarkerPattern, getRootDeckName} from './anki-util.js';
 
@@ -192,7 +192,7 @@ export class AnkiNoteBuilder {
         for (const dictionary of dictionaries) {
             const {name, styles} = dictionary;
             if (typeof styles === 'string') {
-                styleMap.set(name, styles);
+                styleMap.set(name, sanitizeCSS(styles));
             }
         }
         return styleMap;


### PR DESCRIPTION
Prevents malformed css from making it to Anki. Browsers already sanitize css when adding it to the DOM so there's no need to add sanitization there.