### PR TITLE
Preserve integrity check details when moving around dictionaries

### DIFF
--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -141,6 +141,13 @@ class DictionaryEntry {
     }
 
     /**
+     * @returns {import('dictionary-database').DictionaryCountGroup | null}
+     */
+    get databaseCounts() {
+        return this._databaseCounts;
+    }
+
+    /**
      * @param {boolean} value
      */
     setEnabled(value) {
@@ -922,7 +929,7 @@ export class DictionaryController {
         const dictionaryDatabaseCountsMap = new Map();
         for (const entry of this._dictionaryEntries) {
             dictionaryUpdateDownloadUrlMap.set(entry.dictionaryTitle, entry.updateDownloadUrl);
-            dictionaryDatabaseCountsMap.set(entry.dictionaryTitle, entry._databaseCounts);
+            dictionaryDatabaseCountsMap.set(entry.dictionaryTitle, entry.databaseCounts);
             entry.cleanup();
         }
 

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -34,8 +34,9 @@ class DictionaryEntry {
      * @param {number} index
      * @param {import('dictionary-importer').Summary} dictionaryInfo
      * @param {string | null} updateDownloadUrl
+     * @param {import('dictionary-database').DictionaryCountGroup|null} dictionaryDatabaseCounts
      */
-    constructor(dictionaryController, fragment, index, dictionaryInfo, updateDownloadUrl) {
+    constructor(dictionaryController, fragment, index, dictionaryInfo, updateDownloadUrl, dictionaryDatabaseCounts) {
         /** @type {DictionaryController} */
         this._dictionaryController = dictionaryController;
         /** @type {number} */
@@ -47,7 +48,7 @@ class DictionaryEntry {
         /** @type {EventListenerCollection} */
         this._eventListeners = new EventListenerCollection();
         /** @type {?import('dictionary-database').DictionaryCountGroup} */
-        this._databaseCounts = null;
+        this._databaseCounts = dictionaryDatabaseCounts;
         /** @type {ChildNode[]} */
         this._nodes = [...fragment.childNodes];
         /** @type {HTMLInputElement} */
@@ -99,6 +100,8 @@ class DictionaryEntry {
         this._eventListeners.addEventListener(this._integrityButtonCheck, 'click', this._onIntegrityButtonClick.bind(this), false);
         this._eventListeners.addEventListener(this._integrityButtonWarning, 'click', this._onIntegrityButtonClick.bind(this), false);
         this._eventListeners.addEventListener(this._updatesAvailable, 'click', this._onUpdateButtonClick.bind(this), false);
+
+        this.setCounts(this._databaseCounts);
     }
 
     /** */
@@ -113,9 +116,12 @@ class DictionaryEntry {
     }
 
     /**
-     * @param {import('dictionary-database').DictionaryCountGroup} databaseCounts
+     * @param {import('dictionary-database').DictionaryCountGroup?} databaseCounts
      */
     setCounts(databaseCounts) {
+        if (!databaseCounts) {
+            return;
+        }
         this._databaseCounts = databaseCounts;
         let countsMismatch = false;
 
@@ -894,7 +900,7 @@ export class DictionaryController {
             const dictionaryInfo = dictionaryInfoMap.get(name);
             const updateDownloadUrl = dictionaryUpdateDownloadUrlMap.get(name) ?? null;
             if (typeof dictionaryInfo === 'undefined') { continue; }
-            this._createDictionaryEntry(i, dictionaryInfo, updateDownloadUrl);
+            this._createDictionaryEntry(i, dictionaryInfo, updateDownloadUrl, null);
         }
     }
 
@@ -910,14 +916,25 @@ export class DictionaryController {
             dictionaryEntry.cleanup();
         }
 
+        /** @type {Map<string, string | null>} */
+        const dictionaryUpdateDownloadUrlMap = new Map();
+        /** @type {Map<string, import('dictionary-database').DictionaryCountGroup | null>} */
+        const dictionaryDatabaseCountsMap = new Map();
+        for (const entry of this._dictionaryEntries) {
+            dictionaryUpdateDownloadUrlMap.set(entry.dictionaryTitle, entry.updateDownloadUrl);
+            dictionaryDatabaseCountsMap.set(entry.dictionaryTitle, entry._databaseCounts);
+            entry.cleanup();
+        }
+
         const dictionaryOptionsArray = options.dictionaries;
         for (let i = 0; i < dictionaryOptionsArray.length; i++) {
             const {name} = dictionaryOptionsArray[i];
             /** @type {import('dictionary-importer').Summary | undefined} */
             const dictionaryInfo = dictionaries.find((dictionary) => dictionary.title === name);
             if (typeof dictionaryInfo === 'undefined') { continue; }
-            const updateDownloadUrl = dictionaryInfo.downloadUrl ?? null;
-            this._createDictionaryEntry(i, dictionaryInfo, updateDownloadUrl);
+            const updateDownloadUrl = dictionaryUpdateDownloadUrlMap.get(name) ?? null;
+            const dictionaryDatabaseCounts = dictionaryDatabaseCountsMap.get(name) ?? null;
+            this._createDictionaryEntry(i, dictionaryInfo, updateDownloadUrl, dictionaryDatabaseCounts);
         }
         this._dictionaryModalBody.scroll({top: dictionariesModalBodyScrollY});
     }
@@ -1181,11 +1198,12 @@ export class DictionaryController {
      * @param {number} index
      * @param {import('dictionary-importer').Summary} dictionaryInfo
      * @param {string|null} updateDownloadUrl
+     * @param {import('dictionary-database').DictionaryCountGroup|null} dictionaryDatabaseCounts
      */
-    _createDictionaryEntry(index, dictionaryInfo, updateDownloadUrl) {
+    _createDictionaryEntry(index, dictionaryInfo, updateDownloadUrl, dictionaryDatabaseCounts) {
         const fragment = this.instantiateTemplateFragment('dictionary');
 
-        const entry = new DictionaryEntry(this, fragment, index, dictionaryInfo, updateDownloadUrl);
+        const entry = new DictionaryEntry(this, fragment, index, dictionaryInfo, updateDownloadUrl, dictionaryDatabaseCounts);
         this._dictionaryEntries.push(entry);
         entry.prepare();
 


### PR DESCRIPTION
Borrows from #1902. Probably best to merge that one first. Could have conflicts as well.
