### PR TITLE
Fix `scan-disable` being bypassed for some elements

### DIFF
--- a/ext/js/dom/text-source-element.js
+++ b/ext/js/dom/text-source-element.js
@@ -69,6 +69,14 @@ export class TextSourceElement {
     }
 
     /**
+     * The string representing the element's constrained text value.
+     * @type {string}
+     */
+    get content() {
+        return this._content;
+    }
+
+    /**
      * The text start offset position within the full content.
      * @type {number}
      */

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -505,7 +505,7 @@ export class TextScanner extends EventDispatcher {
             const result = await this._findDictionaryEntries(textSource, searchTerms, searchKanji, optionsContext);
             if (result !== null) {
                 ({dictionaryEntries, sentence, type} = result);
-            } else if (showEmpty || (textSource !== null && isAltText && await this._isTextLookupWorthy(textSource.fullContent))) {
+            } else if (showEmpty || (textSource !== null && isAltText && await this._isTextLookupWorthy(textSource.content))) {
                 // Shows a "No results found" message
                 dictionaryEntries = [];
                 sentence = {text: '', offset: 0};


### PR DESCRIPTION
Somewhat fixes #1946

The `scan-disable` class or any other classes that get tossed into the excludes at some point cause `content` to shrink when running `_constrainTextSource` over them. But `fullContent` does not shrink. `fullContent` cannot be used in the `this._isTextLookupWorthy` check to determine whether to show an empty popup.