### PR TITLE
Add option to reset settings of individual profiles

### DIFF
--- a/ext/js/pages/settings/profile-controller.js
+++ b/ext/js/pages/settings/profile-controller.js
@@ -42,9 +42,13 @@ export class ProfileController {
         /** @type {HTMLSelectElement} */
         this._profileCopySourceSelect = querySelectorNotNull(document, '#profile-copy-source-select');
         /** @type {HTMLElement} */
+        this._resetProfileNameElement = querySelectorNotNull(document, '#profile-reset-name');
+        /** @type {HTMLElement} */
         this._removeProfileNameElement = querySelectorNotNull(document, '#profile-remove-name');
         /** @type {HTMLButtonElement} */
         this._profileAddButton = querySelectorNotNull(document, '#profile-add-button');
+        /** @type {HTMLButtonElement} */
+        this._profileResetConfirmButton = querySelectorNotNull(document, '#profile-reset-confirm-button');
         /** @type {HTMLButtonElement} */
         this._profileRemoveConfirmButton = querySelectorNotNull(document, '#profile-remove-confirm-button');
         /** @type {HTMLButtonElement} */
@@ -84,6 +88,7 @@ export class ProfileController {
         const {platform: {os}} = await this._settingsController.application.api.getEnvironmentInfo();
         this._profileConditionsUI.os = os;
 
+        this._profileResetModal = this._modalController.getModal('profile-reset');
         this._profileRemoveModal = this._modalController.getModal('profile-remove');
         this._profileCopyModal = this._modalController.getModal('profile-copy');
         this._profileConditionsModal = this._modalController.getModal('profile-conditions');
@@ -93,6 +98,7 @@ export class ProfileController {
         if (this._profileActiveSelect !== null) { this._profileActiveSelect.addEventListener('change', this._onProfileActiveChange.bind(this), false); }
         if (this._profileTargetSelect !== null) { this._profileTargetSelect.addEventListener('change', this._onProfileTargetChange.bind(this), false); }
         if (this._profileAddButton !== null) { this._profileAddButton.addEventListener('click', this._onAdd.bind(this), false); }
+        if (this._profileResetConfirmButton !== null) { this._profileResetConfirmButton.addEventListener('click', this._onResetConfirm.bind(this), false); }
         if (this._profileRemoveConfirmButton !== null) { this._profileRemoveConfirmButton.addEventListener('click', this._onDeleteConfirm.bind(this), false); }
         if (this._profileCopyConfirmButton !== null) { this._profileCopyConfirmButton.addEventListener('click', this._onCopyConfirm.bind(this), false); }
 
@@ -205,6 +211,26 @@ export class ProfileController {
 
         // Update profile index
         this._settingsController.profileIndex = index;
+    }
+
+    /**
+     * @param {number} profileIndex
+     */
+    async resetProfile(profileIndex) {
+        const profile = this._getProfile(profileIndex);
+        if (profile === null) { return; }
+
+        const defaultOptions = await this._settingsController.getDefaultOptions();
+        const defaultProfileOptions = defaultOptions.profiles[0];
+        defaultProfileOptions.name = profile.name;
+
+        await this._settingsController.modifyGlobalSettings([{
+            action: 'set',
+            path: `profiles[${profileIndex}]`,
+            value: defaultProfileOptions,
+        }]);
+
+        await this._settingsController.refresh();
     }
 
     /**
@@ -330,6 +356,18 @@ export class ProfileController {
     /**
      * @param {number} profileIndex
      */
+    openResetProfileModal(profileIndex) {
+        const profile = this._getProfile(profileIndex);
+        if (profile === null || this.profileCount <= 1) { return; }
+
+        /** @type {HTMLElement} */ (this._resetProfileNameElement).textContent = profile.name;
+        /** @type {import('./modal.js').Modal} */ (this._profileResetModal).node.dataset.profileIndex = `${profileIndex}`;
+        /** @type {import('./modal.js').Modal} */ (this._profileResetModal).setVisible(true);
+    }
+
+    /**
+     * @param {number} profileIndex
+     */
     openDeleteProfileModal(profileIndex) {
         const profile = this._getProfile(profileIndex);
         if (profile === null || this.profileCount <= 1) { return; }
@@ -444,6 +482,20 @@ export class ProfileController {
     /** */
     _onAdd() {
         void this.duplicateProfile(this._settingsController.profileIndex);
+    }
+
+    /** */
+    _onResetConfirm() {
+        const modal = /** @type {import('./modal.js').Modal} */ (this._profileResetModal);
+        modal.setVisible(false);
+        const {node} = modal;
+        const profileIndex = node.dataset.profileIndex;
+        delete node.dataset.profileIndex;
+
+        const validProfileIndex = this._tryGetValidProfileIndex(profileIndex);
+        if (validProfileIndex === null) { return; }
+
+        void this.resetProfile(validProfileIndex);
     }
 
     /** */
@@ -789,6 +841,9 @@ class ProfileEntry {
                 break;
             case 'duplicate':
                 void this._profileController.duplicateProfile(this._index);
+                break;
+            case 'reset':
+                this._profileController.openResetProfileModal(this._index);
                 break;
             case 'delete':
                 this._profileController.openDeleteProfileModal(this._index);

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -463,6 +463,19 @@
         </div>
     </div></div>
 
+    <div id="profile-reset-modal" class="modal" tabindex="-1" role="dialog" hidden><div class="modal-content modal-content-small">
+        <div class="modal-header"><div class="modal-title">Confirm Profile Reset</div></div>
+        <div class="modal-body">
+            <p>
+                Are you sure you want to reset the profile <em id="profile-reset-name"></em> to default?
+            </p>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="low-emphasis" data-modal-action="hide">Cancel</button>
+            <button type="button" class="danger" id="profile-reset-confirm-button">Reset Profile</button>
+        </div>
+    </div></div>
+
     <div id="profile-remove-modal" class="modal" tabindex="-1" role="dialog" hidden><div class="modal-content modal-content-small">
         <div class="modal-header"><div class="modal-title">Confirm Profile Deletion</div></div>
         <div class="modal-body">

--- a/ext/templates-settings.html
+++ b/ext/templates-settings.html
@@ -38,6 +38,7 @@
     <button type="button" class="popup-menu-item" data-menu-action="copyFrom">Copy from&hellip;</button>
     <button type="button" class="popup-menu-item" data-menu-action="editConditions">Edit conditions&hellip;</button>
     <button type="button" class="popup-menu-item" data-menu-action="duplicate">Duplicate</button>
+    <button type="button" class="popup-menu-item" data-menu-action="reset">Reset to Default</button>
     <button type="button" class="popup-menu-item" data-menu-action="delete">Delete</button>
 </div></div></div></template>
 <template id="profile-condition-menu-template"><div class="popup-menu-container" tabindex="-1" role="dialog"><div class="popup-menu"><div class="popup-menu-body">


### PR DESCRIPTION
Since adding profiles clones the settings of an existing profile, there's no reasonable way for a user to create a default profile or get one back to default without resetting all of their settings.