### PR TITLE
Add Hawaiian language support

### DIFF
--- a/ext/js/language/language-descriptors.js
+++ b/ext/js/language/language-descriptors.js
@@ -225,6 +225,14 @@ const languageDescriptors = [
         languageTransforms: ancientGreekTransforms,
     },
     {
+        // no 2 letter iso for hawaiian
+        iso: 'haw',
+        iso639_3: 'haw',
+        name: 'Hawaiian',
+        exampleText: 'heluhelu',
+        textPreprocessors: capitalizationPreprocessors,
+    },
+    {
         iso: 'he',
         iso639_3: 'heb',
         name: 'Hebrew',

--- a/types/ext/language-descriptors.d.ts
+++ b/types/ext/language-descriptors.d.ts
@@ -144,6 +144,9 @@ type AllTextProcessors = {
             convertLatinToGreek: TextProcessor<boolean>;
         };
     };
+    haw: {
+        pre: CapitalizationPreprocessors;
+    };
     he: Record<string, never>;
     hi: Record<string, never>;
     hu: {


### PR DESCRIPTION
The Hawaiian language generally the Latin alphabet with some other symbols like the Okina `ʻ` symbol.

I presume because it uses capitalisation, and that the dictionary forms also include Okina and the symbols that means there does not need to be much processing. I hope so, I will test the edge cases after it's merged in.

Basically, I presume Yomitan works by looking up text in the dictionary and displays it if it exists. Please correct me if I am wrong and if I need to write some sort of custom parser. 

So instead of going "Oh, this is English text, let's look it up in the dictionary" I am presuming Yomitan will look up anything it hovers over in the dictionary, and if it matches it will display it regardless of alphabet.

Example text:

```
ʻōlelo
```

Please note Hawaiian only has a 3 letter ISO code.

There is no preprocessing support yet, this is just an initial PR to enable basic functionality.