### PR TITLE
Detect missing entries when dicts fail to import with `Check Integrity` button

### DIFF
--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -2358,7 +2358,8 @@ button.hotkey-list-item-enabled-button[data-scope-count='0'] {
 }
 .dictionary-outdated-button,
 .dictionary-update-available,
-.dictionary-integrity-button {
+.dictionary-integrity-button-check,
+.dictionary-integrity-button-warning {
     --button-content-color: transparent;
     --button-border-color: transparent;
     --button-background-color: transparent;

--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -2405,16 +2405,6 @@ button.hotkey-list-item-enabled-button[data-scope-count='0'] {
     display: table-cell;
     white-space: pre-line;
 }
-.dictionary-counts {
-    width: 100%;
-    box-sizing: border-box;
-    font-size: inherit;
-    max-height: 10em;
-    line-height: 1.25;
-    font-family: 'Courier New', Courier, monospace;
-    white-space: pre;
-    overflow: auto;
-}
 
 #dictionary-alias-input {
     width: 100%;

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -123,11 +123,8 @@ class DictionaryEntry {
                 countsMismatch = true;
             }
         }
-        if (countsMismatch) {
-            this._integrityButtonWarning.hidden = false;
-        } else {
-            this._integrityButtonCheck.hidden = false;
-        }
+        this._integrityButtonWarning.hidden = countsMismatch;
+        this._integrityButtonCheck.hidden = !countsMismatch;
     }
 
     /**

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -121,6 +121,7 @@ class DictionaryEntry {
         for (const [key, value] of Object.entries(counts)) {
             if (value !== this._dictionaryInfo.counts[key].total) {
                 countsMismatch = true;
+                console.log('hit');
             }
         }
         this._integrityButtonWarning.hidden = countsMismatch;
@@ -264,8 +265,6 @@ class DictionaryEntry {
         const versionElement = querySelectorNotNull(modal.node, '.dictionary-revision');
         /** @type {HTMLElement} */
         const outdateElement = querySelectorNotNull(modal.node, '.dictionary-outdated-notification');
-        /** @type {HTMLElement} */
-        const countsElement = querySelectorNotNull(modal.node, '.dictionary-counts');
         /** @type {HTMLInputElement} */
         const wildcardSupportedElement = querySelectorNotNull(modal.node, '.dictionary-prefix-wildcard-searches-supported');
         /** @type {HTMLElement} */
