### PR TITLE
Remove ending slash from ankiconnect ignore

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -12,4 +12,4 @@
 ^https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings$
 ^https://pixabay.com/sound-effects/error-8-206492/$
 ^https://pixabay.com/service/license-summary/$
-^https://foosoft.net/projects/anki-connect/
+^https://foosoft.net/projects/anki-connect


### PR DESCRIPTION
It is linked without the slash somewhere so link checker is still breaking. (Followup to #1972)