### PR TITLE
Remove \r from anki note generator tsv

### DIFF
--- a/ext/js/pages/settings/anki-deck-generator-controller.js
+++ b/ext/js/pages/settings/anki-deck-generator-controller.js
@@ -550,7 +550,7 @@ export class AnkiDeckGeneratorController {
         let tsv = '';
         for (const key in noteFields) {
             if (Object.prototype.hasOwnProperty.call(noteFields, key)) {
-                tsv += noteFields[key].replaceAll('\t', '&nbsp;&nbsp;&nbsp;').replaceAll('\n', '') + '\t';
+                tsv += noteFields[key].replaceAll('\t', '&nbsp;&nbsp;&nbsp;').replaceAll('\n', '').replaceAll('\r', '') + '\t';
             }
         }
         return tsv;


### PR DESCRIPTION
Apparently some dicts have a `\r\n` in them and even after removing the `\n`, the browser inflates it back to `\r\n` when saving.