### PR TITLE
Fix underline on kanji headword characters jumping around with different fonts

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -967,9 +967,9 @@ button.action-button:active {
     color: var(--headword-current-furigana-text-color);
 }
 .headword-kanji-link {
-    border-bottom: var(--headword-thin-border-size) dashed var(--headword-current-kanji-border-color);
+    text-decoration: underline dashed var(--headword-current-kanji-border-color) var(--headword-thin-border-size);
+    text-underline-offset: calc(var(--headword-font-size) / 15);
     color: var(--headword-current-kanji-text-color);
-    text-decoration: none;
     cursor: pointer;
 }
 :root[data-result-output-mode=merge] .headword-list-details {


### PR DESCRIPTION
Fixes #1917

The container size seems to change strangely sometimes depending on the font. So `border-bottom` isn't great to use as an underline. Browsers have more info on fonts that can help position the underline if we use a real underline with `text-decoration`.

Using 1/15 the font size for the offset since that appeared to match well to what it was before on chromium (firefox was a bit larger offset) with the some default fonts.

Example: 
![image](https://github.com/user-attachments/assets/c5d66442-7624-4b7b-9dd7-3045d001acd0)
