### PR TITLE
Check if modifier is set when scanning from keypress without move before pushing through synthetic mouse event

### DIFF
--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -584,11 +584,24 @@ export class TextScanner extends EventDispatcher {
     }
 
     /**
+     * @param {import('input').Modifier[]} activeModifiers
+     * @returns {boolean}
+     */
+    _modifierKeySet(activeModifiers) {
+        /** @type {string[]} */
+        const settingsModifiers = [];
+        for (const settingsInput of this._inputs) {
+            settingsModifiers.push(...settingsInput.include);
+        }
+        return activeModifiers.some((modifier) => settingsModifiers.includes(modifier));
+    }
+
+    /**
      * @param {KeyboardEvent} e
      */
     _onKeyDown(e) {
         const modifiers = getActiveModifiers(e);
-        if (this._lastMouseMove !== null && (modifiers.length > 0)) {
+        if (this._lastMouseMove !== null && modifiers.length > 0 && this._modifierKeySet(modifiers)) {
             if (this._inputtingText()) { return; }
             const syntheticMousePointerEvent = new PointerEvent(this._lastMouseMove.type, {
                 screenX: this._lastMouseMove.screenX,


### PR DESCRIPTION
Fixes #1931

Since the downstream code from this function has no way of knowing this input came from a keypress (and it's probably not great to make another param), synthetic mouse events should not be blindly sent through if they do not contain any modifiers matching those set in the user's scanning settings.