### PR TITLE
Set duplicateBehavior default to `new`

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -1070,7 +1070,7 @@
                                     "duplicateBehavior": {
                                         "type": "string",
                                         "enum": ["prevent", "overwrite", "new"],
-                                        "default": "prevent"
+                                        "default": "new"
                                     },
                                     "fieldTemplates": {
                                         "type": ["string", "null"],

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -78,7 +78,7 @@ export class DisplayAnki {
         /** @type {boolean} */
         this._duplicateScopeCheckAllModels = false;
         /** @type {import('settings').AnkiDuplicateBehavior} */
-        this._duplicateBehavior = 'prevent';
+        this._duplicateBehavior = 'new';
         /** @type {import('settings').AnkiScreenshotFormat} */
         this._screenshotFormat = 'png';
         /** @type {number} */


### PR DESCRIPTION
It has been accidentally defaulting to `new` for quite awhile now and there have also been many users recently that have had issues due to this defaulting to `prevent` (a recent fix caused the default to actually apply properly).