### PR TITLE
Make anki error footer notification text red and bold

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -1945,6 +1945,12 @@ button.footer-notification-close-button {
     padding-left: 1.5em;
     list-style: disc;
 }
+.anki-note-error-info {
+    color: var(--danger-color);
+}
+.anki-note-error-header {
+    font-weight: bold;
+}
 
 
 /* Conditional styles */


### PR DESCRIPTION
Fixes #1753 

Not going full red with the background and all since I don't think it should be too disruptive.

| Before | ![image](https://github.com/user-attachments/assets/e08c46f9-330e-4cb3-b9c5-1d4303888431) | ![image](https://github.com/user-attachments/assets/7bd14046-a97e-4bba-af93-d6bc4f99b730) | 
|--------|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
| After  | ![image](https://github.com/user-attachments/assets/980165ec-8b2f-4a57-b39d-aa3c69f68b0a) | ![image](https://github.com/user-attachments/assets/d7d0ccc5-64b4-4157-94e1-38a9e20a5060) |