### PR TITLE
Reintroduce `content-visibility: auto`

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -832,6 +832,7 @@ button.action-button:active {
 .entry {
     padding: var(--entry-vertical-padding) var(--entry-horizontal-padding);
     position: relative;
+    content-visibility: auto;
     contain-intrinsic-height: auto 500px;
 }
 .entry+.entry {

--- a/ext/css/structured-content.css
+++ b/ext/css/structured-content.css
@@ -171,13 +171,8 @@
     display: none;
     position: absolute;
     left: 0;
-    top: 100%;
+    bottom: 100%; /* we must open upwards here because of content-visibility: auto on .entry which will prevent painting outside of the .entry bounds */
     z-index: 1;
-}
-.entry:nth-last-of-type(1):not(:nth-of-type(1)) .gloss-image-link[data-collapsed=true] .gloss-image-container,
-:root[data-glossary-layout-mode=compact] .entry:nth-last-of-type(1):not(:nth-of-type(1)) .gloss-image-link[data-collapsible=true] .gloss-image-container {
-    bottom: 100%;
-    top: auto;
 }
 .gloss-image-link[data-collapsed=true]:hover .gloss-image-container,
 .gloss-image-link[data-collapsed=true]:focus .gloss-image-container,

--- a/ext/data/structured-content-style.json
+++ b/ext/data/structured-content-style.json
@@ -245,18 +245,8 @@
             ["display", "none"],
             ["position", "absolute"],
             ["left", "0"],
-            ["top", "100%"],
-            ["z-index", "1"]
-        ]
-    },
-    {
-        "selectors": [
-            ".entry:nth-last-of-type(1):not(:nth-of-type(1)) .gloss-image-link[data-collapsed=true] .gloss-image-container",
-            ":root[data-glossary-layout-mode=compact] .entry:nth-last-of-type(1):not(:nth-of-type(1)) .gloss-image-link[data-collapsible=true] .gloss-image-container"
-        ],
-        "styles": [
             ["bottom", "100%"],
-            ["top", "auto"]
+            ["z-index", "1"]
         ]
     },
     {


### PR DESCRIPTION
For the performance reasons stated in #1487 , reintroduce `content-visibility: auto` which provides massive benefits when the popup has a lot of content.

But this time modify the hover image in compact glossary mode to open upwards instead of downwards to avoid it getting cutoff at the bottom when it exceeds the boundary of `.entry` (because `content-visibility: auto` prevents painting outside of the element bounds). This avoids the issue in #1705 