### PR TITLE
Handle mobile browsers pretending to be composing

### DIFF
--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -161,6 +161,8 @@ export class Display extends EventDispatcher {
         this._frameEndpoint = (pageType === 'popup' ? new FrameEndpoint(this._application.api) : null);
         /** @type {?import('environment').Browser} */
         this._browser = null;
+        /** @type {?import('environment').OperatingSystem} */
+        this._platform = null;
         /** @type {?HTMLTextAreaElement} */
         this._copyTextarea = null;
         /** @type {?TextScanner} */
@@ -316,11 +318,13 @@ export class Display extends EventDispatcher {
 
         // State setup
         const {documentElement} = document;
-        const {browser} = await this._application.api.getEnvironmentInfo();
+        const {browser, platform} = await this._application.api.getEnvironmentInfo();
         this._browser = browser;
+        this._platform = platform.os;
 
         if (documentElement !== null) {
             documentElement.dataset.browser = browser;
+            documentElement.dataset.platform = platform.os;
         }
 
         this._languageSummaries = await this._application.api.getLanguageSummaries();

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -20,8 +20,8 @@ import {ClipboardMonitor} from '../comm/clipboard-monitor.js';
 import {createApiMap, invokeApiMapHandler} from '../core/api-map.js';
 import {EventListenerCollection} from '../core/event-listener-collection.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
+import {isComposing} from '../language/ime-utilities.js';
 import {convertToKanaIME} from '../language/ja/japanese-wanakana.js';
-import {isFakeComposing} from '../language/text-utilities.js';
 
 export class SearchDisplayController {
     /**
@@ -259,10 +259,9 @@ export class SearchDisplayController {
      * @param {InputEvent} event
      */
     _searchTextKanaConversion(element, event) {
-        // Desktop Composing
-        if (event.isComposing && document.documentElement.dataset.platform !== 'android') { return; }
-        // Android Composing
-        if (event.isComposing && !isFakeComposing(event) && document.documentElement.dataset.platform === 'android' && document.documentElement.dataset.browser !== 'firefox-mobile') { return; }
+        const platform = document.documentElement.dataset.platform ?? 'unknown';
+        const browser = document.documentElement.dataset.browser ?? 'unknown';
+        if (isComposing(event, platform, browser)) { return; }
         const {kanaString, newSelectionStart} = convertToKanaIME(element.value, element.selectionStart);
         element.value = kanaString;
         element.setSelectionRange(newSelectionStart, newSelectionStart);

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -259,7 +259,7 @@ export class SearchDisplayController {
      * @param {InputEvent} event
      */
     _searchTextKanaConversion(element, event) {
-        if (!this._wanakanaEnabled || (event.isComposing && !isFakeComposing(event))) { return; }
+        if (!this._wanakanaEnabled || (event.isComposing && !isFakeComposing(event) && document.documentElement.dataset.platform !== 'android')) { return; }
         const {kanaString, newSelectionStart} = convertToKanaIME(element.value, element.selectionStart);
         element.value = kanaString;
         element.setSelectionRange(newSelectionStart, newSelectionStart);

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -21,6 +21,7 @@ import {createApiMap, invokeApiMapHandler} from '../core/api-map.js';
 import {EventListenerCollection} from '../core/event-listener-collection.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
 import {convertToKanaIME} from '../language/ja/japanese-wanakana.js';
+import {isFakeComposing} from '../language/text-utilities.js';
 
 export class SearchDisplayController {
     /**
@@ -244,7 +245,7 @@ export class SearchDisplayController {
     }
 
     /**
-     * @param {KeyboardEvent} e
+     * @param {InputEvent} e
      */
     _onSearchInput(e) {
         this._updateSearchHeight(true);
@@ -255,10 +256,10 @@ export class SearchDisplayController {
 
     /**
      * @param {HTMLTextAreaElement} element
-     * @param {KeyboardEvent} event
+     * @param {InputEvent} event
      */
     _searchTextKanaConversion(element, event) {
-        if (!this._wanakanaEnabled || event.isComposing) { return; }
+        if (!this._wanakanaEnabled || (event.isComposing && !isFakeComposing(event))) { return; }
         const {kanaString, newSelectionStart} = convertToKanaIME(element.value, element.selectionStart);
         element.value = kanaString;
         element.setSelectionRange(newSelectionStart, newSelectionStart);

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -262,7 +262,7 @@ export class SearchDisplayController {
         // Desktop Composing
         if (event.isComposing && document.documentElement.dataset.platform !== 'android') { return; }
         // Android Composing
-        if (event.isComposing && !isFakeComposing(event) && document.documentElement.dataset.platform === 'android') { return; }
+        if (event.isComposing && !isFakeComposing(event) && document.documentElement.dataset.platform === 'android' && document.documentElement.dataset.browser !== 'firefox-mobile') { return; }
         const {kanaString, newSelectionStart} = convertToKanaIME(element.value, element.selectionStart);
         element.value = kanaString;
         element.setSelectionRange(newSelectionStart, newSelectionStart);

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -259,7 +259,10 @@ export class SearchDisplayController {
      * @param {InputEvent} event
      */
     _searchTextKanaConversion(element, event) {
-        if (!this._wanakanaEnabled || (event.isComposing && !isFakeComposing(event) && document.documentElement.dataset.platform !== 'android')) { return; }
+        // Desktop Composing
+        if (event.isComposing && document.documentElement.dataset.platform !== 'android') { return; }
+        // Android Composing
+        if (event.isComposing && !isFakeComposing(event) && document.documentElement.dataset.platform === 'android') { return; }
         const {kanaString, newSelectionStart} = convertToKanaIME(element.value, element.selectionStart);
         element.value = kanaString;
         element.setSelectionRange(newSelectionStart, newSelectionStart);

--- a/ext/js/language/ime-utilities.js
+++ b/ext/js/language/ime-utilities.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Mobile browsers report that keyboards are composing even when they are clearly sending normal input.
+ * This conflicts with detection of desktop IME composing which is reported correctly.
+ * If the composing input is a single alphabetic letter, it is almost certainly a mobile keyboard pretending to be composing.
+ * This is not foolproof. For example a Japanese IME could try to convert `えい` to `A` which would show as "fake composing". But this is unlikely.
+ * @param {InputEvent} event
+ * @returns {boolean}
+ */
+export function isFakeComposing(event) {
+    return !!event.data?.match(/^[A-Za-z]$/);
+}
+
+/**
+ * @param {InputEvent} event
+ * @param {string} platform
+ * @param {string} browser
+ * @returns {boolean}
+ */
+export function isComposing(event, platform, browser) {
+    // Desktop Composing
+    if (event.isComposing && platform !== 'android') { return true; }
+
+    // Android Composing
+    // eslint-disable-next-line sonarjs/prefer-single-boolean-return
+    if (event.isComposing && !isFakeComposing(event) && platform === 'android' && browser !== 'firefox-mobile') { return true; }
+
+    return false;
+}

--- a/ext/js/language/text-utilities.js
+++ b/ext/js/language/text-utilities.js
@@ -27,3 +27,15 @@ export function getLanguageFromText(text) {
     if (isStringPartiallyJapanese(text)) { return 'ja'; }
     return null;
 }
+
+/**
+ * Mobile browsers report that keyboards are composing even when they are clearly sending normal input.
+ * This conflicts with detection of desktop IME composing which is reported correctly.
+ * If the composing input is a single alphabetic letter, it is almost certainly a mobile keyboard pretending to be composing.
+ * This is not foolproof. For example a Japanese IME could try to convert `えい` to `A` which would show as "fake composing". But this is unlikely.
+ * @param {InputEvent} event
+ * @returns {boolean}
+ */
+export function isFakeComposing(event) {
+    return !!event.data?.match(/^[A-Za-z]$/);
+}

--- a/ext/js/language/text-utilities.js
+++ b/ext/js/language/text-utilities.js
@@ -27,15 +27,3 @@ export function getLanguageFromText(text) {
     if (isStringPartiallyJapanese(text)) { return 'ja'; }
     return null;
 }
-
-/**
- * Mobile browsers report that keyboards are composing even when they are clearly sending normal input.
- * This conflicts with detection of desktop IME composing which is reported correctly.
- * If the composing input is a single alphabetic letter, it is almost certainly a mobile keyboard pretending to be composing.
- * This is not foolproof. For example a Japanese IME could try to convert `えい` to `A` which would show as "fake composing". But this is unlikely.
- * @param {InputEvent} event
- * @returns {boolean}
- */
-export function isFakeComposing(event) {
-    return !!event.data?.match(/^[A-Za-z]$/);
-}

--- a/ext/js/pages/settings/popup-preview-frame.js
+++ b/ext/js/pages/settings/popup-preview-frame.js
@@ -281,7 +281,11 @@ export class PopupPreviewFrame {
      * @param {InputEvent} event
      */
     _searchTextKanaConversion(element, event) {
-        if (event.isComposing && !isFakeComposing(event)) { return; }
+        // Desktop Composing
+        if (event.isComposing && document.documentElement.dataset.platform !== 'android') { return; }
+        // Android Composing
+        if (event.isComposing && !isFakeComposing(event) && document.documentElement.dataset.platform === 'android') { return; }
+
         const {kanaString, newSelectionStart} = convertToKanaIME(element.value, element.selectionStart);
         element.value = kanaString;
         element.setSelectionRange(newSelectionStart, newSelectionStart);

--- a/ext/js/pages/settings/popup-preview-frame.js
+++ b/ext/js/pages/settings/popup-preview-frame.js
@@ -284,7 +284,7 @@ export class PopupPreviewFrame {
         // Desktop Composing
         if (event.isComposing && document.documentElement.dataset.platform !== 'android') { return; }
         // Android Composing
-        if (event.isComposing && !isFakeComposing(event) && document.documentElement.dataset.platform === 'android') { return; }
+        if (event.isComposing && !isFakeComposing(event) && document.documentElement.dataset.platform === 'android' && document.documentElement.dataset.browser !== 'firefox-mobile') { return; }
 
         const {kanaString, newSelectionStart} = convertToKanaIME(element.value, element.selectionStart);
         element.value = kanaString;

--- a/ext/js/pages/settings/popup-preview-frame.js
+++ b/ext/js/pages/settings/popup-preview-frame.js
@@ -22,8 +22,8 @@ import {createApiMap, invokeApiMapHandler} from '../../core/api-map.js';
 import {EventListenerCollection} from '../../core/event-listener-collection.js';
 import {querySelectorNotNull} from '../../dom/query-selector.js';
 import {TextSourceRange} from '../../dom/text-source-range.js';
+import {isComposing} from '../../language/ime-utilities.js';
 import {convertToKanaIME} from '../../language/ja/japanese-wanakana.js';
-import {isFakeComposing} from '../../language/text-utilities.js';
 
 export class PopupPreviewFrame {
     /**
@@ -281,10 +281,9 @@ export class PopupPreviewFrame {
      * @param {InputEvent} event
      */
     _searchTextKanaConversion(element, event) {
-        // Desktop Composing
-        if (event.isComposing && document.documentElement.dataset.platform !== 'android') { return; }
-        // Android Composing
-        if (event.isComposing && !isFakeComposing(event) && document.documentElement.dataset.platform === 'android' && document.documentElement.dataset.browser !== 'firefox-mobile') { return; }
+        const platform = document.documentElement.dataset.platform ?? 'unknown';
+        const browser = document.documentElement.dataset.browser ?? 'unknown';
+        if (isComposing(event, platform, browser)) { return; }
 
         const {kanaString, newSelectionStart} = convertToKanaIME(element.value, element.selectionStart);
         element.value = kanaString;

--- a/ext/js/pages/settings/popup-preview-frame.js
+++ b/ext/js/pages/settings/popup-preview-frame.js
@@ -23,6 +23,7 @@ import {EventListenerCollection} from '../../core/event-listener-collection.js';
 import {querySelectorNotNull} from '../../dom/query-selector.js';
 import {TextSourceRange} from '../../dom/text-source-range.js';
 import {convertToKanaIME} from '../../language/ja/japanese-wanakana.js';
+import {isFakeComposing} from '../../language/text-utilities.js';
 
 export class PopupPreviewFrame {
     /**
@@ -268,7 +269,7 @@ export class PopupPreviewFrame {
     }
 
     /**
-     * @param {KeyboardEvent} e
+     * @param {InputEvent} e
      */
     _onSearchInput(e) {
         const element = /** @type {HTMLTextAreaElement} */ (e.currentTarget);
@@ -277,10 +278,10 @@ export class PopupPreviewFrame {
 
     /**
      * @param {HTMLTextAreaElement} element
-     * @param {KeyboardEvent} event
+     * @param {InputEvent} event
      */
     _searchTextKanaConversion(element, event) {
-        if (event.isComposing) { return; }
+        if (event.isComposing && !isFakeComposing(event)) { return; }
         const {kanaString, newSelectionStart} = convertToKanaIME(element.value, element.selectionStart);
         element.value = kanaString;
         element.setSelectionRange(newSelectionStart, newSelectionStart);


### PR DESCRIPTION
Android browsers often pretend to be composing when typing. Having a blanket filter for composing doesn't work here.

On mobile chromium browsers we can fairly easily check if theyre pretending to be composing by checking if they're "composing" a single alphabetic letter.

On firefox mobile, this doesn't work so it's excluded from this check.