### PR TITLE
Never take up 3 rows when wrapping search header items on small screens

### DIFF
--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -195,18 +195,16 @@ h1 {
 }
 #search-settings-button {
     margin-right: 0;
+    float: right;
 }
-.search-options-left {
-    display: flex;
-    flex-flow: row wrap;
-    align-items: center;
+.search-options-right {
+    flex: 1;
 }
 .search-options {
     display: flex;
     flex-flow: row wrap;
     margin: 0.5em 0 0 0;
     align-items: center;
-    justify-content: space-between;
 }
 .search-option {
     flex: 0 1 auto;

--- a/ext/search.html
+++ b/ext/search.html
@@ -34,18 +34,18 @@
 
                         <div class="scan-disable">
                             <div class="search-options">
-                                <div class="search-options-left">
-                                    <div class="search-option" id="search-option-profile-select">
-                                        <span class="profile-select-container"><select class="profile-select" id="profile-select">
-                                            <optgroup label="Default Profile" id="profile-select-option-group"></optgroup>
-                                        </select></span>
-                                    </div>
-                                    <label class="search-option" id="search-option-clipboard-monitor-container">
-                                        <label class="toggle"><input type="checkbox" id="clipboard-monitor-enable"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
-                                        <span class="search-option-label">Clipboard monitor</span>
-                                    </label>
+                                <div class="search-option" id="search-option-profile-select">
+                                    <span class="profile-select-container"><select class="profile-select" id="profile-select">
+                                        <optgroup label="Default Profile" id="profile-select-option-group"></optgroup>
+                                    </select></span>
                                 </div>
-                                <div class="search-option" id="search-settings-button" data-modal-action="show,search-settings"><span class="icon" data-icon="cog"></span></div>
+                                <label class="search-option" id="search-option-clipboard-monitor-container">
+                                    <label class="toggle"><input type="checkbox" id="clipboard-monitor-enable"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                                    <span class="search-option-label">Clipboard monitor</span>
+                                </label>
+                                <div class="search-options-right">
+                                    <div class="search-option" id="search-settings-button" data-modal-action="show,search-settings"><span class="icon" data-icon="cog"></span></div>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/d5c9e17f-20f9-4f8f-a67c-e3c499a85b03) | ![after](https://github.com/user-attachments/assets/39c78f3f-c92a-4efd-ac79-3b247afa75cd) |
| ![before_full](https://github.com/user-attachments/assets/c6e14fb7-95d6-46a9-98c5-a971a95f3294) | ![after_full](https://github.com/user-attachments/assets/2c7d10b5-8044-4efe-a183-75ef52ef5363) |

(full size has no change)