### PR TITLE
Fix {sentence-furigana-plain} sometimes cutting off the first character

### DIFF
--- a/ext/js/data/anki-note-builder.js
+++ b/ext/js/data/anki-note-builder.js
@@ -569,7 +569,7 @@ export class AnkiNoteBuilder {
                 }
             }
         }
-        result = result.substring(1);
+        result = result.trimStart();
         return result;
     }
 


### PR DESCRIPTION
Fixes #1877

If the start of a sentence has a word that contains a reading, there will be an added space at the start that should be trimmed off. But if there is no reading, there is no leading space since spaces can only be put between the starts of words that require furigana when using the `furigana-plain` format. Otherwise the spaces will render as real spaces instead of separators between words when rendering furigana.

The first character was being trimmed off always and this removed the first character if there wasnt an added space (the first word didnt have a reading).