### PR TITLE
Fix disabled scanning on search page not disabling for touch

### DIFF
--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -2027,7 +2027,7 @@ export class Display extends EventDispatcher {
      * @param {import('settings').ProfileOptions} options
      */
     _updateContentTextScanner(options) {
-        if (!options.scanning.enablePopupSearch) {
+        if ((!options.scanning.enablePopupSearch && this._pageType === 'popup') || (!options.scanning.enableOnSearchPage && this._pageType === 'search')) {
             if (this._contentTextScanner !== null) {
                 this._contentTextScanner.setEnabled(false);
                 this._contentTextScanner.clearSelection();

--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -119,7 +119,7 @@ export class QueryParser extends EventDispatcher {
             this._textScanner.language = language;
             this._textScanner.setOptions(scanning);
         }
-        this._textScanner.setEnabled(true);
+
         if (selectedParserChanged && this._parseResults.length > 0) {
             this._renderParseResult();
         }

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -1098,7 +1098,7 @@ export class TextScanner extends EventDispatcher {
 
         eventListenerInfos.push(this._getSelectionChangeCheckUserSelectionListener());
 
-        for (const [...args] of eventListenerInfos) {
+        for (const args of eventListenerInfos) {
             this._eventListeners.addEventListener(...args);
         }
     }


### PR DESCRIPTION
1. `options.scanning.enableOnSearchPage` was never properly checked for. It was checked for in `_updateNestedFrontend` but the disable is promptly overwritten.

2. `query-parser.js` `setOptions` calls `this._textScanner.setEnabled(true);` right before it is also called by its parent `display.js` `_updateContentTextScanner`. The value it sets is also immediately overwritten.

    This is the only time that function is ever called, limiting its use solely to confuse me in figuring out this bug. So I've removed it.

3. Who in the world wrote this: `[...args]`.