### PR TITLE
Update anki single glossary fields when updating a dictionary with a name change

### DIFF
--- a/ext/js/data/anki-template-util.js
+++ b/ext/js/data/anki-template-util.js
@@ -152,7 +152,7 @@ export function getDynamicFieldMarkers(dictionaries, dictionaryInfo) {
  * @param {string} str
  * @returns {string}
  */
-function getKebabCase(str) {
+export function getKebabCase(str) {
     return str
         .replace(/[\s_\u3000]/g, '-')
         .replace(/[^\p{L}\p{N}-]/gu, '')

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -20,6 +20,7 @@ import {ExtensionError} from '../../core/extension-error.js';
 import {readResponseJson} from '../../core/json.js';
 import {log} from '../../core/log.js';
 import {toError} from '../../core/to-error.js';
+import {getKebabCase} from '../../data/anki-template-util.js';
 import {DictionaryWorker} from '../../dictionary/dictionary-worker.js';
 import {querySelectorNotNull} from '../../dom/query-selector.js';
 import {DictionaryController} from './dictionary-controller.js';
@@ -643,6 +644,22 @@ export class DictionaryImportController {
         const errors2 = await this._addDictionarySettings(result, profilesDictionarySettings);
 
         await this._settingsController.application.api.triggerDatabaseUpdated('dictionary', 'import');
+
+        // Only runs if updating a dictionary
+        if (profilesDictionarySettings !== null) {
+            const options = await this._settingsController.getOptionsFull();
+            const {profiles} = options;
+
+            for (const profile of profiles) {
+                const ankiTermFields = profile.options.anki.terms.fields;
+                const oldFieldSegmentRegex = new RegExp(getKebabCase(profilesDictionarySettings[profile.id].name), 'g');
+                const newFieldSegment = getKebabCase(result.title);
+                for (const key of Object.keys(ankiTermFields)) {
+                    ankiTermFields[key].value = ankiTermFields[key].value.replace(oldFieldSegmentRegex, newFieldSegment);
+                }
+            }
+            await this._settingsController.setAllSettings(options);
+        }
 
         if (errors.length > 0) {
             errors.push(new Error(`Dictionary may not have been imported properly: ${errors.length} error${errors.length === 1 ? '' : 's'} reported.`));


### PR DESCRIPTION
Some dictionaries put dates in the name and this can be annoying to users of single glossary handlebars when updating since they have to manually update the handlebars.

Test dictionary (random small kty dict with intentionally messed up title): [kty-zh-hu-gloss_edit.zip](https://github.com/user-attachments/files/19151040/kty-zh-hu-gloss_edit.zip)
