### PR TITLE
Only show dictionaries with at least one term for single-glossary handlebars

### DIFF
--- a/ext/js/data/anki-template-util.js
+++ b/ext/js/data/anki-template-util.js
@@ -111,7 +111,7 @@ export function getDynamicTemplates(options, dictionaryInfo) {
         const currentDictionaryInfo = dictionaryInfo.find(({title}) => title === dictionary.name);
         if (!dictionary.enabled) { continue; }
         const totalTerms = currentDictionaryInfo?.counts?.terms?.total;
-        if (!!totalTerms && totalTerms > 0) { continue; }
+        if (!totalTerms || totalTerms === 0) { continue; }
         dynamicTemplates += `
 {{#*inline "single-glossary-${getKebabCase(dictionary.name)}"}}
     {{~> glossary selectedDictionary='${escapeDictName(dictionary.name)}'}}
@@ -140,7 +140,7 @@ export function getDynamicFieldMarkers(dictionaries, dictionaryInfo) {
         const currentDictionaryInfo = dictionaryInfo.find(({title}) => title === dictionary.name);
         if (!dictionary.enabled) { continue; }
         const totalTerms = currentDictionaryInfo?.counts?.terms?.total;
-        if (!!totalTerms && totalTerms > 0) { continue; }
+        if (!totalTerms || totalTerms === 0) { continue; }
         markers.push(`single-glossary-${getKebabCase(dictionary.name)}`);
     }
     return markers;

--- a/ext/js/data/anki-template-util.js
+++ b/ext/js/data/anki-template-util.js
@@ -110,7 +110,8 @@ export function getDynamicTemplates(options, dictionaryInfo) {
     for (const dictionary of options.dictionaries) {
         const currentDictionaryInfo = dictionaryInfo.find(({title}) => title === dictionary.name);
         if (!dictionary.enabled) { continue; }
-        if (currentDictionaryInfo?.counts?.terms.total === 0) { continue; }
+        const totalTerms = currentDictionaryInfo?.counts?.terms?.total;
+        if (!!totalTerms && totalTerms > 0) { continue; }
         dynamicTemplates += `
 {{#*inline "single-glossary-${getKebabCase(dictionary.name)}"}}
     {{~> glossary selectedDictionary='${escapeDictName(dictionary.name)}'}}
@@ -138,7 +139,8 @@ export function getDynamicFieldMarkers(dictionaries, dictionaryInfo) {
     for (const dictionary of dictionaries) {
         const currentDictionaryInfo = dictionaryInfo.find(({title}) => title === dictionary.name);
         if (!dictionary.enabled) { continue; }
-        if (currentDictionaryInfo?.counts?.terms.total === 0) { continue; }
+        const totalTerms = currentDictionaryInfo?.counts?.terms?.total;
+        if (!!totalTerms && totalTerms > 0) { continue; }
         markers.push(`single-glossary-${getKebabCase(dictionary.name)}`);
     }
     return markers;

--- a/ext/js/data/anki-template-util.js
+++ b/ext/js/data/anki-template-util.js
@@ -102,12 +102,15 @@ export function getStandardFieldMarkers(type) {
 
 /**
  * @param {import('settings').ProfileOptions} options
+ * @param {import('dictionary-importer').Summary[]} dictionaryInfo
  * @returns {string}
  */
-export function getDynamicTemplates(options) {
+export function getDynamicTemplates(options, dictionaryInfo) {
     let dynamicTemplates = '\n';
     for (const dictionary of options.dictionaries) {
+        const currentDictionaryInfo = dictionaryInfo.find(({title}) => title === dictionary.name);
         if (!dictionary.enabled) { continue; }
+        if (currentDictionaryInfo?.counts?.terms.total === 0) { continue; }
         dynamicTemplates += `
 {{#*inline "single-glossary-${getKebabCase(dictionary.name)}"}}
     {{~> glossary selectedDictionary='${escapeDictName(dictionary.name)}'}}
@@ -127,12 +130,15 @@ export function getDynamicTemplates(options) {
 
 /**
  * @param {import('settings').DictionariesOptions} dictionaries
+ * @param {import('dictionary-importer').Summary[]} dictionaryInfo
  * @returns {string[]} The list of field markers.
  */
-export function getDynamicFieldMarkers(dictionaries) {
+export function getDynamicFieldMarkers(dictionaries, dictionaryInfo) {
     const markers = [];
     for (const dictionary of dictionaries) {
+        const currentDictionaryInfo = dictionaryInfo.find(({title}) => title === dictionary.name);
         if (!dictionary.enabled) { continue; }
+        if (currentDictionaryInfo?.counts?.terms.total === 0) { continue; }
         markers.push(`single-glossary-${getKebabCase(dictionary.name)}`);
     }
     return markers;

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -833,8 +833,9 @@ export class DisplayAnki {
      * @returns {Promise<string>}
      */
     async _getAnkiFieldTemplates(options) {
+        const dictionaryInfo = await this._display.application.api.getDictionaryInfo();
         const staticTemplates = await this._getStaticAnkiFieldTemplates(options);
-        const dynamicTemplates = getDynamicTemplates(options);
+        const dynamicTemplates = getDynamicTemplates(options, dictionaryInfo);
         return staticTemplates + dynamicTemplates;
     }
 
@@ -935,6 +936,12 @@ export class DisplayAnki {
         if (context === null) { throw new Error('Note context not initialized'); }
         const modeOptions = this._modeOptions.get(mode);
         if (typeof modeOptions === 'undefined') { throw new Error(`Unsupported note type: ${mode}`); }
+        if (!this._ankiFieldTemplates) {
+            const options = this._display.getOptions();
+            if (options) {
+                await this._updateAnkiFieldTemplates(options);
+            }
+        }
         const template = this._ankiFieldTemplates;
         if (typeof template !== 'string') { throw new Error('Invalid template'); }
         const {deck: deckName, model: modelName} = modeOptions;

--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -31,8 +31,11 @@ import {ObjectPropertyAccessor} from '../../general/object-property-accessor.js'
 export class AnkiController {
     /**
      * @param {import('./settings-controller.js').SettingsController} settingsController
+     * @param {import('../../application.js').Application} application
      */
-    constructor(settingsController) {
+    constructor(settingsController, application) {
+        /** @type {import('../../application.js').Application} */
+        this._application = application;
         /** @type {import('./settings-controller.js').SettingsController} */
         this._settingsController = settingsController;
         /** @type {AnkiConnect} */
@@ -181,7 +184,7 @@ export class AnkiController {
 
         this._updateDuplicateOverwriteWarning(anki.duplicateBehavior);
 
-        this._setupFieldMenus(dictionaries);
+        void this._setupFieldMenus(dictionaries);
     }
 
     /** */
@@ -309,7 +312,7 @@ export class AnkiController {
     /**
      * @param {import('settings').DictionariesOptions} dictionaries
      */
-    _setupFieldMenus(dictionaries) {
+    async _setupFieldMenus(dictionaries) {
         /** @type {[types: import('dictionary').DictionaryEntryType[], templateName: string][]} */
         const fieldMenuTargets = [
             [['term'], 'anki-card-terms-field-menu'],
@@ -339,7 +342,8 @@ export class AnkiController {
                 markers.push(...getStandardFieldMarkers(type));
             }
             if (types.includes('term')) {
-                markers.push(...getDynamicFieldMarkers(dictionaries));
+                const dictionaryInfo = await this._application.api.getDictionaryInfo();
+                markers.push(...getDynamicFieldMarkers(dictionaries, dictionaryInfo));
             }
             markers = [...new Set(markers.sort())];
 

--- a/ext/js/pages/settings/anki-deck-generator-controller.js
+++ b/ext/js/pages/settings/anki-deck-generator-controller.js
@@ -434,7 +434,7 @@ export class AnkiDeckGeneratorController {
             query: sentenceText,
             fullQuery: sentenceText,
         };
-        const template = this._getAnkiTemplate(options);
+        const template = await this._getAnkiTemplate(options);
         const deckOptionsFields = options.anki.terms.fields;
         const {general: {resultOutputMode, glossaryLayoutMode, compactTags}} = options;
         const fields = [];
@@ -512,12 +512,13 @@ export class AnkiDeckGeneratorController {
 
     /**
      * @param {import('settings').ProfileOptions} options
-     * @returns {string}
+     * @returns {Promise<string>}
      */
-    _getAnkiTemplate(options) {
+    async _getAnkiTemplate(options) {
         let staticTemplates = options.anki.fieldTemplates;
         if (typeof staticTemplates !== 'string') { staticTemplates = this._defaultFieldTemplates; }
-        const dynamicTemplates = getDynamicTemplates(options);
+        const dictionaryInfo = await this._application.api.getDictionaryInfo();
+        const dynamicTemplates = getDynamicTemplates(options, dictionaryInfo);
         return staticTemplates + '\n' + dynamicTemplates;
     }
 

--- a/ext/js/pages/settings/anki-templates-controller.js
+++ b/ext/js/pages/settings/anki-templates-controller.js
@@ -263,7 +263,7 @@ export class AnkiTemplatesController {
                     query: sentenceText,
                     fullQuery: sentenceText,
                 };
-                const template = this._getAnkiTemplate(options);
+                const template = await this._getAnkiTemplate(options);
                 const {general: {resultOutputMode, glossaryLayoutMode, compactTags}} = options;
                 const {note, errors} = await this._ankiNoteBuilder.createNote(/** @type {import('anki-note-builder').CreateNoteDetails} */ ({
                     dictionaryEntry,
@@ -315,12 +315,13 @@ export class AnkiTemplatesController {
 
     /**
      * @param {import('settings').ProfileOptions} options
-     * @returns {string}
+     * @returns {Promise<string>}
      */
-    _getAnkiTemplate(options) {
+    async _getAnkiTemplate(options) {
         let staticTemplates = options.anki.fieldTemplates;
         if (typeof staticTemplates !== 'string') { staticTemplates = this._defaultFieldTemplates; }
-        const dynamicTemplates = getDynamicTemplates(options);
+        const dictionaryInfo = await this._application.api.getDictionaryInfo();
+        const dynamicTemplates = getDynamicTemplates(options, dictionaryInfo);
         return staticTemplates + '\n' + dynamicTemplates;
     }
 }

--- a/ext/js/pages/settings/settings-main.js
+++ b/ext/js/pages/settings/settings-main.js
@@ -124,7 +124,7 @@ await Application.main(true, async (application) => {
     const settingsBackup = new BackupController(settingsController, modalController);
     preparePromises.push(settingsBackup.prepare());
 
-    const ankiController = new AnkiController(settingsController);
+    const ankiController = new AnkiController(settingsController, application);
     preparePromises.push(ankiController.prepare());
 
     const ankiDeckGeneratorController = new AnkiDeckGeneratorController(application, settingsController, modalController, ankiController);


### PR DESCRIPTION
Some users have thought they could use the `single-glossary` handlebars for frequency or pronunciation dicts due to them showing on the list. This removes them. It also opens the door for other handlebars for example `single-frequency` or `single-pitch-accent`.