### PR TITLE
Add toggle for `<all_urls>` on permissions page

### DIFF
--- a/ext/permissions.html
+++ b/ext/permissions.html
@@ -37,6 +37,9 @@
                     request audio for playback and download, and connect with Anki.
                 </div>
             </div>
+            <div class="settings-item-right">
+                <label class="toggle"><input type="checkbox" class="permissions-origin-toggle" data-origin="&lt;all_urls&gt;"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+            </div>
         </div></div>
         <div class="settings-item"><div class="settings-item-inner">
             <div class="settings-item-left">


### PR DESCRIPTION
Currently there is no way to change this permission besides the welcome page. I assume this wasn't added due to it being tested on chromium which has this permission by default and cannot be enabled/disabled. But on firefox this is a permission that we have to request and it should be included.