### PR TITLE
Allow selecting different flashcard formats in note generator

### DIFF
--- a/ext/js/pages/settings/anki-deck-generator-controller.js
+++ b/ext/js/pages/settings/anki-deck-generator-controller.js
@@ -518,7 +518,7 @@ export class AnkiDeckGeneratorController {
     }
 
     /**
-     * @param {import('dictionary').TermDictionaryEntry} dictionaryEntry
+     * @param {import('dictionary').DictionaryEntry} dictionaryEntry
      * @returns {Array<object>}
      */
     _getDictionaryEntryMedia(dictionaryEntry) {

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -1282,10 +1282,9 @@
             </div>
             <textarea autocomplete="off" spellcheck="false" id="generate-anki-notes-textarea" class="no-wrap margin-above" data-tab-action="indent,4"></textarea>
             <div class="generate-anki-notes-test-container margin-above">
-                <p>
-                    Active Anki deck: <code id="generate-anki-notes-active-deck"></code><br>
-                    Active Anki model: <code id="generate-anki-notes-active-model"></code>
-                </p>
+                <div>Active Anki Flashcard Format: <select id="generate-anki-flashcard-format"></select></div>
+                <div>Active Anki deck: <code id="generate-anki-notes-active-deck"></code></div>
+                <div>Active Anki model: <code id="generate-anki-notes-active-model"></code></div>
                 <div class="generate-anki-notes-test-table margin-above">
                     <div class="generate-anki-notes-test-table-header">Test word</div>
                     <div></div>

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -311,13 +311,15 @@ export type AnkiScreenshotOptions = {
 };
 
 export type AnkiCardFormat = {
-    type: 'kanji' | 'term';
+    type: AnkiCardFormatType;
     name: string;
     deck: string;
     model: string;
     fields: AnkiFields;
     icon: AddNoteIcon;
 };
+
+export type AnkiCardFormatType = 'kanji' | 'term';
 
 export type AddNoteIcon = 'big-circle' | 'small-circle' | 'big-square' | 'big-diamond';
 


### PR DESCRIPTION
This was overlooked in #1930.

Adds support for kanji formats in note generator as well.