### PR TITLE
Partially preserve newlines in search queries on search page

### DIFF
--- a/ext/js/data/string-util.js
+++ b/ext/js/data/string-util.js
@@ -70,12 +70,12 @@ export function readCodePointsBackward(text, position, count) {
 }
 
 /**
- * Trims trailing whitespace and adds a space on the end if it needed trimming.
+ * Trims and condenses trailing whitespace and adds a space on the end if it needed trimming.
  * @param {string} text
  * @returns {string}
  */
 export function trimTrailingWhitespacePlusSpace(text) {
-    const prevTextLength = text.length;
-    const textTrimmed = text.trimEnd();
-    return prevTextLength === textTrimmed.length ? textTrimmed : textTrimmed + ' ';
+    // Consense multiple leading and trailing newlines into one newline
+    // Trim trailing whitespace excluding newlines
+    return text.replaceAll(/(\n+$|^\n+)/g, '\n').replaceAll(/[^\S\n]+$/g, ' ');
 }

--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -300,12 +300,14 @@ export class QueryParser extends EventDispatcher {
     _createParseResult(data) {
         let offset = 0;
         const fragment = document.createDocumentFragment();
-        for (const term of data) {
+        for (let i = 0; i < data.length; i++) {
+            const term = data[i];
             const termNode = document.createElement('span');
             termNode.className = 'query-parser-term';
             termNode.dataset.offset = `${offset}`;
             for (const {text, reading} of term) {
-                const trimmedText = trimTrailingWhitespacePlusSpace(text);
+                // trimEnd only for final text
+                const trimmedText = i === data.length - 1 ? text.trimEnd() : trimTrailingWhitespacePlusSpace(text);
                 if (reading.length === 0) {
                     termNode.appendChild(document.createTextNode(trimmedText));
                 } else {


### PR DESCRIPTION
When copy-pasting a lot of text with newlines in it, it can be hard to quickly find a certain spot in the text since it would be reformatted to remove the newlines. The newlines should be kept. But it seems reasonable to condense them.

#1600 and #1625 both overdid the trimming. In order to fix #1463 all that was really required was to trim the final piece of text...

Tested with Japanese and English (does not break spacing in languages with spaces).

Before:
![image](https://github.com/user-attachments/assets/58c9c2cc-1ec7-402c-ad83-30d9af06aff9)

![image](https://github.com/user-attachments/assets/e33006d7-093d-453a-b8ff-206be80cda6e)

After:
![image](https://github.com/user-attachments/assets/a20fd804-b697-47f5-a954-212295f4aff7)
![image](https://github.com/user-attachments/assets/4faa5893-a5ad-425d-9b03-1afc9648454f)

![image](https://github.com/user-attachments/assets/bcd1e30b-a7e2-47e6-80b5-f8066bc240eb)
