### PR TITLE
Bump awalsh128/cache-apt-pkgs-action to version that does not use deprecated dependencies

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install CJK fonts
-        uses: awalsh128/cache-apt-pkgs-action@a6c3917cc929dd0345bfb2d3feaf9101823370ad # v1.4.2
+        uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
         with:
           packages: fonts-ipafont-mincho
           execute_install_scripts: true


### PR DESCRIPTION
Fixes playwright test failing.

https://github.com/awalsh128/cache-apt-pkgs-action/commit/5902b33ae29014e6ca012c5d8025d4346556bd40