### PR TITLE
Fix finding media to inject in anki note generator

### DIFF
--- a/ext/js/pages/settings/anki-deck-generator-controller.js
+++ b/ext/js/pages/settings/anki-deck-generator-controller.js
@@ -505,9 +505,7 @@ export class AnkiDeckGeneratorController {
      * @returns {Array<string>}
      */
     _findAllPaths(obj) {
-        // @ts-expect-error - Recursive function to find object keys deeply nested in objects and arrays. Essentially impossible to type correctly.
-        // eslint-disable-next-line unicorn/no-array-reduce, @typescript-eslint/no-unsafe-argument
-        return Object.entries(obj).reduce((acc, [key, value]) => (key === 'path' ? [...acc, value] : (typeof value === 'object' ? [...acc, ...this._findAllPaths(value)] : acc)), []);
+        return JSON.stringify(obj).match(/(?<="path":").*?(?=")/g) ?? [];
     }
 
     /**

--- a/ext/js/pages/settings/anki-deck-generator-controller.js
+++ b/ext/js/pages/settings/anki-deck-generator-controller.js
@@ -501,6 +501,11 @@ export class AnkiDeckGeneratorController {
     }
 
     /**
+     * Extracts all values of json keys named `path` which contain a string value.
+     * Example json snippet containing a path:
+     * ...","path":"example-dictionary/svg/example-media.svg","...
+     * The path can be found in many different positions in the structure of the definition json.
+     * It is most reliable to flatten it to a string and use regex.
      * @param {object} obj
      * @returns {Array<string>}
      */


### PR DESCRIPTION
The previous function was ridiculous and ended up failing on some weird combinations of nested objects and arrays. Which Yomitan dicts tend to be extremely prone to creating.

Since all that is required is extracting a string for the path to media, it is much easier to flatten the entire definition structure into a string and search it with regex. No witchcraft necessary.

The media in this case only includes images or svgs contained in definitions. Audio fetching has no issue.