### PR TITLE
Add horizontal padding to search header

### DIFF
--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -53,8 +53,9 @@ body {
     height: 100%;
     overflow: hidden;
 }
-#content-scroll {
-    padding: var(--search-scroll-container-horizontal-padding);
+.search-header {
+    padding-left: var(--search-scroll-container-horizontal-padding);
+    padding-right: var(--search-scroll-container-horizontal-padding);
 }
 h1 {
     font-size: 2em;

--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -18,6 +18,7 @@
 
 /* Variables */
 :root {
+    --search-scroll-container-horizontal-padding: 0.72em;
     --query-horizontal-padding: 0;
 
     --padding: calc(10em / var(--font-size-no-units));
@@ -51,6 +52,9 @@ body {
     color: var(--text-color);
     height: 100%;
     overflow: hidden;
+}
+#content-scroll {
+    padding: var(--search-scroll-container-horizontal-padding);
 }
 h1 {
     font-size: 2em;


### PR DESCRIPTION
In #1815, I removed padding on the search page. But the search header does still need padding. On mobile devices or for users the squish their search window into a small vertical sliver, it looks horrible. with everything extending into the sides.

| Before Bug | Current Master | This PR |
|----------|----------|----------|
| ![before](https://github.com/user-attachments/assets/697cdf47-3bf9-4b8e-8be1-15514a1eb75e) |   ![before](https://github.com/user-attachments/assets/0b6f8b77-654d-48a6-803b-2421cd16c06a)   |   ![after](https://github.com/user-attachments/assets/57ec8b83-4af4-44d4-a5b9-4c5578d60e10)   |