### PR TITLE
Try and reduce playwright flakiness

### DIFF
--- a/test/playwright/visual.spec.js
+++ b/test/playwright/visual.spec.js
@@ -149,7 +149,7 @@ test.describe('popup', () => {
 
             try {
                 await page.mouse.move(box.x - 5, box.y - 5); // Hover near the test
-                await page.mouse.move(box.x + 15, box.y + 15); // Hover over the test
+                await page.mouse.move(box.x + 15, box.y + 15, {steps: 10}); // Hover over the test
                 if (expectedState === 'visible') {
                     const popup_frame = await frame_attached;
                     await (await /** @type {import('@playwright/test').Frame} */ (popup_frame).frameElement())


### PR DESCRIPTION
We can see in https://github.com/yomidevs/yomitan/pull/1740 that there seems to be some flakiness with playwright results on popups.

I removed this `steps` in one of the playwright performance PRs since I thought I had it working in a non-flaky manner, but it's possible this is still required to bring it from 99% to 100%, so this will attempt to reintroduce it.