### PR TITLE
Add Bulgarian language support

### DIFF
--- a/ext/js/language/language-descriptors.js
+++ b/ext/js/language/language-descriptors.js
@@ -113,6 +113,13 @@ const languageDescriptors = [
         languageTransforms: arabicTransforms,
     },
     {
+        iso: 'bg',
+        iso639_3: 'bul',
+        name: 'Bulgarian',
+        exampleText: 'чета',
+        textPreprocessors: capitalizationPreprocessors,
+    },
+    {
         iso: 'cs',
         iso639_3: 'ces',
         name: 'Czech',

--- a/types/ext/language-descriptors.d.ts
+++ b/types/ext/language-descriptors.d.ts
@@ -97,6 +97,9 @@ type AllTextProcessors = {
             convertHaToTaMarbuta: TextProcessor<boolean>;
         };
     };
+    bg: {
+        pre: CapitalizationPreprocessors;
+    };
     cs: {
         pre: CapitalizationPreprocessors;
     };


### PR DESCRIPTION
Add basic support for the Bulgarian language. No transforms, just the capitalization preprocessor since it uses the cyrillic alphabet.