### PR TITLE
Add Welsh support

### DIFF
--- a/ext/js/language/language-descriptors.js
+++ b/ext/js/language/language-descriptors.js
@@ -401,6 +401,13 @@ const languageDescriptors = [
         },
     },
     {
+        iso: 'cy',
+        iso639_3: 'cym',
+        name: 'Welsh',
+        exampleText: 'ddarllen',
+        textPreprocessors: capitalizationPreprocessors,
+    },
+    {
         iso: 'yi',
         iso639_3: 'yid',
         name: 'Yiddish',

--- a/types/ext/language-descriptors.d.ts
+++ b/types/ext/language-descriptors.d.ts
@@ -214,7 +214,7 @@ type AllTextProcessors = {
     };
     cy: {
         pre:  CapitalizationPreprocessors; 
-    }
+    };
     yi: {
         pre: {
             combineYiddishLigatures: TextProcessor<boolean>;

--- a/types/ext/language-descriptors.d.ts
+++ b/types/ext/language-descriptors.d.ts
@@ -212,6 +212,9 @@ type AllTextProcessors = {
             normalizeDiacritics: TextProcessor<'old' | 'new' | 'off'>;
         };
     };
+    cy: {
+        pre:  CapitalizationPreprocessors; 
+    }
     yi: {
         pre: {
             combineYiddishLigatures: TextProcessor<boolean>;

--- a/types/ext/language-descriptors.d.ts
+++ b/types/ext/language-descriptors.d.ts
@@ -213,7 +213,7 @@ type AllTextProcessors = {
         };
     };
     cy: {
-        pre:  CapitalizationPreprocessors; 
+        pre: CapitalizationPreprocessors;
     };
     yi: {
         pre: {


### PR DESCRIPTION
This PR adds the Welsh language support.
https://en.wikipedia.org/wiki/Welsh_language

The welsh language uses capitalisation and has an alphabet with 29 characters in the alphabet (although several are diagraphs), from the Latin alphabet: https://en.wikipedia.org/wiki/Welsh_orthography
The language supports Majuscule forms, Titlecase forms and Miniscule forms. There are 8 diacritics which are primarily used for vowels, made up of letters from the Latin alphabet.