### PR TITLE
Add support for omnibox search with Yomitan

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -34,7 +34,7 @@
             "type": "module"
         },
         "omnibox": {
-            "keyword": "Yomitan"
+            "keyword": "yomi"
         },
         "content_scripts": [
             {

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -33,6 +33,9 @@
             "service_worker": "sw.js",
             "type": "module"
         },
+        "omnibox": {
+            "keyword": "Yomitan"
+        },
         "content_scripts": [
             {
                 "run_at": "document_idle",

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1373,6 +1373,8 @@ export class Backend {
 
         this._setupContextMenu(options);
 
+        this._attachOmniboxListener();
+
         void this._accessibilityController.update(this._getOptionsFull(false));
 
         this._sendMessageAllTabsIgnoreResponse({action: 'applicationOptionsUpdated', params: {source}});
@@ -1402,6 +1404,14 @@ export class Backend {
         } catch (e) {
             log.error(e);
         }
+    }
+
+    /** */
+    _attachOmniboxListener() {
+        chrome.omnibox.onInputEntered.addListener((text) => {
+            const newURL = 'search.html?query=' + encodeURIComponent(text);
+            void chrome.tabs.create({url: newURL});
+        });
     }
 
     /**

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1408,10 +1408,14 @@ export class Backend {
 
     /** */
     _attachOmniboxListener() {
-        chrome.omnibox.onInputEntered.addListener((text) => {
-            const newURL = 'search.html?query=' + encodeURIComponent(text);
-            void chrome.tabs.create({url: newURL});
-        });
+        try {
+            chrome.omnibox.onInputEntered.addListener((text) => {
+                const newURL = 'search.html?query=' + encodeURIComponent(text);
+                void chrome.tabs.create({url: newURL});
+            });
+        } catch (e) {
+            log.error(e);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #1688

Tested on Firefox and Chromium. I don't see any extra permissions that are required to add this to the manifest.

How this works is if a user types `Yomitan {whatever}` in the search bar, the browser will show a suggestion (if suggestions are enabled) to search `{whatever}` in Yomitan's search page.