### PR TITLE
Update search query text when searching and set cursor to end of line

### DIFF
--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -20,7 +20,7 @@ import {ClipboardMonitor} from '../comm/clipboard-monitor.js';
 import {createApiMap, invokeApiMapHandler} from '../core/api-map.js';
 import {EventListenerCollection} from '../core/event-listener-collection.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
-import {convertToKanaIME} from '../language/ja/japanese-wanakana.js';
+import {convertToKana, convertToKanaIME} from '../language/ja/japanese-wanakana.js';
 
 export class SearchDisplayController {
     /**
@@ -597,6 +597,8 @@ export class SearchDisplayController {
      * @param {?import('settings').OptionsContextFlag[]} flags
      */
     _search(animate, historyMode, lookup, flags) {
+        this._updateSearchText();
+
         const query = this._queryInput.value;
         const depth = this._display.depth;
         const url = window.location.href;
@@ -650,6 +652,15 @@ export class SearchDisplayController {
                 searchButton.style.height = `${scrollHeight}px`;
             }
         }
+    }
+
+    /** */
+    _updateSearchText() {
+        if (this._wanakanaEnabled) {
+            // don't use convertToKanaIME since user searching has finalized the text and is no longer composing
+            this._queryInput.value = convertToKana(this._queryInput.value);
+        }
+        this._queryInput.setSelectionRange(this._queryInput.value.length, this._queryInput.value.length);
     }
 
     /**


### PR DESCRIPTION
It's a bit strange to type something ending in `ん` with a single `n` on the end and then see the search happen but `n` doesn't become `ん`. This doesn't matter for strictly usability (Yomitan searches the `ん` anyways) but it feels weird. The user searching can be taken similarly to the user acknowledging that composing is finished and converting everything should be fine.

With this change for example typing `どn` and searching will make it automatically become `どん` in the search bar.

Clicking in the middle of the search text, searching, then hitting backspace or typing and having the text cursor end up back where you clicked before your searched is also weird. And especially annoying when trying to quickly wipe the search box (ctrl + shift + backspace).