### PR TITLE
make russian preprocessor bidirectional

### DIFF
--- a/ext/js/language/ru/russian-text-preprocessors.js
+++ b/ext/js/language/ru/russian-text-preprocessors.js
@@ -27,12 +27,19 @@ export const removeRussianDiacritics = {
     },
 };
 
-/** @type {import('language').TextProcessor<boolean>} */
+/** @type {import('language').BidirectionalConversionPreprocessor} */
 export const yoToE = {
-    name: 'Yo to E',
-    description: 'ё → е, Ё → Е',
-    options: basicTextProcessorOptions,
+    name: 'Convert "ё" to "е"',
+    description: 'ё → е, Ё → Е and vice versa',
+    options: ['off', 'direct', 'inverse'],
     process: (str, setting) => {
-        return setting ? str.replace(/ё/g, 'е').replace(/Ё/g, 'Е') : str;
+        switch (setting) {
+            case 'off':
+                return str;
+            case 'direct':
+                return str.replace(/ё/g, 'е').replace(/Ё/g, 'Е');
+            case 'inverse':
+                return str.replace(/е/g, 'ё').replace(/Е/g, 'Ё');
+        }
     },
 };

--- a/types/ext/language-descriptors.d.ts
+++ b/types/ext/language-descriptors.d.ts
@@ -189,7 +189,7 @@ type AllTextProcessors = {
     };
     ru: {
         pre: CapitalizationPreprocessors & {
-            yoToE: TextProcessor<boolean>;
+            yoToE: BidirectionalConversionPreprocessor;
             removeRussianDiacritics: TextProcessor<boolean>;
         };
     };


### PR DESCRIPTION
Makes the `yoToE` Russian preprocessor bidirectional.

Allows coverage for situations like:

- застегивала → застёгивала → застёгивать
- теплой → тёплой → тёплый
- вдвоем → вдвоём