### PR TITLE
Modify tag.sh to sign tags

### DIFF
--- a/tag.sh
+++ b/tag.sh
@@ -48,7 +48,7 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 	exit 1
 fi
 
-git tag $TAG
+git tag -s $TAG
 
 echo -e -n "${YELLOW}Do you want to push the tag ${TAG} to the remote repository (which will cause a pre-release to get created)? (y/n): ${NC}"
 read -p "" -n 1 -r


### PR DESCRIPTION
We should sign/annotate our tags so it's clear who did the tag. See #1687 as well.

Eventually we may be able to modify our CI to require the tag to be signed before creating the release, which would give us some really nice cryptographic guarantees about the release validity all the way to the store essentially.