@@ -282,7 +281,6 @@ class DictionaryEntry {
         titleElement.textContent = title;
         versionElement.textContent = `rev.${revision}`;
         outdateElement.hidden = (version >= 3);
-        countsElement.textContent = this._databaseCounts !== null ? JSON.stringify(this._databaseCounts, null, 4) : '';
         wildcardSupportedElement.checked = prefixWildcardsSupported;
         partsOfSpeechFilterSetting.hidden = !counts?.terms.total;
         partsOfSpeechFilterToggle.dataset.setting = `dictionaries[${this._index}].partsOfSpeechFilter`;
@@ -320,7 +318,7 @@ class DictionaryEntry {
         let any = false;
         for (const [key, label] of /** @type {([keyof (typeof this._dictionaryInfo & typeof this._dictionaryInfo.counts), string])[]} */ (Object.entries(targets))) {
             const info = dictionaryInfo[key];
-            const displayText = ((_info) => {
+            let displayText = ((_info) => {
                 if (typeof _info === 'string') { return _info; }
                 if (_info && typeof _info === 'object' && 'total' in _info) {
                     return _info.total ? `${_info.total}` : false;
@@ -338,6 +336,9 @@ class DictionaryEntry {
             const infoElement = querySelectorNotNull(details, '.dictionary-details-entry-info');
 
             labelElement.textContent = `${label}:`;
+            if (this._databaseCounts) {
+                displayText = 'Expected: ' + displayText + ' (Database: ' + this._databaseCounts[key] + ')';
+            }
             infoElement.textContent = displayText;
             fragment.appendChild(details);
 
@@ -473,11 +474,6 @@ class DictionaryExtraInfo {
         const modal = this._parent.modalController.getModal('dictionary-extra-data');
         if (modal === null) { return; }
 
-        /** @type {HTMLElement} */
-        const dictionaryCounts = querySelectorNotNull(modal.node, '.dictionary-counts');
-
-        const info = {counts: this._totalCounts, remainders: this._remainders};
-        dictionaryCounts.textContent = JSON.stringify(info, null, 4);
         const titleNode = modal.node.querySelector('.dictionary-total-count');
         this._setTitle(titleNode);
 

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -359,7 +359,7 @@ class DictionaryEntry {
             const infoElement = querySelectorNotNull(details, '.dictionary-details-entry-info');
 
             labelElement.textContent = `${label}:`;
-            if (this._databaseCounts) {
+            if (this._databaseCounts && this._databaseCounts[key]) {
                 displayText = 'Expected: ' + displayText + ' (Database: ' + this._databaseCounts[key] + ')';
             }
             infoElement.textContent = displayText;

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -500,7 +500,52 @@ class DictionaryExtraInfo {
         const titleNode = modal.node.querySelector('.dictionary-total-count');
         this._setTitle(titleNode);
 
+        /** @type {HTMLElement} */
+        const detailsTableElement = querySelectorNotNull(modal.node, '.dictionary-details-table');
+        this._setupDetails(detailsTableElement);
+
         modal.setVisible(true);
+    }
+
+    /**
+     * @param {Element} detailsTable
+     * @returns {boolean}
+     */
+    _setupDetails(detailsTable) {
+        /** @type {Partial<Record<keyof (typeof this._totalCounts), string>>} */
+        const targets = {
+            terms: 'Term Count',
+            termMeta: 'Term Meta Count',
+            kanji: 'Kanji Count',
+            kanjiMeta: 'Kanji Meta Count',
+            tagMeta: 'Tag Count',
+            media: 'Media Count',
+        };
+
+        const fragment = document.createDocumentFragment();
+        let any = false;
+        for (const [key, label] of (Object.entries(targets))) {
+            if (!this._remainders[key]) {
+                continue;
+            }
+            const details = /** @type {HTMLElement} */ (this._dictionaryController.instantiateTemplate('dictionary-details-entry'));
+            details.dataset.type = key;
+
+            /** @type {HTMLElement} */
+            const labelElement = querySelectorNotNull(details, '.dictionary-details-entry-label');
+            /** @type {HTMLElement} */
+            const infoElement = querySelectorNotNull(details, '.dictionary-details-entry-info');
+
+            labelElement.textContent = `${label}:`;
+            infoElement.textContent = this._remainders[key].toString();
+            fragment.appendChild(details);
+
+            any = true;
+        }
+
+        detailsTable.textContent = '';
+        detailsTable.appendChild(fragment);
+        return any;
     }
 
     /**

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -61,7 +61,9 @@ class DictionaryEntry {
         /** @type {HTMLButtonElement} */
         this._outdatedButton = querySelectorNotNull(fragment, '.dictionary-outdated-button');
         /** @type {HTMLButtonElement} */
-        this._integrityButton = querySelectorNotNull(fragment, '.dictionary-integrity-button');
+        this._integrityButtonCheck = querySelectorNotNull(fragment, '.dictionary-integrity-button-check');
+        /** @type {HTMLButtonElement} */
+        this._integrityButtonWarning = querySelectorNotNull(fragment, '.dictionary-integrity-button-warning');
         /** @type {HTMLButtonElement} */
         this._updatesAvailable = querySelectorNotNull(fragment, '.dictionary-update-available');
         /** @type {HTMLElement} */
@@ -94,7 +96,8 @@ class DictionaryEntry {
         this._eventListeners.addEventListener(this._upButton, 'click', (() => { this._move(-1); }).bind(this), false);
         this._eventListeners.addEventListener(this._downButton, 'click', (() => { this._move(1); }).bind(this), false);
         this._eventListeners.addEventListener(this._outdatedButton, 'click', this._onOutdatedButtonClick.bind(this), false);
-        this._eventListeners.addEventListener(this._integrityButton, 'click', this._onIntegrityButtonClick.bind(this), false);
+        this._eventListeners.addEventListener(this._integrityButtonCheck, 'click', this._onIntegrityButtonClick.bind(this), false);
+        this._eventListeners.addEventListener(this._integrityButtonWarning, 'click', this._onIntegrityButtonClick.bind(this), false);
         this._eventListeners.addEventListener(this._updatesAvailable, 'click', this._onUpdateButtonClick.bind(this), false);
     }
 
@@ -114,7 +117,17 @@ class DictionaryEntry {
      */
     setCounts(counts) {
         this._counts = counts;
-        this._integrityButton.hidden = false;
+        let countsMismatch = false;
+        for (const [key, value] of Object.entries(counts)) {
+            if (value !== this._dictionaryInfo.counts[key].total) {
+                countsMismatch = true;
+            }
+        }
+        if (countsMismatch) {
+            this._integrityButtonWarning.hidden = false;
+        } else {
+            this._integrityButtonCheck.hidden = false;
+        }
     }
 
     /**
@@ -431,7 +444,7 @@ class DictionaryExtraInfo {
         }
 
         /** @type {HTMLButtonElement} */
-        const dictionaryIntegrityButton = querySelectorNotNull(fragment, '.dictionary-integrity-button');
+        const dictionaryIntegrityButton = querySelectorNotNull(fragment, '.dictionary-integrity-button-check');
 
         const titleNode = fragment.querySelector('.dictionary-total-count');
         this._setTitle(titleNode);

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -124,8 +124,8 @@ class DictionaryEntry {
                 console.log('hit');
             }
         }
-        this._integrityButtonWarning.hidden = countsMismatch;
-        this._integrityButtonCheck.hidden = !countsMismatch;
+        this._integrityButtonWarning.hidden = !countsMismatch;
+        this._integrityButtonCheck.hidden = countsMismatch;
     }
 
     /**

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -47,7 +47,7 @@ class DictionaryEntry {
         /** @type {EventListenerCollection} */
         this._eventListeners = new EventListenerCollection();
         /** @type {?import('dictionary-database').DictionaryCountGroup} */
-        this._counts = null;
+        this._databaseCounts = null;
         /** @type {ChildNode[]} */
         this._nodes = [...fragment.childNodes];
         /** @type {HTMLInputElement} */
@@ -116,7 +116,7 @@ class DictionaryEntry {
      * @param {import('dictionary-database').DictionaryCountGroup} counts
      */
     setCounts(counts) {
-        this._counts = counts;
+        this._databaseCounts = counts;
         let countsMismatch = false;
         for (const [key, value] of Object.entries(counts)) {
             if (value !== this._dictionaryInfo.counts[key].total) {
@@ -282,7 +282,7 @@ class DictionaryEntry {
         titleElement.textContent = title;
         versionElement.textContent = `rev.${revision}`;
         outdateElement.hidden = (version >= 3);
-        countsElement.textContent = this._counts !== null ? JSON.stringify(this._counts, null, 4) : '';
+        countsElement.textContent = this._databaseCounts !== null ? JSON.stringify(this._databaseCounts, null, 4) : '';
         wildcardSupportedElement.checked = prefixWildcardsSupported;
         partsOfSpeechFilterSetting.hidden = !counts?.terms.total;
         partsOfSpeechFilterToggle.dataset.setting = `dictionaries[${this._index}].partsOfSpeechFilter`;

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -435,14 +435,14 @@ class DictionaryEntry {
 
 class DictionaryExtraInfo {
     /**
-     * @param {DictionaryController} parent
+     * @param {DictionaryController} dictionaryController
      * @param {import('dictionary-database').DictionaryCountGroup} totalCounts
      * @param {import('dictionary-database').DictionaryCountGroup} remainders
      * @param {number} totalRemainder
      */
-    constructor(parent, totalCounts, remainders, totalRemainder) {
+    constructor(dictionaryController, totalCounts, remainders, totalRemainder) {
         /** @type {DictionaryController} */
-        this._parent = parent;
+        this._dictionaryController = dictionaryController;
         /** @type {import('dictionary-database').DictionaryCountGroup} */
         this._totalCounts = totalCounts;
         /** @type {import('dictionary-database').DictionaryCountGroup} */
@@ -459,7 +459,7 @@ class DictionaryExtraInfo {
      * @param {HTMLElement} container
      */
     prepare(container) {
-        const fragment = this._parent.instantiateTemplateFragment('dictionary-extra');
+        const fragment = this._dictionaryController.instantiateTemplateFragment('dictionary-extra');
         for (const node of fragment.childNodes) {
             this._nodes.push(node);
         }
@@ -494,7 +494,7 @@ class DictionaryExtraInfo {
 
     /** */
     _showDetails() {
-        const modal = this._parent.modalController.getModal('dictionary-extra-data');
+        const modal = this._dictionaryController.modalController.getModal('dictionary-extra-data');
         if (modal === null) { return; }
 
         const titleNode = modal.node.querySelector('.dictionary-total-count');

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -121,7 +121,6 @@ class DictionaryEntry {
         for (const [key, value] of Object.entries(counts)) {
             if (value !== this._dictionaryInfo.counts[key].total) {
                 countsMismatch = true;
-                console.log('hit');
             }
         }
         this._integrityButtonWarning.hidden = !countsMismatch;

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -465,7 +465,7 @@ class DictionaryExtraInfo {
         }
 
         /** @type {HTMLButtonElement} */
-        const dictionaryIntegrityButton = querySelectorNotNull(fragment, '.dictionary-integrity-button-check');
+        const dictionaryIntegrityButton = querySelectorNotNull(fragment, '.dictionary-integrity-button-warning');
 
         const titleNode = fragment.querySelector('.dictionary-total-count');
         this._setTitle(titleNode);

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -67,7 +67,7 @@
         </div>
         <div class="modal-footer">
             <button type="button" class="low-emphasis danger dictionary-database-mutating-input" id="dictionary-delete-all-button">Delete All</button>
-            <button type="button" class="low-emphasis dictionary-database-mutating-input debug-only" id="dictionary-check-integrity">Check Integrity</button>
+            <button type="button" class="low-emphasis dictionary-database-mutating-input advanced-only" id="dictionary-check-integrity">Check Integrity</button>
             <button type="button" class="low-emphasis dictionary-database-mutating-input" id="dictionary-check-updates">Check for Updates</button>
             <button type="button" class="low-emphasis dictionary-database-mutating-input" id="dictionary-import-button">Import</button>
             <button type="button" data-modal-action="hide">Close</button>

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -249,6 +249,9 @@
                 The database contains extra data which is not associated with any installed dictionary.
                 Purging the database can fix this issue.
             </p>
+            <div class="settings-item"><div class="settings-item-children">
+                <div class="dictionary-details-table"></div>
+            </div></div>
         </div>
         <div class="modal-footer">
             <button type="button" data-modal-action="hide">Close</button>

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -231,7 +231,6 @@
             <hr>
             <div class="settings-item"><div class="settings-item-children">
                 <div class="dictionary-details-table"></div>
-                <div class="dictionary-counts"></div>
             </div></div>
         </div>
         <div class="modal-footer">
@@ -250,7 +249,6 @@
                 The database contains extra data which is not associated with any installed dictionary.
                 Purging the database can fix this issue.
             </p>
-            <div class="dictionary-counts"></div>
         </div>
         <div class="modal-footer">
             <button type="button" data-modal-action="hide">Close</button>

--- a/ext/templates-settings.html
+++ b/ext/templates-settings.html
@@ -90,9 +90,6 @@
         <span>
             <strong class="dictionary-title">Unassociated Data</strong> <span class="light dictionary-total-count"></span>
         </span>
-        <button type="button" class="dictionary-integrity-button-check" hidden>
-            <div class="badge warning-badge"><span class="icon" data-icon="exclamation-point-short"></span></div>
-        </button>
         <button type="button" class="dictionary-integrity-button-warning">
             <div class="badge warning-badge"><span class="icon" data-icon="exclamation-point-short"></span></div>
         </button>

--- a/ext/templates-settings.html
+++ b/ext/templates-settings.html
@@ -57,8 +57,11 @@
         <button type="button" class="dictionary-outdated-button" hidden>
             <div class="badge warning-badge"><span class="icon" data-icon="exclamation-point-short"></span></div>
         </button>
-        <button type="button" class="dictionary-integrity-button" hidden>
+        <button type="button" class="dictionary-integrity-button-check" hidden>
             <div class="badge info-badge badge-small-icon"><span class="icon" data-icon="checkmark"></span></div>
+        </button>
+        <button type="button" class="dictionary-integrity-button-warning" hidden>
+            <div class="badge warning-badge"><span class="icon" data-icon="exclamation-point-short"></span></div>
         </button>
         <button type="button" class="dictionary-update-available" hidden>
             <div class="badge info-badge badge-small-icon"><span class="icon" data-icon="exclamation-point-short" title="Update available"></span></div>
@@ -87,7 +90,10 @@
         <span>
             <strong class="dictionary-title">Unassociated Data</strong> <span class="light dictionary-total-count"></span>
         </span>
-        <button type="button" class="dictionary-integrity-button">
+        <button type="button" class="dictionary-integrity-button-check" hidden>
+            <div class="badge warning-badge"><span class="icon" data-icon="exclamation-point-short"></span></div>
+        </button>
+        <button type="button" class="dictionary-integrity-button-warning">
             <div class="badge warning-badge"><span class="icon" data-icon="exclamation-point-short"></span></div>
         </button>
     </div>


### PR DESCRIPTION
Fixes #1582. Tested on Firefox and Chromium.

Checking integrity is kindof pointless if it can't even check if your dicts have the expected amount of entries. 

Ideally this would be automatic but unfortunately it isn't reasonable to automatically show this when a user enters the settings page due to how long it takes to run over the entire database for the integrity check.

Also makes Unassociated Data and other check integrity data displays not a json string dump.

It may be worth pulling the `Check Integrity` button back into advanced settings instead of debug settings since especially on mobile, users often have issues with their dicts partially importing due to their device turning off or the browser hanging from battery saving. Though, this is "debugging" still.

Dict counts before integrity check (same as before this PR):
![image](https://github.com/user-attachments/assets/70fb14ef-9121-46c6-ac3f-8cbe700c17fd)

Dict counts after integrity check:
![image](https://github.com/user-attachments/assets/8ce28c20-ac7b-443f-a16e-88e00a91c0b1)

Unassociated Data:
![image](https://github.com/user-attachments/assets/83df0432-3dd6-44ad-bd1d-d0fbfb090e2a)
