### PR TITLE
Check for wanakanaEnabled on search page before applying kana conversion

### DIFF
--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -251,7 +251,9 @@ export class SearchDisplayController {
         this._updateSearchHeight(true);
 
         const element = /** @type {HTMLTextAreaElement} */ (e.currentTarget);
-        this._searchTextKanaConversion(element, e);
+        if (this._wanakanaEnabled) {
+            this._searchTextKanaConversion(element, e);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes all languages getting Japanese IME text substitutions instead of just Japanese on search page.

Regression introduced in #1875