### PR TITLE
Update readme package list and remove version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,17 @@ Yomitan uses several third-party libraries to function.
 
 <!-- The following table is generated using the command `npm run license-report:markdown`. -->
 
-| Name                | Installed version | License type | Link                                             |
-| :------------------ | :---------------- | :----------- | :----------------------------------------------- |
-| @zip.js/zip.js      | 2.7.32            | BSD-3-Clause | git+https://github.com/gildas-lormeau/zip.js.git |
-| dexie               | 3.2.4             | Apache-2.0   | git+https://github.com/dfahlander/Dexie.js.git   |
-| dexie-export-import | 4.0.7             | Apache-2.0   | git+https://github.com/dexie/Dexie.js.git        |
-| yomitan-handlebars  | 1.0.0             | MIT          | n/a                                              |
-| parse5              | 7.1.2             | MIT          | git://github.com/inikulin/parse5.git             |
-| hangul.js           | 0.2.6             | MIT          | git+https://github.com/e-/Hangul.js.git          |
+| Name                | License type | Link                                                                   |
+| :------------------ | :----------- | :--------------------------------------------------------------------- |
+| @resvg/resvg-wasm   | MPL-2.0      | git+ssh://git@github.com/yisibl/resvg-js.git                           |
+| @zip.js/zip.js      | BSD-3-Clause | git+https://github.com/gildas-lormeau/zip.js.git                       |
+| dexie               | Apache-2.0   | git+https://github.com/dexie/Dexie.js.git                              |
+| dexie-export-import | Apache-2.0   | git+https://github.com/dexie/Dexie.js.git                              |
+| hangul-js           | MIT          | git://github.com/e-/Hangul.js.git                                      |
+| kanji-processor     | n/a          | https://registry.npmjs.org/kanji-processor/-/kanji-processor-1.0.2.tgz |
+| parse5              | MIT          | git://github.com/inikulin/parse5.git                                   |
+| yomitan-handlebars  | MIT          | n/a                                                                    |
+| linkedom            | ISC          | git+https://github.com/WebReflection/linkedom.git                      |
 
 ## Attribution
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "test:unit:options": "vitest run --config test/data/vitest.options.config.json",
         "test:build": "node ./dev/bin/build.js --dryRun --all",
         "license-report:html": "license-report --output=html --only=prod --fields=name --fields=installedVersion --fields=licenseType --fields=link --html.cssFile=dev/data/legal-npm.css > ext/legal-npm.html",
-        "license-report:markdown": "license-report --output=markdown --only=prod --fields=name --fields=installedVersion --fields=licenseType --fields=link",
+        "license-report:markdown": "license-report --output=markdown --only=prod --fields=name --fields=licenseType --fields=link",
         "prepare": "husky"
     },
     "repository": {


### PR DESCRIPTION
Updating this often gets overlooked and it certainly is not getting updated every time we update dependencies so I've removed the version numbers from this.