### PR TITLE
Fix setStartOffset stopAtWordBoundary behavior to terminate at the beginning of current div

### DIFF
--- a/ext/js/dom/dom-text-scanner.js
+++ b/ext/js/dom/dom-text-scanner.js
@@ -131,7 +131,7 @@ export class DOMTextScanner {
         let lastNode = /** @type {Node} */ (node);
         let resetOffset = this._resetOffset;
         let newlines = 0;
-    seekLoop:
+        seekLoop:
         while (node !== null) {
             let enterable = false;
             const nodeType = node.nodeType;

--- a/ext/js/dom/dom-text-scanner.js
+++ b/ext/js/dom/dom-text-scanner.js
@@ -152,13 +152,14 @@ export class DOMTextScanner {
                     break;
                 }
                 lastNode = node;
-                const initialNodeAtBeginningOfNodeGoingBackwards = node === this._initialNode && this._offset === 0 && !forward;
-                const initialNodeAtEndOfNodeGoingForwards = node === this._initialNode && this._offset === node.childNodes.length && forward;
                 this._offset = 0;
+                const isInitialNode = node === this._initialNode;
                 ({enterable, newlines} = DOMTextScanner.getElementSeekInfo(/** @type {Element} */ (node)));
-                if (newlines > this._newlines && generateLayoutContent) {
+                if (!isInitialNode && newlines > this._newlines && generateLayoutContent) {
                     this._newlines = newlines;
                 }
+                const initialNodeAtBeginningOfNodeGoingBackwards = node === this._initialNode && this._offset === 0 && !forward;
+                const initialNodeAtEndOfNodeGoingForwards = node === this._initialNode && this._offset === node.childNodes.length && forward;
                 if (initialNodeAtBeginningOfNodeGoingBackwards || initialNodeAtEndOfNodeGoingForwards) {
                     enterable = false;
                 }

--- a/ext/js/dom/dom-text-scanner.js
+++ b/ext/js/dom/dom-text-scanner.js
@@ -131,6 +131,7 @@ export class DOMTextScanner {
         let lastNode = /** @type {Node} */ (node);
         let resetOffset = this._resetOffset;
         let newlines = 0;
+    seekLoop:
         while (node !== null) {
             let enterable = false;
             const nodeType = node.nodeType;
@@ -142,7 +143,7 @@ export class DOMTextScanner {
                     this._seekTextNodeBackward(/** @type {Text} */ (node), resetOffset);
 
                 if (!shouldContinueScanning) {
-                    // Length reached
+                    // Length reached or reached a word boundary
                     break;
                 }
             } else if (nodeType === ELEMENT_NODE) {
@@ -172,6 +173,10 @@ export class DOMTextScanner {
                 ({newlines} = DOMTextScanner.getElementSeekInfo(/** @type {Element} */ (exitedNode)));
                 if (newlines > this._newlines && generateLayoutContent) {
                     this._newlines = newlines;
+                }
+                if (newlines > 0 && this._stopAtWordBoundary && !forward) {
+                    // Element nodes are considered word boundaries when scanning backwards
+                    break seekLoop;
                 }
             }
 
@@ -285,14 +290,10 @@ export class DOMTextScanner {
             case 2:
             case 3:
                 if (this._newlines > 0) {
-                    if (this._content.length > 0) {
-                        const useNewlineCount = Math.min(this._remainder, this._newlines);
-                        this._content += '\n'.repeat(useNewlineCount);
-                        this._remainder -= useNewlineCount;
-                        this._newlines -= useNewlineCount;
-                    } else {
-                        this._newlines = 0;
-                    }
+                    const useNewlineCount = Math.min(this._remainder, this._newlines);
+                    this._content += '\n'.repeat(useNewlineCount);
+                    this._remainder -= useNewlineCount;
+                    this._newlines -= useNewlineCount;
                     this._lineHasContent = false;
                     this._lineHasWhitespace = false;
                     if (this._remainder <= 0) {
@@ -341,14 +342,10 @@ export class DOMTextScanner {
             case 2:
             case 3:
                 if (this._newlines > 0) {
-                    if (this._content.length > 0) {
-                        const useNewlineCount = Math.min(this._remainder, this._newlines);
-                        this._content = '\n'.repeat(useNewlineCount) + this._content;
-                        this._remainder -= useNewlineCount;
-                        this._newlines -= useNewlineCount;
-                    } else {
-                        this._newlines = 0;
-                    }
+                    const useNewlineCount = Math.min(this._remainder, this._newlines);
+                    this._content = '\n'.repeat(useNewlineCount) + this._content;
+                    this._remainder -= useNewlineCount;
+                    this._newlines -= useNewlineCount;
                     this._lineHasContent = false;
                     this._lineHasWhitespace = false;
                     if (this._remainder <= 0) {

--- a/ext/js/dom/dom-text-scanner.js
+++ b/ext/js/dom/dom-text-scanner.js
@@ -152,14 +152,14 @@ export class DOMTextScanner {
                     break;
                 }
                 lastNode = node;
+                const initialNodeAtBeginningOfNodeGoingBackwards = node === this._initialNode && this._offset === 0 && !forward;
+                const initialNodeAtEndOfNodeGoingForwards = node === this._initialNode && this._offset === node.childNodes.length && forward;
                 this._offset = 0;
                 const isInitialNode = node === this._initialNode;
                 ({enterable, newlines} = DOMTextScanner.getElementSeekInfo(/** @type {Element} */ (node)));
                 if (!isInitialNode && newlines > this._newlines && generateLayoutContent) {
                     this._newlines = newlines;
                 }
-                const initialNodeAtBeginningOfNodeGoingBackwards = node === this._initialNode && this._offset === 0 && !forward;
-                const initialNodeAtEndOfNodeGoingForwards = node === this._initialNode && this._offset === node.childNodes.length && forward;
                 if (initialNodeAtBeginningOfNodeGoingBackwards || initialNodeAtEndOfNodeGoingForwards) {
                     enterable = false;
                 }

--- a/test/data/html/dom-text-scanner.html
+++ b/test/data/html/dom-text-scanner.html
@@ -17,11 +17,11 @@
         data-test-data='{
             "node": "div:nth-of-type(1)",
             "offset": 0,
-            "length": 15,
+            "length": 16,
             "expected": {
                 "node": "div:nth-of-type(2)>div::text",
                 "offset": 3,
-                "content": "小ぢん\nまり1\n小ぢん\nまり2"
+                "content": "\n小ぢん\nまり1\n小ぢん\nまり2"
             }
         }'
     >


### PR DESCRIPTION
Fixes #1636 and #1648

Basically if you click the first word of a div
```html
<div>
  <div>Clipboard Monitor</div>
  <span>query</span>
</span>
```

the DOMTextScanner starts the scan right before `<span>query</span>`. When `extractSentence` is run and it goes backwards to `<div>Clipboard Monitor</div>`, `this._newlines` is set to `1` for being a div but it doesn't hit this  [`if (this._content.length > 0)` condition](https://github.com/yomidevs/yomitan/blob/master/ext/js/dom/dom-text-scanner.js#L344) which causes the `\n` not to be added to `this._content`

The fix is actually fixing two issues:

1. `setStartOffset` with `stopAtWordBoundary = true` terminates outside the div of the word if the word is at the beginning of the div.
```html
<div class="outer">
<!-- terminates here -->
    <div class="inner">word</div>
</div>
```
We fix this to terminate at the beginning of the `div.inner` element rather than the end of the of `div.outer`
2. DOMTextScanner doesn't add new lines if the existing `this._content` is an empty string. I'm not sure why the check was put in in the first place, but it was introduced 5 years ago when DOMTextScanner was created, so context is certainly lost now. We can remove this conditional and add newlines independent of whether the existing `content` is `''`

Tested on Chrome on search page and ttsu as well as the replication instructions for #1636 and #1648