### PR TITLE
Move fullscreen toggle for popup open shadow dom test outside shadow dom

### DIFF
--- a/test/data/html/popup-tests.html
+++ b/test/data/html/popup-tests.html
@@ -55,22 +55,24 @@
         </div>
     </test-case>
 
-    <test-case data-shadow-mode="open" data-expected-result="failure">
+    <test-case data-shadow-mode="open">
         <test-description>Content inside of an open shadow DOM.</test-description>
-        <div class="template-content-container hovertarget"></div>
-        <template>
+        <div class="fullscreen-element container">
+            <div class="template-content-container hovertarget"></div>
             <link rel="stylesheet" href="test-stylesheet.css">
-            <div class="fullscreen-element container">
-                <div class="container-inner">
-                    <div>
-                        ありがとう
-                    </div>
-                    <div>
-                        <a href="#" class="fullscreen-link">Toggle fullscreen</a>
+            <template>
+                <div class="container">
+                    <div class="container-inner">
+                        <div>
+                            ありがとう
+                        </div>
                     </div>
                 </div>
+            </template>
+            <div>
+                <a href="#" class="fullscreen-link">Toggle fullscreen</a>
             </div>
-        </template>
+        </div>
     </test-case>
 
     <test-case data-shadow-mode="closed" data-expected-result="failure">


### PR DESCRIPTION
**I have not actually tested this with playwright yet.**

Apparently shadow dom gets "exclusive" fullscreen when it is fullscreened and popups cannot be rendered. Due to #1845, Yomitan can now scan inside open shadow dom on Chromium but the playwright tests arent able to test this since it fullscreens the shadow dom itself.

The solution is to wrap the shadow dom in an external div and fullscreen that instead.

Currently this looks quite wacky and may need some fixes to the styling. If it's even possible to do so with the mix of in and out of shadow dom.