### PR TITLE
add open attribute for details

### DIFF
--- a/ext/data/schemas/dictionary-term-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-term-bank-v3-schema.json
@@ -119,6 +119,10 @@
                                     "type": "string",
                                     "description": "Hover text for the element."
                                 },
+                                "open": {
+                                    "type": "boolean",
+                                    "description": "Whether or not the details element is open by default."
+                                },
                                 "lang": {
                                     "type": "string",
                                     "description": "Defines the language of an element in the format defined by RFC 5646."

--- a/ext/js/display/structured-content-generator.js
+++ b/ext/js/display/structured-content-generator.js
@@ -366,11 +366,12 @@ export class StructuredContentGenerator {
                 break;
         }
         if (hasStyle) {
-            const {style, title} = /** @type {import('structured-content').StyledElement} */ (content);
+            const {style, title, open} = /** @type {import('structured-content').StyledElement} */ (content);
             if (typeof style === 'object' && style !== null) {
                 this._setStructuredContentElementStyle(node, style);
             }
             if (typeof title === 'string') { node.title = title; }
+            if (typeof open === 'boolean' && open) { node.setAttribute('open', ''); }
         }
         if (hasChildren) {
             this._appendStructuredContent(node, content.content, dictionary, language);

--- a/types/ext/structured-content.d.ts
+++ b/types/ext/structured-content.d.ts
@@ -131,6 +131,10 @@ export type StyledElement = {
      */
     title?: string;
     /**
+     * Whether or not the details element is open by default.
+     */
+    open?: boolean;
+    /**
      * Defines the language of an element in the format defined by RFC 5646.
      */
     lang?: string;


### PR DESCRIPTION
Allows the `details` element to be opened by default.

I'm creating a new layout for extra information in [kaikki-to-yomitan](https://github.com/yomidevs/kaikki-to-yomitan) like `etymology`, `head-info`, `synonyms`, `morphemes` etc. So this will be useful for having entries like `morphemes` open by default.