### PR TITLE
Add 'language' parameter to audio API call

### DIFF
--- a/ext/js/media/audio-downloader.js
+++ b/ext/js/media/audio-downloader.js
@@ -445,7 +445,7 @@ export class AudioDownloader {
     }
 
     /** @type {import('audio-downloader').GetInfoHandler} */
-    async _getInfoCustom(term, reading, details) {
+    async _getInfoCustom(term, reading, details, languageSummary) {
         if (typeof details !== 'object' || details === null) {
             throw new Error('Invalid arguments');
         }
@@ -453,12 +453,12 @@ export class AudioDownloader {
         if (typeof url !== 'string') {
             throw new Error('Invalid url');
         }
-        url = this._getCustomUrl(term, reading, url);
+        url = this._getCustomUrl(term, reading, url, languageSummary);
         return [{type: 'url', url}];
     }
 
     /** @type {import('audio-downloader').GetInfoHandler} */
-    async _getInfoCustomJson(term, reading, details) {
+    async _getInfoCustomJson(term, reading, details, languageSummary) {
         if (typeof details !== 'object' || details === null) {
             throw new Error('Invalid arguments');
         }
@@ -466,7 +466,7 @@ export class AudioDownloader {
         if (typeof url !== 'string') {
             throw new Error('Invalid url');
         }
-        url = this._getCustomUrl(term, reading, url);
+        url = this._getCustomUrl(term, reading, url, languageSummary);
 
         const response = await this._requestBuilder.fetchAnonymous(url, DEFAULT_REQUEST_INIT_PARAMS);
 
@@ -498,22 +498,26 @@ export class AudioDownloader {
      * @param {string} term
      * @param {string} reading
      * @param {string} url
+     * @param {import('language').LanguageSummary} languageSummary
      * @returns {string}
      * @throws {Error}
      */
-    _getCustomUrl(term, reading, url) {
+    _getCustomUrl(term, reading, url, languageSummary) {
         if (typeof url !== 'string') {
             throw new Error('No custom URL defined');
         }
-        const data = {term, reading};
+        const data = {term,
+            reading,
+            language: languageSummary.iso};
         /**
+         * ?
          * @param {string} m0
          * @param {string} m1
          * @returns {string}
          */
         const replacer = (m0, m1) => (
             Object.prototype.hasOwnProperty.call(data, m1) ?
-            `${data[/** @type {'term'|'reading'} */ (m1)]}` :
+            `${data[/** @type {'term'|'reading'|'language'} */ (m1)]}` :
             m0
         );
         return url.replace(/\{([^}]*)\}/g, replacer);

--- a/ext/js/media/audio-downloader.js
+++ b/ext/js/media/audio-downloader.js
@@ -507,10 +507,10 @@ export class AudioDownloader {
             throw new Error('No custom URL defined');
         }
         const data = {
-	    term,
+            term,
             reading,
-            language: languageSummary.iso
-	};
+            language: languageSummary.iso,
+        };
         /**
          * @param {string} m0
          * @param {string} m1

--- a/ext/js/media/audio-downloader.js
+++ b/ext/js/media/audio-downloader.js
@@ -506,11 +506,12 @@ export class AudioDownloader {
         if (typeof url !== 'string') {
             throw new Error('No custom URL defined');
         }
-        const data = {term,
+        const data = {
+	    term,
             reading,
-            language: languageSummary.iso};
+            language: languageSummary.iso
+	};
         /**
-         * ?
          * @param {string} m0
          * @param {string} m1
          * @returns {string}


### PR DESCRIPTION
For improving the audio server API, adding a 'language' parameter to the API call would make things more organized for working with multiple languages.
I added that parameter.