### PR TITLE
Add missing termMeta to dict details modal

### DIFF
--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -299,6 +299,7 @@ class DictionaryEntry {
             sourceLanguage: 'Source Language',
             targetLanguage: 'Target Language',
             terms: 'Term Count',
+            termMeta: 'Term Meta Count',
             kanji: 'Kanji Count',
             kanjiMeta: 'Kanji Meta Count',
             tagMeta: 'Tag Count',


### PR DESCRIPTION
Somehow this got missed in #1248