### PR TITLE
Add foosoft ankiconnect repo to lycheeignore

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -12,3 +12,4 @@
 ^https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings$
 ^https://pixabay.com/sound-effects/error-8-206492/$
 ^https://pixabay.com/service/license-summary/$
+^https://foosoft.net/projects/anki-connect/


### PR DESCRIPTION
Foosoft has implemented [go-away](https://git.gammaspectra.live/git/go-away) to the anki-connect repo. Lychee seems to get flagged by this and always fail.