### PR TITLE
Fix profile delete causing errors fetching current profile

### DIFF
--- a/ext/js/pages/settings/profile-controller.js
+++ b/ext/js/pages/settings/profile-controller.js
@@ -206,9 +206,6 @@ export class ProfileController {
             deleteCount: 0,
             items: [newProfile],
         }]);
-
-        // Update profile index
-        this._settingsController.profileIndex = index;
     }
 
     /**


### PR DESCRIPTION
Duplicating or adding a new profile does not change the profile to the new profile. It always adds onto the end of the list. It will never need to set the currently active profile index.

Setting the profile here causes a desync of the active profile which causes other functions to request the wrong profile index when trying to get the current profile. Deleting this profile after adding it causes index out of range errors.

Likely missed this when implementing #1983.