### PR TITLE
feat: add Toki Pona dictionaries for multiple languages

### DIFF
--- a/ext/data/recommended-dictionaries.json
+++ b/ext/data/recommended-dictionaries.json
@@ -743,6 +743,104 @@
             }
         ]
     },
+    "tok": {
+        "frequency": [],
+        "grammar": [],
+        "kanji": [],
+        "pronunciation": [],
+        "terms": [
+            {
+                "name": "toki-pona-to-chinese",
+                "description": "Toki Pona to Chinese dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-chinese.zip"
+            },
+            {
+                "name": "toki-pona-to-czech",
+                "description": "Toki Pona to Czech dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-czech.zip"
+            },
+            {
+                "name": "toki-pona-to-dutch",
+                "description": "Toki Pona to Dutch dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-dutch.zip"
+            },
+            {
+                "name": "toki-pona-to-english",
+                "description": "Toki Pona to English dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-english.zip"
+            },
+            {
+                "name": "toki-pona-to-esperanto",
+                "description": "Toki Pona to Esperanto dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-esperanto.zip"
+            },
+            {
+                "name": "toki-pona-to-french",
+                "description": "Toki Pona to French dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-french.zip"
+            },
+            {
+                "name": "toki-pona-to-german",
+                "description": "Toki Pona to German dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-german.zip"
+            },
+            {
+                "name": "toki-pona-to-indonesian",
+                "description": "Toki Pona to Indonesian dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-indonesian.zip"
+            },
+            {
+                "name": "toki-pona-to-italian",
+                "description": "Toki Pona to Italian dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-italian.zip"
+            },
+            {
+                "name": "toki-pona-to-polish",
+                "description": "Toki Pona to Polish dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-polish.zip"
+            },
+            {
+                "name": "toki-pona-to-portuguese",
+                "description": "Toki Pona to Portuguese dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-portuguese.zip"
+            },
+            {
+                "name": "toki-pona-to-russian",
+                "description": "Toki Pona to Russian dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-russian.zip"
+            },
+            {
+                "name": "toki-pona-to-slovak",
+                "description": "Toki Pona to Slovak dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-slovak.zip"
+            },
+            {
+                "name": "toki-pona-to-spanish",
+                "description": "Toki Pona to Spanish dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-spanish.zip"
+            },
+            {
+                "name": "toki-pona-to-turkish",
+                "description": "Toki Pona to Turkish dictionary",
+                "homepage": "https://github.com/bee-san/awesome-toki-pona",
+                "downloadUrl": "https://github.com/bee-san/awesome-toki-pona/releases/download/0.0.1/toki-pona-to-turkish.zip"
+            }
+        ]
+    },
     "zh": {
         "frequency": [],
         "grammar": [],


### PR DESCRIPTION
For Toki Pona there is 140 words in the whole language (it's constructed)

There is 1 and only 1 official dictionary.

There are no opinions on dictionaries, as there is only 1.

For this language, let's add toki pona -> $LANGUAGE in recommended dicts

this means that the user does not have to search for their language. 