### PR TITLE
Apply preventNextMouseDown for touch end to prevent instantly closing popup 

### DIFF
--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -1344,7 +1344,16 @@ export class TextScanner extends EventDispatcher {
      * @param {import('text-scanner').InputInfo} inputInfo
      */
     async _searchAtFromTouchEnd(x, y, inputInfo) {
+        const textSourceCurrentPrevious = this._textSourceCurrent !== null ? this._textSourceCurrent.clone() : null;
+
         await this._searchAt(x, y, inputInfo);
+
+        if (
+            this._textSourceCurrent !== null &&
+            !(textSourceCurrentPrevious !== null && this._textSourceCurrent.hasSameStart(textSourceCurrentPrevious))
+        ) {
+            this._preventNextMouseDown = true;
+        }
     }
 
     /**


### PR DESCRIPTION
On some sites, there is an issue where touching too quickly will show the popup but then it will instantly disappear. This only happens when the popup is triggered on a touch end (touch release an touch tap).

Adding `preventNextMouseDown` prevents erroneous clicks from being registered after the touch release that make the popup close itself.

This implementation is similar to `_searchAtFromTouchStart` right above it.