### PR TITLE
Pierce shadowroots on Chromium using caretPositionFromPoint

### DIFF
--- a/ext/js/dom/text-source-generator.js
+++ b/ext/js/dom/text-source-generator.js
@@ -417,13 +417,30 @@ export class TextSourceGenerator {
     }
 
     /**
-     * @param {Element | ShadowRoot} element
-     * @returns {(ShadowRoot)[]}
+     * @param {Element | ShadowRoot} inputElement
+     * @returns {ShadowRoot[]}
      */
-    _findShadowRoots(element) {
-        const allElements = [element, ...element.querySelectorAll('*')];
-        const filteredShadowRoots = allElements.filter((e) => !!e.shadowRoot);
-        return filteredShadowRoots.flatMap((e) => [e.shadowRoot, ...this._findShadowRoots(e.shadowRoot)]);
+    _findShadowRoots(inputElement) {
+        const allElements = [inputElement, ...inputElement.querySelectorAll('*')];
+        /** @type {Element[]} */
+        const shadowRootContainingElements = [];
+        for (const element of allElements) {
+            if (!(element instanceof ShadowRoot) && !!element.shadowRoot) {
+                shadowRootContainingElements.push(element);
+            }
+        }
+        /** @type {ShadowRoot[]} */
+        const shadowRoots = [];
+        for (const element of shadowRootContainingElements) {
+            if (element.shadowRoot) {
+                shadowRoots.push(element.shadowRoot);
+                const nestedShadowRoots = this._findShadowRoots(element.shadowRoot);
+                if (nestedShadowRoots) {
+                    shadowRoots.push(...nestedShadowRoots);
+                }
+            }
+        }
+        return shadowRoots;
     }
 
     /**

--- a/ext/js/dom/text-source-generator.js
+++ b/ext/js/dom/text-source-generator.js
@@ -449,8 +449,12 @@ export class TextSourceGenerator {
      * @returns {?Range}
      */
     _caretPositionFromPoint(x, y) {
-        const shadowRoots = this._findShadowRoots(document.body);
-        const position = shadowRoots.length > 0 ? document.caretPositionFromPoint(x, y, {shadowRoots: shadowRoots}) : document.caretPositionFromPoint(x, y);
+        const documentCaretPositionFromPoint = document.caretPositionFromPoint(x, y);
+        const documentCaretPositionOffsetNode = documentCaretPositionFromPoint?.offsetNode;
+
+        const shadowRoots = documentCaretPositionOffsetNode instanceof Element ? this._findShadowRoots(documentCaretPositionOffsetNode) : [];
+
+        const position = shadowRoots.length > 0 ? document.caretPositionFromPoint(x, y, {shadowRoots: shadowRoots}) : documentCaretPositionFromPoint;
         if (position === null) {
             return null;
         }

--- a/ext/js/dom/text-source-generator.js
+++ b/ext/js/dom/text-source-generator.js
@@ -450,7 +450,7 @@ export class TextSourceGenerator {
      */
     _caretPositionFromPoint(x, y) {
         const shadowRoots = this._findShadowRoots(document.body);
-        const position = /** @type {(x: number, y: number) => ?{offsetNode: Node, offset: number}} */ document.caretPositionFromPoint(x, y, {shadowRoots: shadowRoots});
+        const position = shadowRoots.length > 0 ? document.caretPositionFromPoint(x, y, {shadowRoots: shadowRoots}) : document.caretPositionFromPoint(x, y);
         if (position === null) {
             return null;
         }

--- a/ext/js/dom/text-source-generator.js
+++ b/ext/js/dom/text-source-generator.js
@@ -452,7 +452,9 @@ export class TextSourceGenerator {
         const documentCaretPositionFromPoint = document.caretPositionFromPoint(x, y);
         const documentCaretPositionOffsetNode = documentCaretPositionFromPoint?.offsetNode;
 
-        const shadowRoots = documentCaretPositionOffsetNode instanceof Element ? this._findShadowRoots(documentCaretPositionOffsetNode) : [];
+        // nodeName `#text` indicates we have already drilled down as far as required to scan the text
+        const shadowRootSearchRequired = documentCaretPositionOffsetNode instanceof Element && documentCaretPositionOffsetNode.nodeName !== '#text';
+        const shadowRoots = shadowRootSearchRequired ? this._findShadowRoots(documentCaretPositionOffsetNode) : [];
 
         const position = shadowRoots.length > 0 ? document.caretPositionFromPoint(x, y, {shadowRoots: shadowRoots}) : documentCaretPositionFromPoint;
         if (position === null) {


### PR DESCRIPTION
Fixes #1044

Almost a year ago I wrote this comment https://github.com/yomidevs/yomitan/issues/1044#issuecomment-2254261520 on our shadow dom issues. Since then, Chromium has gotten `caretPositionFromPoint` into stable builds and support for the `shadowRoots` option has been added. There also should have been plenty of time for all maintained Chromium forks to get up to date with this feature.

This allows piercing any shadow root specified by the options. Firefox's implementation pierces all shadow roots by default but we aren't so lucky to get that on Chromium (the people making the w3c spec were against handling it like this https://github.com/w3c/csswg-drafts/issues/9932#issuecomment-2035004366). `_findShadowRoots` here will get us all the shadow roots within all children of the input element.

The shadow roots are only searched for if `caretPositionFromPoint` hasnt drilled down to the text to begin with (if we already have the text theres no point in searching for it further). And if the text isn't found, it will start searching for shadow roots at whatever element it ended up drilling down to until it hit shadow dom.

Tested on Firefox 136 and Chromium 133. Unsure if this will blow up on any older versions (testing on kiwi would be a good idea). The feature `caretPositionFromPoint` is checked for with fallback provided.

Easy test case: https://chromestatus.com/feature/5201014343073792. This site is *covered* in shadow roots.