### PR TITLE
Throw better error when dictionary index is present in nested directories instead of archive root

### DIFF
--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -37,6 +37,8 @@ const TextWriter = /** @type {typeof import('@zip.js/zip.js').TextWriter} */ (/*
 const Uint8ArrayReader = /** @type {typeof import('@zip.js/zip.js').Uint8ArrayReader} */ (/** @type {unknown} */ (Uint8ArrayReader0));
 const ZipReader = /** @type {typeof import('@zip.js/zip.js').ZipReader} */ (/** @type {unknown} */ (ZipReader0));
 
+const INDEX_FILE_NAME = 'index.json';
+
 export class DictionaryImporter {
     /**
      * @param {import('dictionary-importer-media-loader').GenericMediaLoader} mediaLoader
@@ -244,13 +246,32 @@ export class DictionaryImporter {
 
     /**
      * @param {import('dictionary-importer').ArchiveFileMap} fileMap
+     * @returns {?string}
+     */
+    _findRedundantDirectories(fileMap) {
+        let indexPath = '';
+        for (const file of fileMap) {
+            if (file[0].replace(/.*\//, '') === INDEX_FILE_NAME) {
+                indexPath = file[0];
+            }
+        }
+        const redundantDirectoriesRegex = new RegExp(`.*(?=${INDEX_FILE_NAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`);
+        const redundantDirectories = indexPath.match(redundantDirectoriesRegex);
+        return redundantDirectories ? redundantDirectories[0] : null;
+    }
+
+    /**
+     * @param {import('dictionary-importer').ArchiveFileMap} fileMap
      * @returns {Promise<import('dictionary-data').Index>}
      * @throws {Error}
      */
     async _readAndValidateIndex(fileMap) {
-        const indexFileName = 'index.json';
-        const indexFile = fileMap.get(indexFileName);
+        const indexFile = fileMap.get(INDEX_FILE_NAME);
         if (typeof indexFile === 'undefined') {
+            const redundantDirectories = this._findRedundantDirectories(fileMap);
+            if (redundantDirectories) {
+                throw new Error('Dictionary index found nested in redundant directories: "' + redundantDirectories + '" when it must be in the archive\'s root directory');
+            }
             throw new Error('No dictionary index found in archive');
         }
         const indexFile2 = /** @type {import('@zip.js/zip.js').Entry} */ (indexFile);
@@ -259,7 +280,7 @@ export class DictionaryImporter {
         const index = /** @type {unknown} */ (parseJson(indexContent));
 
         if (!ajvSchemas.dictionaryIndex(index)) {
-            throw this._formatAjvSchemaError(ajvSchemas.dictionaryIndex, indexFileName);
+            throw this._formatAjvSchemaError(ajvSchemas.dictionaryIndex, INDEX_FILE_NAME);
         }
 
         const validIndex = /** @type {import('dictionary-data').Index} */ (index);


### PR DESCRIPTION
Adding a better error here instead of just internally removing the nested directory paths since other programs that support Yomitan dicts wont necessarily support handling this nesting. It's better to not create splits in the formatting and potentially end up with people passing around dicts in otherwise valid Yomitan format that are packaged in an unexpected way.

Note that this does not touch the error for when the `index.json` is actually missing. And the directories check only runs if the `index.json` is not found.