### PR TITLE
Fix cutoff indicator and audio failed X on search page

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -59,6 +59,7 @@
     --main-content-horizontal-padding: 0em;
     --entry-horizontal-padding: 0.72em;
     --entry-vertical-padding: 0.72em;
+    --query-horizontal-padding: 0.72em;
 
     --sidebar-width-no-units: 40;
     --sidebar-width: calc(1em * (var(--sidebar-width-no-units) / var(--font-size-no-units)));
@@ -607,8 +608,8 @@ button.sidebar-button.sidebar-button-highlight {
 }
 #query-parser-container {
     overflow-y: auto;
-    padding-left: var(--entry-horizontal-padding);
-    padding-right: var(--entry-horizontal-padding);
+    padding-left: var(--query-horizontal-padding);
+    padding-right: var(--query-horizontal-padding);
     padding-bottom: 0.25em;
     border-bottom: var(--headword-thin-border-size) solid var(--light-border-color);
 }

--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -18,9 +18,6 @@
 
 /* Variables */
 :root {
-    --main-content-horizontal-padding: 0.72em;
-    --entry-horizontal-padding: 0;
-
     --padding: calc(10em / var(--font-size-no-units));
     --content-width-search: 700;
     --content-width: calc(1em * var(--content-width-search) / var(--font-size-no-units));

--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -18,6 +18,8 @@
 
 /* Variables */
 :root {
+    --query-horizontal-padding: 0;
+
     --padding: calc(10em / var(--font-size-no-units));
     --content-width-search: 700;
     --content-width: calc(1em * var(--content-width-search) / var(--font-size-no-units));


### PR DESCRIPTION
Fixes #1814
Fixes #1812

`content-visibility: auto;` appears to only render elements in padding when the padding comes from the element itself. Not any if its children. This shifts the padding from being provided by `--main-content-horizontal-padding` to `--entry-horizontal-padding` (which is applied to the `entry` class) on the search page.

Added `--query-horizontal-padding` to allow the search page to override the padding of that element as it had done before but without it breaking the rendering of everything on the sides.

(The element that has padding set to 0):
![Screenshot_2025-02-11_14-46-39](https://github.com/user-attachments/assets/e9248419-f879-416f-9d8f-87ec9ebaa80f)

| Before                                                                                     | After                                                                                     |
|--------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
| ![before](https://github.com/user-attachments/assets/5c680b04-f76e-486d-af2f-16f32337cfbb) | ![after](https://github.com/user-attachments/assets/8aa11f5c-740f-4a74-998d-2be19871a30f) |

(There is no difference besides the triangle displaying on the left side)
