### PR TITLE
Fix wanakana breaking IME input when hitting a conversion containing latin characters

### DIFF
--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -16,11 +16,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import * as wanakana from '../../lib/wanakana.js';
 import {ClipboardMonitor} from '../comm/clipboard-monitor.js';
 import {createApiMap, invokeApiMapHandler} from '../core/api-map.js';
 import {EventListenerCollection} from '../core/event-listener-collection.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
+import {convertToKana} from '../language/ja/japanese-wanakana.js';
 
 export class SearchDisplayController {
     /**
@@ -243,9 +243,23 @@ export class SearchDisplayController {
         this._setIntroVisible(!valid, animate);
     }
 
-    /** */
-    _onSearchInput() {
+    /**
+     * @param {KeyboardEvent} e
+     */
+    _onSearchInput(e) {
         this._updateSearchHeight(true);
+
+        const element = /** @type {HTMLTextAreaElement} */ (e.currentTarget);
+        this._searchTextKanaConversion(element, e);
+    }
+
+    /**
+     * @param {HTMLTextAreaElement} element
+     * @param {KeyboardEvent} event
+     */
+    _searchTextKanaConversion(element, event) {
+        if (!this._wanakanaBound || event.isComposing) { return; }
+        element.value = convertToKana(element.value, {IMEMode: true});
     }
 
     /**
@@ -440,12 +454,10 @@ export class SearchDisplayController {
         this._wanakanaEnabled = enabled;
         if (enabled) {
             if (!this._wanakanaBound) {
-                wanakana.bind(input);
                 this._wanakanaBound = true;
             }
         } else {
             if (this._wanakanaBound) {
-                wanakana.unbind(input);
                 this._wanakanaBound = false;
             }
         }

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -62,8 +62,6 @@ export class SearchDisplayController {
         /** @type {boolean} */
         this._wanakanaEnabled = false;
         /** @type {boolean} */
-        this._wanakanaBound = false;
-        /** @type {boolean} */
         this._introVisible = true;
         /** @type {?import('core').Timeout} */
         this._introAnimationTimer = null;
@@ -258,7 +256,7 @@ export class SearchDisplayController {
      * @param {KeyboardEvent} event
      */
     _searchTextKanaConversion(element, event) {
-        if (!this._wanakanaBound || event.isComposing) { return; }
+        if (!this._wanakanaEnabled || event.isComposing) { return; }
         element.value = convertToKana(element.value, {IMEMode: true});
     }
 
@@ -452,15 +450,6 @@ export class SearchDisplayController {
         this._queryInputEvents.addEventListener(input, 'keydown', this._onSearchKeydown.bind(this), false);
 
         this._wanakanaEnabled = enabled;
-        if (enabled) {
-            if (!this._wanakanaBound) {
-                this._wanakanaBound = true;
-            }
-        } else {
-            if (this._wanakanaBound) {
-                this._wanakanaBound = false;
-            }
-        }
 
         this._queryInputEvents.addEventListener(input, 'input', this._onSearchInput.bind(this), false);
         this._queryInputEventsSetup = true;

--- a/ext/js/language/ja/japanese-wanakana.js
+++ b/ext/js/language/ja/japanese-wanakana.js
@@ -27,10 +27,11 @@ function convertAlphabeticPartToKana(text) {
 
 /**
  * @param {string} text
+ * @param {object} options
  * @returns {string}
  */
-export function convertToKana(text) {
-    return wanakana.toKana(text);
+export function convertToKana(text, options) {
+    return wanakana.toKana(text, options);
 }
 
 /**

--- a/ext/js/pages/settings/popup-preview-frame.js
+++ b/ext/js/pages/settings/popup-preview-frame.js
@@ -16,12 +16,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import * as wanakana from '../../../lib/wanakana.js';
 import {Frontend} from '../../app/frontend.js';
 import {ThemeController} from '../../app/theme-controller.js';
 import {createApiMap, invokeApiMapHandler} from '../../core/api-map.js';
+import {EventListenerCollection} from '../../core/event-listener-collection.js';
 import {querySelectorNotNull} from '../../dom/query-selector.js';
 import {TextSourceRange} from '../../dom/text-source-range.js';
+import {convertToKana} from '../../language/ja/japanese-wanakana.js';
 
 export class PopupPreviewFrame {
     /**
@@ -52,12 +53,12 @@ export class PopupPreviewFrame {
         this._exampleText = querySelectorNotNull(document, '#example-text');
         /** @type {HTMLInputElement} */
         this._exampleTextInput = querySelectorNotNull(document, '#example-text-input');
+        /** @type {EventListenerCollection} */
+        this._exampleTextInputEvents = new EventListenerCollection();
         /** @type {string} */
         this._targetOrigin = chrome.runtime.getURL('/').replace(/\/$/, '');
         /** @type {import('language').LanguageSummary[]} */
         this._languageSummaries = [];
-        /** @type {boolean} */
-        this._wanakanaBound = false;
         /** @type {ThemeController} */
         this._themeController = new ThemeController(document.documentElement);
 
@@ -256,19 +257,31 @@ export class PopupPreviewFrame {
     _setLanguageExampleText({language}) {
         const activeLanguage = /** @type {import('language').LanguageSummary} */ (this._languageSummaries.find(({iso}) => iso === language));
 
-        if (this._exampleTextInput !== null) {
-            if (language === 'ja') {
-                wanakana.bind(this._exampleTextInput);
-                this._wanakanaBound = true;
-            } else if (this._wanakanaBound) {
-                wanakana.unbind(this._exampleTextInput);
-                this._wanakanaBound = false;
-            }
+        this._exampleTextInputEvents.removeAllEventListeners();
+        if (this._exampleTextInput !== null && language === 'ja') {
+            this._exampleTextInputEvents.addEventListener(this._exampleTextInput, 'input', this._onSearchInput.bind(this), false);
         }
 
         this._exampleTextInput.lang = language;
         this._exampleTextInput.value = activeLanguage.exampleText;
         this._exampleTextInput.dispatchEvent(new Event('input'));
+    }
+
+    /**
+     * @param {KeyboardEvent} e
+     */
+    _onSearchInput(e) {
+        const element = /** @type {HTMLTextAreaElement} */ (e.currentTarget);
+        this._searchTextKanaConversion(element, e);
+    }
+
+    /**
+     * @param {HTMLTextAreaElement} element
+     * @param {KeyboardEvent} event
+     */
+    _searchTextKanaConversion(element, event) {
+        if (event.isComposing) { return; }
+        element.value = convertToKana(element.value, {IMEMode: true});
     }
 
     /** */


### PR DESCRIPTION
The previous handling of this by using `wanakana.bind` surrenders handling to wanakana and Yomitan does not have control over when input should be converted. We have to deal with whatever bugs they have. This PR gives Yomitan back control over when conversion should be triggered.

The wanakana library also appears possibly abandoned and has not received updates in 2 years when previously it was receiving quite frequent updates (although the maintainer appears to be somewhat active still). I've created an upstream bug report anyways ([#179](https://github.com/WaniKani/WanaKana/issues/179)). Due to the tiny usage of this library's features we should probably just ditch the library entirely. But I'll leave that to another PR. The changes here are still relevant regardless.

To replicate this bug:
1. Open the search page
2. Ensure that `Automatic kana conversion` is enabled (settings are under the cog)
3. Switch to hiragana input on a japanese IME
4. Type a word in the search bar that can be converted to something that contains half width latin characters (for example `えいご` which can convert to `A5`)
5. Press space multiple times and try to convert to something after `A5` or any latin character containing conversion
6. Wanakana interrupts the IME and forces conversion to end