### PR TITLE
Use addScopeToCssLegacy to fix dict css on Kiwi due to out of date Chromium base

### DIFF
--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -26,7 +26,7 @@ import {ExtensionError} from '../core/extension-error.js';
 import {log} from '../core/log.js';
 import {safePerformance} from '../core/safe-performance.js';
 import {toError} from '../core/to-error.js';
-import {addScopeToCss, clone, deepEqual, promiseTimeout} from '../core/utilities.js';
+import {addScopeToCssLegacy, clone, deepEqual, promiseTimeout} from '../core/utilities.js';
 import {setProfile} from '../data/profiles-util.js';
 import {PopupMenu} from '../dom/popup-menu.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
@@ -1255,7 +1255,7 @@ export class Display extends EventDispatcher {
         for (const {name, enabled, styles = ''} of dictionaries) {
             if (enabled) {
                 const escapedTitle = name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-                customCss += '\n' + addScopeToCss(styles, `[data-dictionary="${escapedTitle}"]`);
+                customCss += '\n' + addScopeToCssLegacy(styles, `[data-dictionary="${escapedTitle}"]`);
             }
         }
         this.setCustomCss(customCss);


### PR DESCRIPTION
Only tested on Chromium. Need a tester for Kiwi.