### PR TITLE
Use normal anchor hashes in anchor links

### DIFF
--- a/ext/issues.html
+++ b/ext/issues.html
@@ -69,7 +69,7 @@
             <p>
                 Audio files can be downloaded from remote servers when creating Anki cards,
                 and sometimes these downloads can stall due to server or internet connectivity issues.
-                The <em>Idle download timeout</em> setting on the <a href="/settings.html#!anki">settings page</a>
+                The <em>Idle download timeout</em> setting on the <a href="/settings.html#anki">settings page</a>
                 specifies a time limit for stalled downloads.
             </p>
         </div></div></div></div>

--- a/ext/js/pages/settings/settings-display-controller.js
+++ b/ext/js/pages/settings/settings-display-controller.js
@@ -90,8 +90,6 @@ export class SettingsDisplayController {
         menuSelectorObserver.observe(document.documentElement, false);
 
         window.addEventListener('keydown', this._onKeyDown.bind(this), false);
-        window.addEventListener('popstate', this._onPopState.bind(this), false);
-        this._updateScrollTarget();
 
         if (this._themeDropdown) {
             this._themeDropdown.addEventListener('change', this._updateTheme.bind(this), false);
@@ -202,11 +200,6 @@ export class SettingsDisplayController {
         e.preventDefault();
     }
 
-    /** */
-    _onPopState() {
-        this._updateScrollTarget();
-    }
-
     /**
      * @param {KeyboardEvent} e
      */
@@ -297,20 +290,6 @@ export class SettingsDisplayController {
                 this._indentInput(e, node, args);
                 break;
         }
-    }
-
-    /** */
-    _updateScrollTarget() {
-        const hash = window.location.hash;
-        if (!hash.startsWith('#!')) { return; }
-
-        const content = this._contentNode;
-        const target = document.getElementById(hash.substring(2));
-        if (content === null || target === null) { return; }
-
-        const rect1 = content.getBoundingClientRect();
-        const rect2 = target.getBoundingClientRect();
-        content.scrollTop += rect2.top - rect1.top;
     }
 
     /**

--- a/ext/popup.html
+++ b/ext/popup.html
@@ -48,7 +48,7 @@
                     <div id="no-dictionaries" hidden>
                         <div class="entry">
                             <p>No dictionaries have been installed or enabled yet.</p>
-                            <p><a href="/settings.html#!dictionaries" target="_top">Go to Dictionaries settings.</a></p>
+                            <p><a href="/settings.html#dictionaries" target="_top">Go to Dictionaries settings.</a></p>
                         </div>
                     </div>
                     <div id="error-extension-unloaded" hidden>

--- a/ext/quick-start-guide.html
+++ b/ext/quick-start-guide.html
@@ -52,12 +52,12 @@
             <div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">
                 Yomitan requires one or more dictionaries to be installed in order to look up terms, kanji, and other information.
                 Several downloadable dictionaries can be found on the <a href="https://github.com/yomidevs/yomitan/blob/master/docs/dictionaries.md#dictionaries" target="_blank" rel="noopener noreferrer">Yomitan homepage</a>.
-                Dictionaries can be configured from the <a href="/settings.html#!dictionaries" rel="noopener">Settings</a> page.
+                Dictionaries can be configured from the <a href="/settings.html#dictionaries" rel="noopener">Settings</a> page.
             </div></div></div>
         </div>
         <div class="settings-item">
             <div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">
-                You can also import an exported collection of dictionaries from the <a href="/settings.html#!backup">Backup section of the Settings</a> page.
+                You can also import an exported collection of dictionaries from the <a href="/settings.html#backup">Backup section of the Settings</a> page.
 
                 <br><br>
 

--- a/ext/search.html
+++ b/ext/search.html
@@ -80,7 +80,7 @@
                     <div id="no-dictionaries" hidden>
                         <div class="entry">
                             <p>No dictionaries have been installed or enabled yet.</p>
-                            <p><a href="/settings.html#!dictionaries" target="_blank">Go to Dictionaries settings.</a></p>
+                            <p><a href="/settings.html#dictionaries" target="_blank">Go to Dictionaries settings.</a></p>
                         </div>
                     </div>
                 </div>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -24,24 +24,24 @@
 <div class="content-left">
     <div class="sidebar"><div class="sidebar-inner scrollbar">
         <div class="sidebar-body">
-            <a href="#!profile"          class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="profile"></span></span><span class="outline-item-label">Profile</span></a>
-            <a href="#!dictionaries"     class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="book"></span><span class="outline-item-left-warning-badge no-dictionaries-enabled-warning" hidden><div class="badge warning-badge"><span class="icon" data-icon="exclamation-point-short"></span></div></span></span><span class="outline-item-label">Dictionaries</span></a>
-            <a href="#!general"          class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="cog"></span></span><span class="outline-item-label">General</span></a>
-            <a href="#!scanning"         class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="scanning"></span></span><span class="outline-item-label">Scanning</span></a>
-            <a href="#!popup"            class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="popup"></span></span><span class="outline-item-label">Popup Behavior</span></a>
-            <a href="#!appearance"       class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="palette"></span></span><span class="outline-item-label">Appearance</span></a>
-            <a href="#!result-display"   class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="monitor"></span></span><span class="outline-item-label">Result Display</span></a>
-            <a href="#!popup-size"       class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="popup-size"></span></span><span class="outline-item-label">Position &amp; Size</span></a>
-            <a href="#!window"           class="button outline-item advanced-only"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="window"></span></span><span class="outline-item-label">Search Window</span></a>
-            <a href="#!audio"            class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="speaker"></span></span><span class="outline-item-label">Audio</span></a>
-            <a href="#!text-parsing"     class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="text-parsing"></span></span><span class="outline-item-label">Text Parsing</span></a>
-            <a href="#!translation"      class="button outline-item advanced-only"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="translation"></span></span><span class="outline-item-label">Translation</span></a>
-            <a href="#!anki"             class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="note-card"></span></span><span class="outline-item-label">Anki</span></a>
-            <a href="#!clipboard"        class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="clipboard"></span></span><span class="outline-item-label">Clipboard</span></a>
-            <a href="#!shortcuts"        class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="keyboard"></span></span><span class="outline-item-label">Shortcuts</span></a>
-            <a href="#!backup"           class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="backup"></span></span><span class="outline-item-label">Backup</span></a>
-            <a href="#!accessibility"    class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="accessibility"></span></span><span class="outline-item-label">Accessibility</span></a>
-            <a href="#!security"         class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="lock"></span></span><span class="outline-item-label">Security</span></a>
+            <a href="#profile"          class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="profile"></span></span><span class="outline-item-label">Profile</span></a>
+            <a href="#dictionaries"     class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="book"></span><span class="outline-item-left-warning-badge no-dictionaries-enabled-warning" hidden><div class="badge warning-badge"><span class="icon" data-icon="exclamation-point-short"></span></div></span></span><span class="outline-item-label">Dictionaries</span></a>
+            <a href="#general"          class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="cog"></span></span><span class="outline-item-label">General</span></a>
+            <a href="#scanning"         class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="scanning"></span></span><span class="outline-item-label">Scanning</span></a>
+            <a href="#popup"            class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="popup"></span></span><span class="outline-item-label">Popup Behavior</span></a>
+            <a href="#appearance"       class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="palette"></span></span><span class="outline-item-label">Appearance</span></a>
+            <a href="#result-display"   class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="monitor"></span></span><span class="outline-item-label">Result Display</span></a>
+            <a href="#popup-size"       class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="popup-size"></span></span><span class="outline-item-label">Position &amp; Size</span></a>
+            <a href="#window"           class="button outline-item advanced-only"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="window"></span></span><span class="outline-item-label">Search Window</span></a>
+            <a href="#audio"            class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="speaker"></span></span><span class="outline-item-label">Audio</span></a>
+            <a href="#text-parsing"     class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="text-parsing"></span></span><span class="outline-item-label">Text Parsing</span></a>
+            <a href="#translation"      class="button outline-item advanced-only"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="translation"></span></span><span class="outline-item-label">Translation</span></a>
+            <a href="#anki"             class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="note-card"></span></span><span class="outline-item-label">Anki</span></a>
+            <a href="#clipboard"        class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="clipboard"></span></span><span class="outline-item-label">Clipboard</span></a>
+            <a href="#shortcuts"        class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="keyboard"></span></span><span class="outline-item-label">Shortcuts</span></a>
+            <a href="#backup"           class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="backup"></span></span><span class="outline-item-label">Backup</span></a>
+            <a href="#accessibility"    class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="accessibility"></span></span><span class="outline-item-label">Accessibility</span></a>
+            <a href="#security"         class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="lock"></span></span><span class="outline-item-label">Security</span></a>
         </div>
         <div class="sidebar-bottom">
             <label class="button outline-item"><span class="outline-item-left">
@@ -92,7 +92,7 @@
     <!-- Profile -->
     <div class="heading-container">
         <div class="heading-container-icon"><span class="icon" data-icon="profile"></span></div>
-        <div class="heading-container-left"><h2 id="profile"><a href="#!profile">Profile</a></h2></div>
+        <div class="heading-container-left"><h2 id="profile"><a href="#profile">Profile</a></h2></div>
     </div>
     <div class="settings-group">
         <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
@@ -126,7 +126,7 @@
         <!-- General -->
         <div class="heading-container">
             <div class="heading-container-icon"><span class="icon" data-icon="cog"></span></div>
-            <div class="heading-container-left"><h2 id="general"><a href="#!general">General</a></h2></div>
+            <div class="heading-container-left"><h2 id="general"><a href="#general">General</a></h2></div>
         </div>
         <div class="settings-group">
             <div class="settings-item"><div class="settings-item-inner">
@@ -186,7 +186,7 @@
     <!-- Dictionaries -->
     <div class="heading-container">
         <div class="heading-container-icon"><span class="icon" data-icon="book"></span></div>
-        <div class="heading-container-left"><h2 id="dictionaries"><a href="#!dictionaries">Dictionaries</a> <span class="heading-sub-text no-wrap" data-modal-action="show,dictionaries">(<span id="dictionary-install-count">#</span> installed, <span id="dictionary-enabled-count">#</span> enabled)</span></h2></div>
+        <div class="heading-container-left"><h2 id="dictionaries"><a href="#dictionaries">Dictionaries</a> <span class="heading-sub-text no-wrap" data-modal-action="show,dictionaries">(<span id="dictionary-install-count">#</span> installed, <span id="dictionary-enabled-count">#</span> enabled)</span></h2></div>
     </div>
     <div class="settings-group">
         <div class="settings-item settings-item-button" data-modal-action="show,dictionaries"><div class="settings-item-inner">
@@ -350,7 +350,7 @@
     <!-- Scanning -->
     <div class="heading-container">
         <div class="heading-container-icon"><span class="icon" data-icon="scanning"></span></div>
-        <div class="heading-container-left"><h2 id="scanning"><a href="#!scanning">Scanning</a></h2></div>
+        <div class="heading-container-left"><h2 id="scanning"><a href="#scanning">Scanning</a></h2></div>
     </div>
     <div class="settings-group">
         <div class="settings-item">
@@ -557,7 +557,7 @@
     <!-- Popup Behavior -->
     <div class="heading-container">
         <div class="heading-container-icon"><span class="icon" data-icon="popup"></span></div>
-        <div class="heading-container-left"><h2 id="popup"><a href="#!popup">Popup Behavior</a></h2></div>
+        <div class="heading-container-left"><h2 id="popup"><a href="#popup">Popup Behavior</a></h2></div>
     </div>
     <div class="settings-group">
         <div class="settings-item"><div class="settings-item-inner">
@@ -694,7 +694,7 @@
     <!-- Appearance -->
     <div class="heading-container">
         <div class="heading-container-icon"><span class="icon" data-icon="palette"></span></div>
-        <div class="heading-container-left"><h2 id="appearance"><a href="#!appearance">Appearance</a></h2></div>
+        <div class="heading-container-left"><h2 id="appearance"><a href="#appearance">Appearance</a></h2></div>
     </div>
     <div class="settings-group">
         <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
@@ -1016,7 +1016,7 @@
     <!-- Result Display -->
     <div class="heading-container">
         <div class="heading-container-icon"><span class="icon" data-icon="monitor"></span></div>
-        <div class="heading-container-left"><h2 id="result-display"><a href="#!result-display">Result Display</a></h2></div>
+        <div class="heading-container-left"><h2 id="result-display"><a href="#result-display">Result Display</a></h2></div>
     </div>
     <div class="settings-group">
         <div class="settings-item">
@@ -1104,7 +1104,7 @@
     <!-- Popup Position & Size -->
     <div class="heading-container">
         <div class="heading-container-icon"><span class="icon" data-icon="popup-size"></span></div>
-        <div class="heading-container-left"><h2 id="popup-size"><a href="#!popup-size">Popup Position &amp; Size</a></h2></div>
+        <div class="heading-container-left"><h2 id="popup-size"><a href="#popup-size">Popup Position &amp; Size</a></h2></div>
     </div>
     <div class="settings-group">
         <div class="settings-item">
@@ -1289,7 +1289,7 @@
     <!-- Search Window -->
     <div class="heading-container advanced-only">
         <div class="heading-container-icon"><span class="icon" data-icon="window"></span></div>
-        <div class="heading-container-left"><h2 id="window"><a href="#!window">Search Window</a></h2></div>
+        <div class="heading-container-left"><h2 id="window"><a href="#window">Search Window</a></h2></div>
         <div class="heading-container-right"><a tabindex="0" class="heading-link-light" id="test-window-open-link">Open&hellip;</a></div>
     </div>
     <div class="settings-group advanced-only">
@@ -1449,7 +1449,7 @@
     <!-- Audio -->
     <div class="heading-container">
         <div class="heading-container-icon"><span class="icon" data-icon="speaker"></span></div>
-        <div class="heading-container-left"><h2 id="audio"><a href="#!audio">Audio</a></h2></div>
+        <div class="heading-container-left"><h2 id="audio"><a href="#audio">Audio</a></h2></div>
     </div>
     <div class="settings-group">
         <div class="settings-item"><div class="settings-item-inner">
@@ -1510,7 +1510,7 @@
     <div>
         <div class="heading-container">
             <div class="heading-container-icon"><span class="icon" data-icon="text-parsing"></span></div>
-            <div class="heading-container-left"><h2 id="text-parsing"><a href="#!text-parsing">Text Parsing</a></h2></div>
+            <div class="heading-container-left"><h2 id="text-parsing"><a href="#text-parsing">Text Parsing</a></h2></div>
             <div class="heading-container-right"><a tabindex="0" class="more-toggle more-only heading-link-light" data-parent-distance="3">Info&hellip;</a></div>
         </div>
         <div class="heading-description more" hidden>
@@ -1635,7 +1635,7 @@
     <div class="advanced-only">
         <div class="heading-container">
             <div class="heading-container-icon"><span class="icon" data-icon="translation"></span></div>
-            <div class="heading-container-left"><h2 id="translation"><a href="#!translation">Translation</a></h2></div>
+            <div class="heading-container-left"><h2 id="translation"><a href="#translation">Translation</a></h2></div>
         </div>
     </div>
     <div class="settings-group advanced-only">
@@ -1665,7 +1665,7 @@
     <div>
         <div class="heading-container">
             <div class="heading-container-icon"><span class="icon" data-icon="note-card"></span></div>
-            <div class="heading-container-left"><h2 id="anki"><a href="#!anki">Anki</a></h2></div>
+            <div class="heading-container-left"><h2 id="anki"><a href="#anki">Anki</a></h2></div>
             <div class="heading-container-right"><a tabindex="0" class="more-toggle more-only heading-link-light" data-parent-distance="3">Info&hellip;</a></div>
         </div>
         <div class="heading-description more" hidden>
@@ -2013,7 +2013,7 @@
     <div>
         <div class="heading-container">
             <div class="heading-container-icon"><span class="icon" data-icon="clipboard"></span></div>
-            <div class="heading-container-left"><h2 id="clipboard"><a href="#!clipboard">Clipboard</a></h2></div>
+            <div class="heading-container-left"><h2 id="clipboard"><a href="#clipboard">Clipboard</a></h2></div>
             <div class="heading-container-right"><a tabindex="0" class="more-toggle more-only heading-link-light" data-parent-distance="3">Info&hellip;</a></div>
         </div>
         <div class="heading-description more" hidden>
@@ -2089,7 +2089,7 @@
     <!-- Shortcuts -->
     <div class="heading-container">
         <div class="heading-container-icon"><span class="icon" data-icon="keyboard"></span></div>
-        <div class="heading-container-left"><h2 id="shortcuts"><a href="#!shortcuts">Shortcuts</a></h2></div>
+        <div class="heading-container-left"><h2 id="shortcuts"><a href="#shortcuts">Shortcuts</a></h2></div>
     </div>
     <div class="settings-group">
         <div class="settings-item"><div class="settings-item-inner">
@@ -2132,7 +2132,7 @@
     <!-- Backup -->
     <div class="heading-container">
         <div class="heading-container-icon"><span class="icon" data-icon="backup"></span></div>
-        <div class="heading-container-left"><h2 id="backup"><a href="#!backup">Backup</a></h2></div>
+        <div class="heading-container-left"><h2 id="backup"><a href="#backup">Backup</a></h2></div>
     </div>
     <div class="settings-group">
         <div class="settings-item"><div class="settings-item-inner">
@@ -2215,7 +2215,7 @@
     <!-- Accessibility -->
     <div class="heading-container">
         <div class="heading-container-icon"><span class="icon" data-icon="accessibility"></span></div>
-        <div class="heading-container-left"><h2 id="accessibility"><a href="#!accessibility">Accessibility</a></h2></div>
+        <div class="heading-container-left"><h2 id="accessibility"><a href="#accessibility">Accessibility</a></h2></div>
     </div>
     <div class="settings-group">
         <div class="settings-item">
@@ -2257,7 +2257,7 @@
     <!-- Security -->
     <div class="heading-container">
         <div class="heading-container-icon"><span class="icon" data-icon="lock"></span></div>
-        <div class="heading-container-left"><h2 id="security"><a href="#!security">Security</a></h2></div>
+        <div class="heading-container-left"><h2 id="security"><a href="#security">Security</a></h2></div>
     </div>
     <div class="settings-group">
         <a href="/permissions.html" rel="noopener" class="settings-item settings-item-button"><div class="settings-item-inner">

--- a/ext/templates-display.html
+++ b/ext/templates-display.html
@@ -192,7 +192,7 @@
 </div></template>
 <template id="footer-notification-anki-view-note-error-template" data-remove-whitespace-text="true">
     Note viewer window could not be opened.<br>
-    Check the <a href="/settings.html#!anki" target="_blank" rel="noopener"><em>Anki</em> &rsaquo; <em>Note viewer window</em></a> setting.
+    Check the <a href="/settings.html#anki" target="_blank" rel="noopener"><em>Anki</em> &rsaquo; <em>Note viewer window</em></a> setting.
 </template>
 <template id="profile-list-item-template"><label class="profile-list-item">
     <div class="profile-list-item-selection"><label class="radio"><input type="radio" class="profile-entry-is-default-radio" name="profile-entry-default-radio"><span class="radio-body"><span class="radio-border"></span><span class="radio-dot"></span></span></label></div>


### PR DESCRIPTION
Fixes #1892

Firefox does not trigger a `popstate` event when navigating to the same anchor link twice. Chromium does (possibly violating the spec). If there is no url change from the anchor link being clicked, Firefox wont fire the event. But Firefox will still navigate to the correct spot on the page.

The anchor link handling within Yomitan intentionally set invalid anchor links (`#!` instead of `#`) to be handled by `_updateScrollTarget`. This doesn't make sense to do. There is no extra handling anywhere that makes this necessary.

It's possible in the past this was to handle scrolling to the correct position on initial page load but that doesn't work. With or without this PR. There are too many reflows and it would need to scroll the position much later than the settings controller will on its prepare. And if this is something we add in the future it can be done with normal anchor links anyways.