### PR TITLE
Pull update url from existing entries when moving to prevent update button from appearing when it shouldnt

### DIFF
--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -910,13 +910,20 @@ export class DictionaryController {
             dictionaryEntry.cleanup();
         }
 
+        /** @type {Map<string, string | null>} */
+        const dictionaryUpdateDownloadUrlMap = new Map();
+        for (const entry of this._dictionaryEntries) {
+            dictionaryUpdateDownloadUrlMap.set(entry.dictionaryTitle, entry.updateDownloadUrl);
+            entry.cleanup();
+        }
+
         const dictionaryOptionsArray = options.dictionaries;
         for (let i = 0; i < dictionaryOptionsArray.length; i++) {
             const {name} = dictionaryOptionsArray[i];
             /** @type {import('dictionary-importer').Summary | undefined} */
             const dictionaryInfo = dictionaries.find((dictionary) => dictionary.title === name);
             if (typeof dictionaryInfo === 'undefined') { continue; }
-            const updateDownloadUrl = dictionaryInfo.downloadUrl ?? null;
+            const updateDownloadUrl = dictionaryUpdateDownloadUrlMap.get(name) ?? null;
             this._createDictionaryEntry(i, dictionaryInfo, updateDownloadUrl);
         }
         this._dictionaryModalBody.scroll({top: dictionariesModalBodyScrollY});


### PR DESCRIPTION
Broke this when I was stripping down the function to make it faster (#1671). Copy paste from the `_updateEntries` code into `_updateCurrentEntries` (only used for moving dicts).

When moving dicts the update button appears on any dict that has an update url set instead of dicts that actually have been checked for an update, and have an update.