### PR TITLE
Don't clear existing search when clipboard is updated and `Update query only` is set

### DIFF
--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1367,7 +1367,9 @@ export class Display extends EventDispatcher {
             safePerformance.mark('display:findDictionaryEntries:end');
             safePerformance.measure('display:findDictionaryEntries', 'display:findDictionaryEntries:start', 'display:findDictionaryEntries:end');
             if (this._setContentToken !== token) { return; }
-            content.dictionaryEntries = dictionaryEntries;
+            if (lookup) {
+                content.dictionaryEntries = dictionaryEntries;
+            }
             changeHistory = true;
         }
 


### PR DESCRIPTION
Fixes #1376... Though strictly as the issue describes this was never an issue, it worked kinda terribly.

Before this pr, setting `Clipboard text search mode` to `Update search only` would indeed not search the word. But it would just clear the entire search so any searched definitions you had there before wouldnt show. This just makes it so nothing changes except the search bar.

Example (I searched よむ initially then copied わかる and you can see わかる is only present in the search bar while the info on よむ is still visible):
![image](https://github.com/user-attachments/assets/e6282be2-26a4-4c04-9f11-5e5c4971eec7)
