### PR TITLE
Sort dictionaries by drag and drop v2

### DIFF
--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -2317,26 +2317,43 @@ button.hotkey-list-item-enabled-button[data-scope-count='0'] {
 /* Dictionary settings */
 .dictionary-list {
     width: 100%;
-    display: grid;
     grid-template-columns: auto auto 1fr auto auto auto;
     grid-template-rows: auto;
-    place-items: center start;
-    margin-top: 0.5em;
+    display: flex;
+    flex-direction: column;
 }
+
 .dictionary-list-index {
-    margin-right: 0.5em;
+    margin-right: var(--dictionary-item-index-margin);
 }
-.dictionary-list[data-count='0']>.dictionary-item-top {
-    display: none;
-}
+
 .dictionary-item-button-height {
     height: var(--icon-button-size);
 }
+
+.dictionary-item.top {
+    color: var(--text-color-light2);
+    padding-left: calc(var(--dictionary-item-index-width) + var(--dictionary-item-index-margin));
+}
+
+.dictionary-item .generic-list-index-prefix::after {
+    display: block;
+    flex-flow: row nowrap;
+    width: var(--dictionary-item-index-width);
+}
+
+.dictionary-list-header {
+    display: flex;
+    margin-left: 25px;
+}
+
 .dictionary-item {
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
     border-top: var(--thin-border-size) solid var(--separator-color2);
+    --dictionary-item-index-margin: 0.5em;
+    --dictionary-item-index-width: 1.2em;
 }
 .dictionary-item-enabled-toggle-container {
     margin-right: 0.5em;

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -47,12 +47,11 @@
             </div>
             <div id="dictionary-error" class="danger-text margin-above" hidden></div>
             <div id="dictionary-list" class="dictionary-list generic-list" data-count="0">
-                <div class="dictionary-item-top"></div>
-                <label class="dictionary-item-top toggle dictionary-item-enabled-toggle-container"><input type="checkbox" id="all-dictionaries-enabled"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
-                <div class="dictionary-item-top dictionary-item-title-container">All</div>
-                <div class="dictionary-item-top dictionary-item-button-height"></div>
-                <div class="dictionary-item-top dictionary-item-button-height"></div>
-                <div class="dictionary-item-top dictionary-item-button-height"></div>
+                <div class="dictionary-list-header">
+                    <div class="dictionary-item-top"></div>
+                    <label class="dictionary-item-top toggle dictionary-item-enabled-toggle-container"><input type="checkbox" id="all-dictionaries-enabled"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                    <div class="dictionary-item-top dictionary-item-title-container">All</div>
+                </div>
             </div>
 
             <div hidden><input type="file" id="dictionary-import-file-input" accept=".zip,application/zip" multiple></div>

--- a/ext/templates-settings.html
+++ b/ext/templates-settings.html
@@ -48,28 +48,30 @@
 
 <!-- Dictionary -->
 <template id="dictionary-template">
-    <div class="dictionary-list-index generic-list-index-prefix"></div>
-    <label class="toggle dictionary-item-enabled-toggle-container"><input type="checkbox" class="dictionary-enabled"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
-    <div class="dictionary-item-title-container">
+    <div class="dictionary-item" draggable="true">
+        <div class="dictionary-list-index generic-list-index-prefix"></div>
+        <label class="toggle dictionary-item-enabled-toggle-container"><input type="checkbox" class="dictionary-enabled"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+        <div class="dictionary-item-title-container">
         <span>
             <strong class="dictionary-title dictionary-alias"></strong> <span class="light dictionary-revision"></span>
         </span>
-        <button type="button" class="dictionary-outdated-button" hidden>
-            <div class="badge warning-badge"><span class="icon" data-icon="exclamation-point-short"></span></div>
-        </button>
-        <button type="button" class="dictionary-integrity-button-check" hidden>
-            <div class="badge info-badge badge-small-icon"><span class="icon" data-icon="checkmark"></span></div>
-        </button>
-        <button type="button" class="dictionary-integrity-button-warning" hidden>
-            <div class="badge warning-badge"><span class="icon" data-icon="exclamation-point-short"></span></div>
-        </button>
-        <button type="button" class="dictionary-update-available" hidden>
-            <div class="badge info-badge badge-small-icon"><span class="icon" data-icon="exclamation-point-short" title="Update available"></span></div>
-        </button>
+            <button type="button" class="dictionary-outdated-button" hidden>
+                <div class="badge warning-badge"><span class="icon" data-icon="exclamation-point-short"></span></div>
+            </button>
+            <button type="button" class="dictionary-integrity-button-check" hidden>
+                <div class="badge info-badge badge-small-icon"><span class="icon" data-icon="checkmark"></span></div>
+            </button>
+            <button type="button" class="dictionary-integrity-button-warning" hidden>
+                <div class="badge warning-badge"><span class="icon" data-icon="exclamation-point-short"></span></div>
+            </button>
+            <button type="button" class="dictionary-update-available" hidden>
+                <div class="badge info-badge badge-small-icon"><span class="icon" data-icon="exclamation-point-short" title="Update available"></span></div>
+            </button>
+        </div>
+        <button type="button" class="icon-button" id="dictionary-move-up" data-menu-action="moveUp"><span class="icon-button-inner"><span class="icon" data-icon="up-chevron"></span></span></button>
+        <button type="button" class="icon-button" id="dictionary-move-down" data-menu-action="moveDown"><span class="icon-button-inner"><span class="icon" data-icon="down-chevron"></span></span></button>
+        <button type="button" class="icon-button dictionary-menu-button" data-menu="dictionary-menu" data-menu-position="below left"><span class="icon-button-inner"><span class="icon" data-icon="kebab-menu"></span></span></button>
     </div>
-    <button type="button" class="icon-button" id="dictionary-move-up" data-menu-action="moveUp"><span class="icon-button-inner"><span class="icon" data-icon="up-chevron"></span></span></button>
-    <button type="button" class="icon-button" id="dictionary-move-down" data-menu-action="moveDown"><span class="icon-button-inner"><span class="icon" data-icon="down-chevron"></span></span></button>
-    <button type="button" class="icon-button dictionary-menu-button" data-menu="dictionary-menu" data-menu-position="below left"><span class="icon-button-inner"><span class="icon" data-icon="kebab-menu"></span></span></button>
 </template>
 <template id="dictionary-details-entry-template"><div class="dictionary-details-entry">
     <span class="dictionary-details-entry-label"></span>


### PR DESCRIPTION
Mentioned this in the commits. But this is work to allow users to short their dictionaries using drag and drop. Th

Based on the [ nature of dragover](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dragover_event) we can't really stop it from firing while in a valid drop area. So the second best thing is using the ``preventDefault()`` function in the ``dragover`` handler and putting most of the logic on the drop which will happen once. That should be more efficient. 

is is my first contribution so any feedback would be helpful. I typically use React and typescript so the OOP coding paradigm took some adjustment.