### PR TITLE
Return array filled with false in canAddNotes if Anki is disabled

### DIFF
--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -163,7 +163,7 @@ export class AnkiConnect {
      * @returns {Promise<boolean[]>}
      */
     async canAddNotes(notes) {
-        if (!this._enabled) { return []; }
+        if (!this._enabled) { return new Array(notes.length).fill(false); }
         await this._checkVersion();
         const result = await this._invoke('canAddNotes', {notes});
         return this._normalizeArray(result, notes.length, 'boolean');


### PR DESCRIPTION
In some areas we rely on this array to be the correct size. This can cause weird errors when a user is enabling or disabling Anki. It makes sense to say that notes cannot be added (false) if Anki is disabled when this gets called.