### PR TITLE
Better bad transaction error and auto reset database from unrecoverable state

### DIFF
--- a/ext/js/data/database.js
+++ b/ext/js/data/database.js
@@ -91,7 +91,11 @@ export class Database {
         if (this._db === null) {
             throw new Error(this._isOpening ? 'Database not ready' : 'Database not open');
         }
-        return this._db.transaction(storeNames, mode);
+        try {
+            return this._db.transaction(storeNames, mode);
+        } catch (e) {
+            throw new Error(toError(e).message + '\nDatabase transaction error, you may need to Delete All dictionaries to reset the database or manually delete the Indexed DB database.');
+        }
     }
 
     /**

--- a/ext/js/data/database.js
+++ b/ext/js/data/database.js
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import {toError} from '../core/to-error.js';
+
 /**
  * @template {string} TObjectStoreName
  */
@@ -47,6 +49,12 @@ export class Database {
                     this._upgrade(db, transaction, oldVersion, structure);
                 }
             });
+            if (this._db.objectStoreNames.length === 0) {
+                this.close();
+                await Database.deleteDatabase(databaseName);
+                this._isOpening = false;
+                await this.open(databaseName, version, structure);
+            }
         } finally {
             this._isOpening = false;
         }


### PR DESCRIPTION
Addresses https://github.com/yomidevs/yomitan/issues/1847#issuecomment-2924122150

If the database gets into a state where there are no object stores, there is also no data present and it is safe to delete the database to recover. It may not be safe to delete the database in other situations, so the user will be presented with a more descriptive error instead if it hits a transaction failure.

Transaction failures seem to be almost always caused by a missing object store and would be an unrecoverable state even if only a single one is missing but there is no evidence of such cases occurring and I currently do not like the idea of potentially bulldozing user data for recovery. In a database corruption with missing object stores it is still technically possible for the user to manually extract some amount of data even if only one object store is present.

It is not possible to repair the database on Yomitan's end after losing some or all of the object stores without pushing a version change which are meant to be for schema updates and it is probably not a good idea to throw them around arbitrarily as it could cause the database to be unopenable or impossible to update in the future if the version number is something unexpected.

https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/createObjectStore

To intentionally create a broken database with missing object stores, throw an error right after opening the database here: https://github.com/yomidevs/yomitan/blob/605f70fcb4e32cfdaacfac5cc962aef4fccfdb91/ext/js/data/database.js#L332
For example:
```js
const request = indexedDB.open(name, version);
throw new Error('break the thing');
```