### PR TITLE
Fix ny becoming んy

### DIFF
--- a/ext/js/language/ja/japanese-wanakana.js
+++ b/ext/js/language/ja/japanese-wanakana.js
@@ -47,7 +47,7 @@ export function convertToKanaIME(text, selectionStart) {
     // Examples (`|` shall be the user's text cursor):
     // `たn|` does not convert to `たん|`. The `n` should be hidden from the converter and `た` should only be sent.
     // `n|の` also does not convert to `ん|の`. Even though the cursor is not at the end of the line, the `n` should still be hidden since it is directly behind the user's text cursor.
-    // `ny|` does not convert to `んy|`. The cursor must be hidden since the user may be trying to type something starting with `ny` such as `nya`.
+    // `ny|` does not convert to `んy|`. The `ny` must be hidden since the user may be trying to type something starting with `ny` such as `nya`.
     // `たnt|` does convert to `たんt|`. The user's text cursor is one character ahead of the `n` so it does not need to be hidden and can be converted.
     // `nとあ|` also converts to `んとあ|` The user's text cursor is two characters away from the `n`.
     // `なno|` will still convert to `なの` instead of `なんお` without issue since the `no` -> `の` conversion will be found before `n` -> `ん` and `o` -> `お`.

--- a/ext/js/language/ja/japanese-wanakana.js
+++ b/ext/js/language/ja/japanese-wanakana.js
@@ -43,9 +43,11 @@ export function convertToKanaIME(text, selectionStart) {
     // If the user starts typing a single `n`, hide it from the converter. (This only applies when using the converter as an IME)
     // The converter must only allow the n to become ん when the user's text cursor is at least one character ahead of it.
     // If `n` occurs directly behind the user's text cursor, it should be hidden from the converter.
+    // If `ny` occurs directly behind the user's text cursor, it must also be hidden from the converter as the user may be trying to type `nya` `nyi` `nyu` `nye` `nyo`.
     // Examples (`|` shall be the user's text cursor):
     // `たn|` does not convert to `たん|`. The `n` should be hidden from the converter and `た` should only be sent.
     // `n|の` also does not convert to `ん|の`. Even though the cursor is not at the end of the line, the `n` should still be hidden since it is directly behind the user's text cursor.
+    // `ny|` does not convert to `んy|`. The cursor must be hidden since the user may be trying to type something starting with `ny` such as `nya`.
     // `たnt|` does convert to `たんt|`. The user's text cursor is one character ahead of the `n` so it does not need to be hidden and can be converted.
     // `nとあ|` also converts to `んとあ|` The user's text cursor is two characters away from the `n`.
     // `なno|` will still convert to `なの` instead of `なんお` without issue since the `no` -> `の` conversion will be found before `n` -> `ん` and `o` -> `お`.
@@ -55,6 +57,10 @@ export function convertToKanaIME(text, selectionStart) {
         const beforeN = text.slice(0, prevSelectionStart - 1);
         const afterN = text.slice(prevSelectionStart);
         kanaString = convertToKana(beforeN) + 'n' + convertToKana(afterN);
+    } else if (text.slice(prevSelectionStart - 2, prevSelectionStart) === 'ny') {
+        const beforeN = text.slice(0, prevSelectionStart - 2);
+        const afterN = text.slice(prevSelectionStart);
+        kanaString = convertToKana(beforeN) + 'ny' + convertToKana(afterN);
     } else {
         kanaString = convertToKana(text);
     }

--- a/test/japanese-util.test.js
+++ b/test/japanese-util.test.js
@@ -173,7 +173,7 @@ describe('Japanese utility functions', () => {
             [['nnn', 3], {kanaString: 'んn', newSelectionStart: 2}], // nnn| -> んn|
             [['nnnnano', 7], {kanaString: 'んんあの', newSelectionStart: 4}], // nnnnano| -> んんあの|
             [['ny', 2], {kanaString: 'ny', newSelectionStart: 2}], // ny| -> ny|
-            [['nya', 3], {kanaString: 'にゃ', newSelectionStart: 2}], // ny| -> ny|
+            [['nya', 3], {kanaString: 'にゃ', newSelectionStart: 2}], // nya| -> にゃ|
         ];
 
         test.each(data)('%s -> %o', (dataValue, expected) => {

--- a/test/japanese-util.test.js
+++ b/test/japanese-util.test.js
@@ -172,6 +172,8 @@ describe('Japanese utility functions', () => {
             [['ttttttttttsu', 12], {kanaString: 'っっっっっっっっっつ', newSelectionStart: 10}], // ttttttttttsu| -> っっっっっっっっっつ|
             [['nnn', 3], {kanaString: 'んn', newSelectionStart: 2}], // nnn| -> んn|
             [['nnnnano', 7], {kanaString: 'んんあの', newSelectionStart: 4}], // nnnnano| -> んんあの|
+            [['ny', 2], {kanaString: 'ny', newSelectionStart: 2}], // ny| -> ny|
+            [['nya', 3], {kanaString: 'にゃ', newSelectionStart: 2}], // ny| -> ny|
         ];
 
         test.each(data)('%s -> %o', (dataValue, expected) => {


### PR DESCRIPTION
nya nyu nyo would become んや んゆ んよ from missing handling of the single `n` case with `ny`.