### PR TITLE
Improve default anki field setup

### DIFF
--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -1021,10 +1021,18 @@ class AnkiCardController {
         const markers = getStandardFieldMarkers(dictionaryEntryType);
         const markerAliases = new Map([
             ['expression', ['phrase', 'term', 'word']],
+            ['reading', ['expression-reading', 'term-reading', 'word-reading']],
+            ['furigana', ['expression-furigana', 'term-furigana', 'word-furigana']],
             ['glossary', ['definition', 'meaning']],
-            ['audio', ['sound']],
+            ['audio', ['sound', 'word-audio', 'term-audio', 'expression-audio']],
             ['dictionary', ['dict']],
-            ['pitch-accents', ['pitch']],
+            ['pitch-accents', ['pitch', 'pitch-accent', 'pitch-pattern']],
+            ['sentence', ['example-sentence']],
+            ['frequency-harmonic-rank', ['freq', 'frequency', 'freq-sort', 'freqency-sort']],
+            ['popup-selection-text', ['selection']],
+            ['pitch-accent-positions', ['pitch-position']],
+            ['pitch-accent-categories', ['pitch-categories']],
+            ['popup-selection-text', ['selection-text']],
         ]);
 
         const hyphenPattern = /-/g;


### PR DESCRIPTION
Yomitan attempts to automatically set up Anki card configuration for users that have note types with fields that match or are similar to the names of handlebars. As is, the set of aliases is extremely small. I've gone through many popular note types and found reasonable field names that can be aliased to help users set things up quickly.

Note that Yomitan allows dashes to be dashes, underscores, or spaces. So the alias `expression-reading` is actually an alias for `expression reading` and `expression_reading` as well.