### PR TITLE
Prevent api glossary and pitch handlebars generation from breaking

### DIFF
--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -187,7 +187,9 @@ export class YomitanApi {
                         const commonDatas = await this._createCommonDatas(text, dictionaryEntries);
                         // @ts-expect-error - `parseHTML` can return `null` but this input has been validated to not be `null`
                         const domlessDocument = parseHTML('').document;
-                        const ankiTemplateRenderer = new AnkiTemplateRenderer(domlessDocument);
+                        // @ts-expect-error - `parseHTML` can return `null` but this input has been validated to not be `null`
+                        const domlessWindow = parseHTML('').window;
+                        const ankiTemplateRenderer = new AnkiTemplateRenderer(domlessDocument, domlessWindow);
                         await ankiTemplateRenderer.prepare();
                         const templateRenderer = ankiTemplateRenderer.templateRenderer;
 

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -38,7 +38,7 @@ export class DisplayGenerator {
         /** @type {HtmlTemplateCollection} */
         this._templates = new HtmlTemplateCollection();
         /** @type {StructuredContentGenerator} */
-        this._structuredContentGenerator = new StructuredContentGenerator(this._contentManager, document);
+        this._structuredContentGenerator = new StructuredContentGenerator(this._contentManager, document, window);
         /** @type {string} */
         this._language = 'ja';
     }

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -22,7 +22,7 @@ import {getDisambiguations, getGroupedPronunciations, getTermFrequency, groupKan
 import {HtmlTemplateCollection} from '../dom/html-template-collection.js';
 import {distributeFurigana, getKanaMorae, getPitchCategory, isCodePointKanji} from '../language/ja/japanese.js';
 import {getLanguageFromText} from '../language/text-utilities.js';
-import {createPronunciationDownstepPosition, createPronunciationGraph, createPronunciationText} from './pronunciation-generator.js';
+import {PronunciationGenerator} from './pronunciation-generator.js';
 import {StructuredContentGenerator} from './structured-content-generator.js';
 
 export class DisplayGenerator {
@@ -39,6 +39,8 @@ export class DisplayGenerator {
         this._templates = new HtmlTemplateCollection();
         /** @type {StructuredContentGenerator} */
         this._structuredContentGenerator = new StructuredContentGenerator(this._contentManager, document, window);
+        /** @type {PronunciationGenerator} */
+        this._pronunciationGenerator = new PronunciationGenerator(document);
         /** @type {string} */
         this._language = 'ja';
     }
@@ -816,15 +818,15 @@ export class DisplayGenerator {
         this._createPronunciationDisambiguations(n, exclusiveTerms, exclusiveReadings);
 
         n = this._querySelector(node, '.pronunciation-downstep-notation-container');
-        n.appendChild(createPronunciationDownstepPosition(position));
+        n.appendChild(this._pronunciationGenerator.createPronunciationDownstepPosition(position));
 
         n = this._querySelector(node, '.pronunciation-text-container');
 
         n.lang = this._language;
-        n.appendChild(createPronunciationText(morae, position, nasalPositions, devoicePositions));
+        n.appendChild(this._pronunciationGenerator.createPronunciationText(morae, position, nasalPositions, devoicePositions));
 
         n = this._querySelector(node, '.pronunciation-graph-container');
-        n.appendChild(createPronunciationGraph(morae, position));
+        n.appendChild(this._pronunciationGenerator.createPronunciationGraph(morae, position));
 
         return node;
     }

--- a/ext/js/display/pronunciation-generator.js
+++ b/ext/js/display/pronunciation-generator.js
@@ -18,410 +18,422 @@
 
 import {getKanaDiacriticInfo, isMoraPitchHigh} from '../language/ja/japanese.js';
 
-/**
- * @param {string[]} morae
- * @param {number} downstepPosition
- * @param {number[]} nasalPositions
- * @param {number[]} devoicePositions
- * @returns {HTMLSpanElement}
- */
-export function createPronunciationText(morae, downstepPosition, nasalPositions, devoicePositions) {
-    const nasalPositionsSet = nasalPositions.length > 0 ? new Set(nasalPositions) : null;
-    const devoicePositionsSet = devoicePositions.length > 0 ? new Set(devoicePositions) : null;
-    const container = document.createElement('span');
-    container.className = 'pronunciation-text';
-    for (let i = 0, ii = morae.length; i < ii; ++i) {
-        const i1 = i + 1;
-        const mora = morae[i];
-        const highPitch = isMoraPitchHigh(i, downstepPosition);
-        const highPitchNext = isMoraPitchHigh(i1, downstepPosition);
-        const nasal = nasalPositionsSet !== null && nasalPositionsSet.has(i1);
-        const devoice = devoicePositionsSet !== null && devoicePositionsSet.has(i1);
+export class PronunciationGenerator {
+    /**
+     * Creates a new instance of the class.
+     * @param {Document} document
+     */
+    constructor(document) {
+        /** @type {Document} */
+        this._document = document;
+    }
 
-        const n1 = document.createElement('span');
-        n1.className = 'pronunciation-mora';
-        n1.dataset.position = `${i}`;
-        n1.dataset.pitch = highPitch ? 'high' : 'low';
-        n1.dataset.pitchNext = highPitchNext ? 'high' : 'low';
+    /**
+     * @param {string[]} morae
+     * @param {number} downstepPosition
+     * @param {number[]} nasalPositions
+     * @param {number[]} devoicePositions
+     * @returns {HTMLSpanElement}
+     */
+    createPronunciationText(morae, downstepPosition, nasalPositions, devoicePositions) {
+        const nasalPositionsSet = nasalPositions.length > 0 ? new Set(nasalPositions) : null;
+        const devoicePositionsSet = devoicePositions.length > 0 ? new Set(devoicePositions) : null;
+        const container = this._document.createElement('span');
+        container.className = 'pronunciation-text';
+        for (let i = 0, ii = morae.length; i < ii; ++i) {
+            const i1 = i + 1;
+            const mora = morae[i];
+            const highPitch = isMoraPitchHigh(i, downstepPosition);
+            const highPitchNext = isMoraPitchHigh(i1, downstepPosition);
+            const nasal = nasalPositionsSet !== null && nasalPositionsSet.has(i1);
+            const devoice = devoicePositionsSet !== null && devoicePositionsSet.has(i1);
 
-        const characterNodes = [];
-        for (const character of mora) {
-            const n2 = document.createElement('span');
-            n2.className = 'pronunciation-character';
-            n2.textContent = character;
-            n1.appendChild(n2);
-            characterNodes.push(n2);
-        }
+            const n1 = this._document.createElement('span');
+            n1.className = 'pronunciation-mora';
+            n1.dataset.position = `${i}`;
+            n1.dataset.pitch = highPitch ? 'high' : 'low';
+            n1.dataset.pitchNext = highPitchNext ? 'high' : 'low';
 
-        if (devoice) {
-            n1.dataset.devoice = 'true';
-            const n3 = document.createElement('span');
-            n3.className = 'pronunciation-devoice-indicator';
-            n1.appendChild(n3);
-        }
-        if (nasal && characterNodes.length > 0) {
-            n1.dataset.nasal = 'true';
-
-            const group = document.createElement('span');
-            group.className = 'pronunciation-character-group';
-
-            const n2 = characterNodes[0];
-            const character = /** @type {string} */ (n2.textContent);
-
-            const characterInfo = getKanaDiacriticInfo(character);
-            if (characterInfo !== null) {
-                n1.dataset.originalText = mora;
-                n2.dataset.originalText = character;
-                n2.textContent = characterInfo.character;
+            const characterNodes = [];
+            for (const character of mora) {
+                const n2 = this._document.createElement('span');
+                n2.className = 'pronunciation-character';
+                n2.textContent = character;
+                n1.appendChild(n2);
+                characterNodes.push(n2);
             }
 
-            let n3 = document.createElement('span');
-            n3.className = 'pronunciation-nasal-diacritic';
-            n3.textContent = '\u309a'; // Combining handakuten
-            group.appendChild(n3);
-
-            n3 = document.createElement('span');
-            n3.className = 'pronunciation-nasal-indicator';
-            group.appendChild(n3);
-
-            /** @type {ParentNode} */ (n2.parentNode).replaceChild(group, n2);
-            group.insertBefore(n2, group.firstChild);
-        }
-
-        const line = document.createElement('span');
-        line.className = 'pronunciation-mora-line';
-        n1.appendChild(line);
-
-        container.appendChild(n1);
-    }
-    return container;
-}
-
-/**
- * @param {string[]} morae
- * @param {number} downstepPosition
- * @returns {SVGSVGElement}
- */
-export function createPronunciationGraph(morae, downstepPosition) {
-    const ii = morae.length;
-
-    const svgns = 'http://www.w3.org/2000/svg';
-    const svg = document.createElementNS(svgns, 'svg');
-    svg.setAttribute('xmlns', svgns);
-    svg.setAttribute('class', 'pronunciation-graph');
-    svg.setAttribute('focusable', 'false');
-    svg.setAttribute('viewBox', `0 0 ${50 * (ii + 1)} 100`);
-
-    if (ii <= 0) { return svg; }
-
-    const path1 = document.createElementNS(svgns, 'path');
-    svg.appendChild(path1);
-
-    const path2 = document.createElementNS(svgns, 'path');
-    svg.appendChild(path2);
-
-    const pathPoints = [];
-    for (let i = 0; i < ii; ++i) {
-        const highPitch = isMoraPitchHigh(i, downstepPosition);
-        const highPitchNext = isMoraPitchHigh(i + 1, downstepPosition);
-        const x = i * 50 + 25;
-        const y = highPitch ? 25 : 75;
-        if (highPitch && !highPitchNext) {
-            addGraphDotDownstep(svg, svgns, x, y);
-        } else {
-            addGraphDot(svg, svgns, x, y);
-        }
-        pathPoints.push(`${x} ${y}`);
-    }
-
-    path1.setAttribute('class', 'pronunciation-graph-line');
-    path1.setAttribute('d', `M${pathPoints.join(' L')}`);
-
-    pathPoints.splice(0, ii - 1);
-    {
-        const highPitch = isMoraPitchHigh(ii, downstepPosition);
-        const x = ii * 50 + 25;
-        const y = highPitch ? 25 : 75;
-        addGraphTriangle(svg, svgns, x, y);
-        pathPoints.push(`${x} ${y}`);
-    }
-
-    path2.setAttribute('class', 'pronunciation-graph-line-tail');
-    path2.setAttribute('d', `M${pathPoints.join(' L')}`);
-
-    return svg;
-}
-
-/**
- * @param {number} downstepPosition
- * @returns {HTMLSpanElement}
- */
-export function createPronunciationDownstepPosition(downstepPosition) {
-    const downstepPositionString = `${downstepPosition}`;
-
-    const n1 = document.createElement('span');
-    n1.className = 'pronunciation-downstep-notation';
-    n1.dataset.downstepPosition = downstepPositionString;
-
-    let n2 = document.createElement('span');
-    n2.className = 'pronunciation-downstep-notation-prefix';
-    n2.textContent = '[';
-    n1.appendChild(n2);
-
-    n2 = document.createElement('span');
-    n2.className = 'pronunciation-downstep-notation-number';
-    n2.textContent = downstepPositionString;
-    n1.appendChild(n2);
-
-    n2 = document.createElement('span');
-    n2.className = 'pronunciation-downstep-notation-suffix';
-    n2.textContent = ']';
-    n1.appendChild(n2);
-
-    return n1;
-}
-
-// Private
-
-/**
- * @param {Element} container
- * @param {string} svgns
- * @param {number} x
- * @param {number} y
- */
-function addGraphDot(container, svgns, x, y) {
-    container.appendChild(createGraphCircle(svgns, 'pronunciation-graph-dot', x, y, '15'));
-}
-
-/**
- * @param {Element} container
- * @param {string} svgns
- * @param {number} x
- * @param {number} y
- */
-function addGraphDotDownstep(container, svgns, x, y) {
-    container.appendChild(createGraphCircle(svgns, 'pronunciation-graph-dot-downstep1', x, y, '15'));
-    container.appendChild(createGraphCircle(svgns, 'pronunciation-graph-dot-downstep2', x, y, '5'));
-}
-
-/**
- * @param {Element} container
- * @param {string} svgns
- * @param {number} x
- * @param {number} y
- */
-function addGraphTriangle(container, svgns, x, y) {
-    const node = document.createElementNS(svgns, 'path');
-    node.setAttribute('class', 'pronunciation-graph-triangle');
-    node.setAttribute('d', 'M0 13 L15 -13 L-15 -13 Z');
-    node.setAttribute('transform', `translate(${x},${y})`);
-    container.appendChild(node);
-}
-
-/**
- * @param {string} svgns
- * @param {string} className
- * @param {number} x
- * @param {number} y
- * @param {string} radius
- * @returns {Element}
- */
-function createGraphCircle(svgns, className, x, y, radius) {
-    const node = document.createElementNS(svgns, 'circle');
-    node.setAttribute('class', className);
-    node.setAttribute('cx', `${x}`);
-    node.setAttribute('cy', `${y}`);
-    node.setAttribute('r', radius);
-    return node;
-}
-
-// The following Jidoujisho pitch graph code is based on code from
-// https://github.com/lrorpilla/jidoujisho licensed under the
-// GNU General Public License v3.0
-
-/**
- * Create a pronounciation graph in the style of Jidoujisho
- * @param {string[]} mora
- * @param {number} downstepPosition
- * @returns {SVGSVGElement}
- */
-export function createPronunciationGraphJJ(mora, downstepPosition) {
-    const patt = pitchValueToPattJJ(mora.length, downstepPosition);
-
-    const positions = Math.max(mora.length, patt.length);
-    const stepWidth = 35;
-    const marginLr = 16;
-    const svgWidth = Math.max(0, ((positions - 1) * stepWidth) + (marginLr * 2));
-
-    const svgns = 'http://www.w3.org/2000/svg';
-    const svg = document.createElementNS(svgns, 'svg');
-    svg.setAttribute('xmlns', svgns);
-    svg.setAttribute('width', `${(svgWidth * (3 / 5))}px`);
-    svg.setAttribute('height', '45px');
-    svg.setAttribute('viewBox', `0 0 ${svgWidth} 75`);
-
-
-    if (mora.length <= 0) { return svg; }
-
-    for (let i = 0; i < mora.length; i++) {
-        const xCenter = marginLr + (i * stepWidth);
-        textJJ(xCenter - 11, mora[i], svgns, svg);
-    }
-
-
-    let pathType = '';
-
-    const circles = [];
-    const paths = [];
-
-    let prevCenter = [-1, -1];
-    for (let i = 0; i < patt.length; i++) {
-        const xCenter = marginLr + (i * stepWidth);
-        const accent = patt[i];
-        let yCenter = 0;
-        if (accent === 'H') {
-            yCenter = 5;
-        } else if (accent === 'L') {
-            yCenter = 30;
-        }
-        circles.push(circleJJ(xCenter, yCenter, i >= mora.length, svgns));
-
-
-        if (i > 0) {
-            if (prevCenter[1] === yCenter) {
-                pathType = 's';
-            } else if (prevCenter[1] < yCenter) {
-                pathType = 'd';
-            } else if (prevCenter[1] > yCenter) {
-                pathType = 'u';
+            if (devoice) {
+                n1.dataset.devoice = 'true';
+                const n3 = this._document.createElement('span');
+                n3.className = 'pronunciation-devoice-indicator';
+                n1.appendChild(n3);
             }
-            paths.push(pathJJ(prevCenter[0], prevCenter[1], pathType, stepWidth, svgns));
+            if (nasal && characterNodes.length > 0) {
+                n1.dataset.nasal = 'true';
+
+                const group = this._document.createElement('span');
+                group.className = 'pronunciation-character-group';
+
+                const n2 = characterNodes[0];
+                const character = /** @type {string} */ (n2.textContent);
+
+                const characterInfo = getKanaDiacriticInfo(character);
+                if (characterInfo !== null) {
+                    n1.dataset.originalText = mora;
+                    n2.dataset.originalText = character;
+                    n2.textContent = characterInfo.character;
+                }
+
+                let n3 = this._document.createElement('span');
+                n3.className = 'pronunciation-nasal-diacritic';
+                n3.textContent = '\u309a'; // Combining handakuten
+                group.appendChild(n3);
+
+                n3 = this._document.createElement('span');
+                n3.className = 'pronunciation-nasal-indicator';
+                group.appendChild(n3);
+
+                /** @type {ParentNode} */ (n2.parentNode).replaceChild(group, n2);
+                group.insertBefore(n2, group.firstChild);
+            }
+
+            const line = this._document.createElement('span');
+            line.className = 'pronunciation-mora-line';
+            n1.appendChild(line);
+
+            container.appendChild(n1);
         }
-        prevCenter = [xCenter, yCenter];
+        return container;
     }
 
-    for (const path of paths) {
-        svg.appendChild(path);
-    }
+    /**
+     * @param {string[]} morae
+     * @param {number} downstepPosition
+     * @returns {SVGSVGElement}
+     */
+    createPronunciationGraph(morae, downstepPosition) {
+        const ii = morae.length;
 
-    for (const circle of circles) {
-        svg.appendChild(circle);
-    }
+        const svgns = 'http://www.w3.org/2000/svg';
+        const svg = this._document.createElementNS(svgns, 'svg');
+        svg.setAttribute('xmlns', svgns);
+        svg.setAttribute('class', 'pronunciation-graph');
+        svg.setAttribute('focusable', 'false');
+        svg.setAttribute('viewBox', `0 0 ${50 * (ii + 1)} 100`);
 
-    return svg;
-}
+        if (ii <= 0) { return svg; }
 
-/**
- * Get H&L pattern
- * @param {number} numberOfMora
- * @param {number} pitchValue
- * @returns {string}
- */
-function pitchValueToPattJJ(numberOfMora, pitchValue) {
-    if (numberOfMora >= 1) {
-        if (pitchValue === 0) {
-        // Heiban
-            return `L${'H'.repeat(numberOfMora)}`;
-        } else if (pitchValue === 1) {
-        // Atamadaka
-            return `H${'L'.repeat(numberOfMora)}`;
-        } else if (pitchValue >= 2) {
-            const stepdown = pitchValue - 2;
-            return `LH${'H'.repeat(stepdown)}${'L'.repeat(numberOfMora - pitchValue + 1)}`;
-        }
-    }
-    return '';
-}
-
-/**
- * @param {number} x
- * @param {number} y
- * @param {boolean} o
- * @param {string} svgns
- * @returns {Element}
- */
-function circleJJ(x, y, o, svgns) {
-    if (o) {
-        const node = document.createElementNS(svgns, 'circle');
-
-        node.setAttribute('r', '4');
-        node.setAttribute('cx', `${(x + 4)}`);
-        node.setAttribute('cy', `${y}`);
-        node.setAttribute('stroke', 'currentColor');
-        node.setAttribute('stroke-width', '2');
-        node.setAttribute('fill', 'none');
-
-        return node;
-    } else {
-        const node = document.createElementNS(svgns, 'circle');
-
-        node.setAttribute('r', '5');
-        node.setAttribute('cx', `${x}`);
-        node.setAttribute('cy', `${y}`);
-        node.setAttribute('style', 'opacity:1;fill:currentColor;');
-
-        return node;
-    }
-}
-
-/**
- * @param {number} x
- * @param {string} mora
- * @param {string} svgns
- * @param {SVGSVGElement} svg
- * @returns {void}
- */
-function textJJ(x, mora, svgns, svg) {
-    if (mora.length === 1) {
-        const path = document.createElementNS(svgns, 'text');
-        path.setAttribute('x', `${x}`);
-        path.setAttribute('y', '67.5');
-        path.setAttribute('style', 'font-size:20px;font-family:sans-serif;fill:currentColor;');
-        path.textContent = mora;
-        svg.appendChild(path);
-    } else {
-        const path1 = document.createElementNS(svgns, 'text');
-        path1.setAttribute('x', `${x - 5}`);
-        path1.setAttribute('y', '67.5');
-        path1.setAttribute('style', 'font-size:20px;font-family:sans-serif;fill:currentColor;');
-        path1.textContent = mora[0];
+        const path1 = this._document.createElementNS(svgns, 'path');
         svg.appendChild(path1);
 
-
-        const path2 = document.createElementNS(svgns, 'text');
-        path2.setAttribute('x', `${x + 12}`);
-        path2.setAttribute('y', '67.5');
-        path2.setAttribute('style', 'font-size:14px;font-family:sans-serif;fill:currentColor;');
-        path2.textContent = mora[1];
+        const path2 = this._document.createElementNS(svgns, 'path');
         svg.appendChild(path2);
+
+        const pathPoints = [];
+        for (let i = 0; i < ii; ++i) {
+            const highPitch = isMoraPitchHigh(i, downstepPosition);
+            const highPitchNext = isMoraPitchHigh(i + 1, downstepPosition);
+            const x = i * 50 + 25;
+            const y = highPitch ? 25 : 75;
+            if (highPitch && !highPitchNext) {
+                this._addGraphDotDownstep(svg, svgns, x, y);
+            } else {
+                this._addGraphDot(svg, svgns, x, y);
+            }
+            pathPoints.push(`${x} ${y}`);
+        }
+
+        path1.setAttribute('class', 'pronunciation-graph-line');
+        path1.setAttribute('d', `M${pathPoints.join(' L')}`);
+
+        pathPoints.splice(0, ii - 1);
+        {
+            const highPitch = isMoraPitchHigh(ii, downstepPosition);
+            const x = ii * 50 + 25;
+            const y = highPitch ? 25 : 75;
+            this._addGraphTriangle(svg, svgns, x, y);
+            pathPoints.push(`${x} ${y}`);
+        }
+
+        path2.setAttribute('class', 'pronunciation-graph-line-tail');
+        path2.setAttribute('d', `M${pathPoints.join(' L')}`);
+
+        return svg;
     }
-}
 
-/**
- * @param {number} x
- * @param {number} y
- * @param {string} type
- * @param {number} stepWidth
- * @param {string} svgns
- * @returns {Element}
- */
-function pathJJ(x, y, type, stepWidth, svgns) {
-    let delta = '';
-    switch (type) {
-        case 's':
-            delta = stepWidth + ',0';
-            break;
-        case 'u':
-            delta = stepWidth + ',-25';
-            break;
-        case 'd':
-            delta = stepWidth + ',25';
-            break;
+    /**
+     * @param {number} downstepPosition
+     * @returns {HTMLSpanElement}
+     */
+    createPronunciationDownstepPosition(downstepPosition) {
+        const downstepPositionString = `${downstepPosition}`;
+
+        const n1 = this._document.createElement('span');
+        n1.className = 'pronunciation-downstep-notation';
+        n1.dataset.downstepPosition = downstepPositionString;
+
+        let n2 = this._document.createElement('span');
+        n2.className = 'pronunciation-downstep-notation-prefix';
+        n2.textContent = '[';
+        n1.appendChild(n2);
+
+        n2 = this._document.createElement('span');
+        n2.className = 'pronunciation-downstep-notation-number';
+        n2.textContent = downstepPositionString;
+        n1.appendChild(n2);
+
+        n2 = this._document.createElement('span');
+        n2.className = 'pronunciation-downstep-notation-suffix';
+        n2.textContent = ']';
+        n1.appendChild(n2);
+
+        return n1;
     }
 
-    const path = document.createElementNS(svgns, 'path');
-    path.setAttribute('d', `m ${x},${y} ${delta}`);
-    path.setAttribute('style', 'fill:none;stroke:currentColor;stroke-width:1.5;');
+    // The following Jidoujisho pitch graph code is based on code from
+    // https://github.com/lrorpilla/jidoujisho licensed under the
+    // GNU General Public License v3.0
 
-    return path;
+    /**
+     * Create a pronounciation graph in the style of Jidoujisho
+     * @param {string[]} mora
+     * @param {number} downstepPosition
+     * @returns {SVGSVGElement}
+     */
+    createPronunciationGraphJJ(mora, downstepPosition) {
+        const patt = this._pitchValueToPattJJ(mora.length, downstepPosition);
+
+        const positions = Math.max(mora.length, patt.length);
+        const stepWidth = 35;
+        const marginLr = 16;
+        const svgWidth = Math.max(0, ((positions - 1) * stepWidth) + (marginLr * 2));
+
+        const svgns = 'http://www.w3.org/2000/svg';
+        const svg = this._document.createElementNS(svgns, 'svg');
+        svg.setAttribute('xmlns', svgns);
+        svg.setAttribute('width', `${(svgWidth * (3 / 5))}px`);
+        svg.setAttribute('height', '45px');
+        svg.setAttribute('viewBox', `0 0 ${svgWidth} 75`);
+
+
+        if (mora.length <= 0) { return svg; }
+
+        for (let i = 0; i < mora.length; i++) {
+            const xCenter = marginLr + (i * stepWidth);
+            this._textJJ(xCenter - 11, mora[i], svgns, svg);
+        }
+
+
+        let pathType = '';
+
+        const circles = [];
+        const paths = [];
+
+        let prevCenter = [-1, -1];
+        for (let i = 0; i < patt.length; i++) {
+            const xCenter = marginLr + (i * stepWidth);
+            const accent = patt[i];
+            let yCenter = 0;
+            if (accent === 'H') {
+                yCenter = 5;
+            } else if (accent === 'L') {
+                yCenter = 30;
+            }
+            circles.push(this._circleJJ(xCenter, yCenter, i >= mora.length, svgns));
+
+
+            if (i > 0) {
+                if (prevCenter[1] === yCenter) {
+                    pathType = 's';
+                } else if (prevCenter[1] < yCenter) {
+                    pathType = 'd';
+                } else if (prevCenter[1] > yCenter) {
+                    pathType = 'u';
+                }
+                paths.push(this._pathJJ(prevCenter[0], prevCenter[1], pathType, stepWidth, svgns));
+            }
+            prevCenter = [xCenter, yCenter];
+        }
+
+        for (const path of paths) {
+            svg.appendChild(path);
+        }
+
+        for (const circle of circles) {
+            svg.appendChild(circle);
+        }
+
+        return svg;
+    }
+
+
+    // Private
+
+    /**
+     * @param {Element} container
+     * @param {string} svgns
+     * @param {number} x
+     * @param {number} y
+     */
+    _addGraphDot(container, svgns, x, y) {
+        container.appendChild(this._createGraphCircle(svgns, 'pronunciation-graph-dot', x, y, '15'));
+    }
+
+    /**
+     * @param {Element} container
+     * @param {string} svgns
+     * @param {number} x
+     * @param {number} y
+     */
+    _addGraphDotDownstep(container, svgns, x, y) {
+        container.appendChild(this._createGraphCircle(svgns, 'pronunciation-graph-dot-downstep1', x, y, '15'));
+        container.appendChild(this._createGraphCircle(svgns, 'pronunciation-graph-dot-downstep2', x, y, '5'));
+    }
+
+    /**
+     * @param {Element} container
+     * @param {string} svgns
+     * @param {number} x
+     * @param {number} y
+     */
+    _addGraphTriangle(container, svgns, x, y) {
+        const node = this._document.createElementNS(svgns, 'path');
+        node.setAttribute('class', 'pronunciation-graph-triangle');
+        node.setAttribute('d', 'M0 13 L15 -13 L-15 -13 Z');
+        node.setAttribute('transform', `translate(${x},${y})`);
+        container.appendChild(node);
+    }
+
+    /**
+     * @param {string} svgns
+     * @param {string} className
+     * @param {number} x
+     * @param {number} y
+     * @param {string} radius
+     * @returns {Element}
+     */
+    _createGraphCircle(svgns, className, x, y, radius) {
+        const node = this._document.createElementNS(svgns, 'circle');
+        node.setAttribute('class', className);
+        node.setAttribute('cx', `${x}`);
+        node.setAttribute('cy', `${y}`);
+        node.setAttribute('r', radius);
+        return node;
+    }
+
+    /**
+     * Get H&L pattern
+     * @param {number} numberOfMora
+     * @param {number} pitchValue
+     * @returns {string}
+     */
+    _pitchValueToPattJJ(numberOfMora, pitchValue) {
+        if (numberOfMora >= 1) {
+            if (pitchValue === 0) {
+                // Heiban
+                return `L${'H'.repeat(numberOfMora)}`;
+            } else if (pitchValue === 1) {
+                // Atamadaka
+                return `H${'L'.repeat(numberOfMora)}`;
+            } else if (pitchValue >= 2) {
+                const stepdown = pitchValue - 2;
+                return `LH${'H'.repeat(stepdown)}${'L'.repeat(numberOfMora - pitchValue + 1)}`;
+            }
+        }
+        return '';
+    }
+
+    /**
+     * @param {number} x
+     * @param {number} y
+     * @param {boolean} o
+     * @param {string} svgns
+     * @returns {Element}
+     */
+    _circleJJ(x, y, o, svgns) {
+        if (o) {
+            const node = this._document.createElementNS(svgns, 'circle');
+
+            node.setAttribute('r', '4');
+            node.setAttribute('cx', `${(x + 4)}`);
+            node.setAttribute('cy', `${y}`);
+            node.setAttribute('stroke', 'currentColor');
+            node.setAttribute('stroke-width', '2');
+            node.setAttribute('fill', 'none');
+
+            return node;
+        } else {
+            const node = this._document.createElementNS(svgns, 'circle');
+
+            node.setAttribute('r', '5');
+            node.setAttribute('cx', `${x}`);
+            node.setAttribute('cy', `${y}`);
+            node.setAttribute('style', 'opacity:1;fill:currentColor;');
+
+            return node;
+        }
+    }
+
+    /**
+     * @param {number} x
+     * @param {string} mora
+     * @param {string} svgns
+     * @param {SVGSVGElement} svg
+     * @returns {void}
+     */
+    _textJJ(x, mora, svgns, svg) {
+        if (mora.length === 1) {
+            const path = this._document.createElementNS(svgns, 'text');
+            path.setAttribute('x', `${x}`);
+            path.setAttribute('y', '67.5');
+            path.setAttribute('style', 'font-size:20px;font-family:sans-serif;fill:currentColor;');
+            path.textContent = mora;
+            svg.appendChild(path);
+        } else {
+            const path1 = this._document.createElementNS(svgns, 'text');
+            path1.setAttribute('x', `${x - 5}`);
+            path1.setAttribute('y', '67.5');
+            path1.setAttribute('style', 'font-size:20px;font-family:sans-serif;fill:currentColor;');
+            path1.textContent = mora[0];
+            svg.appendChild(path1);
+
+
+            const path2 = this._document.createElementNS(svgns, 'text');
+            path2.setAttribute('x', `${x + 12}`);
+            path2.setAttribute('y', '67.5');
+            path2.setAttribute('style', 'font-size:14px;font-family:sans-serif;fill:currentColor;');
+            path2.textContent = mora[1];
+            svg.appendChild(path2);
+        }
+    }
+
+    /**
+     * @param {number} x
+     * @param {number} y
+     * @param {string} type
+     * @param {number} stepWidth
+     * @param {string} svgns
+     * @returns {Element}
+     */
+    _pathJJ(x, y, type, stepWidth, svgns) {
+        let delta = '';
+        switch (type) {
+            case 's':
+                delta = stepWidth + ',0';
+                break;
+            case 'u':
+                delta = stepWidth + ',-25';
+                break;
+            case 'd':
+                delta = stepWidth + ',25';
+                break;
+        }
+
+        const path = this._document.createElementNS(svgns, 'path');
+        path.setAttribute('d', `m ${x},${y} ${delta}`);
+        path.setAttribute('style', 'fill:none;stroke:currentColor;stroke-width:1.5;');
+
+        return path;
+    }
 }

--- a/ext/js/display/structured-content-generator.js
+++ b/ext/js/display/structured-content-generator.js
@@ -24,12 +24,15 @@ export class StructuredContentGenerator {
     /**
      * @param {import('./display-content-manager.js').DisplayContentManager|import('../templates/anki-template-renderer-content-manager.js').AnkiTemplateRendererContentManager} contentManager
      * @param {Document} document
+     * @param {Window} window
      */
-    constructor(contentManager, document) {
+    constructor(contentManager, document, window) {
         /** @type {import('./display-content-manager.js').DisplayContentManager|import('../templates/anki-template-renderer-content-manager.js').AnkiTemplateRendererContentManager} */
         this._contentManager = contentManager;
         /** @type {Document} */
         this._document = document;
+        /** @type {Window} */
+        this._window = window;
     }
 
     /**
@@ -114,7 +117,7 @@ export class StructuredContentGenerator {
         if (this._contentManager instanceof DisplayContentManager) {
             node.addEventListener('click', () => {
                 if (this._contentManager instanceof DisplayContentManager) {
-                    void this._contentManager.openMediaInTab(path, dictionary, window);
+                    void this._contentManager.openMediaInTab(path, dictionary, this._window);
                 }
             });
         }
@@ -150,7 +153,7 @@ export class StructuredContentGenerator {
                 /** @type {HTMLImageElement} */ (this._createElement('img', 'gloss-image'));
             if (sizeUnits === 'em' && (hasPreferredWidth || hasPreferredHeight)) {
                 const emSize = 14; // We could Number.parseFloat(getComputedStyle(document.documentElement).fontSize); here for more accuracy but it would cause a layout and be extremely slow; possible improvement would be to calculate and cache the value
-                const scaleFactor = 2 * window.devicePixelRatio;
+                const scaleFactor = 2 * this._window.devicePixelRatio;
                 image.style.width = `${usedWidth}em`;
                 image.style.height = `${usedWidth * invAspectRatio}em`;
                 image.width = usedWidth * emSize * scaleFactor;

--- a/ext/js/dom/css-style-applier.js
+++ b/ext/js/dom/css-style-applier.js
@@ -17,6 +17,8 @@
  */
 
 import {readResponseJson} from '../core/json.js';
+import {log} from '../core/log.js';
+import {toError} from '../core/to-error.js';
 
 /**
  * This class is used to apply CSS styles to elements using a consistent method
@@ -80,7 +82,12 @@ export class CssStyleApplier {
             if (className === null || className.length === 0) { continue; }
             let cssTextNew = '';
             for (const {selectors, styles} of this._getCandidateCssRulesForClass(className)) {
-                if (!element.matches(selectors)) { continue; }
+                try { // `css-select` used by `linkedom` in the Yomitan API does not support some pseudo elements and may error
+                    if (!element.matches(selectors)) { continue; }
+                } catch (e) {
+                    log.log('Failed to match css selectors: ' + selectors + '\n' + toError(e).message);
+                    continue;
+                }
                 cssTextNew += this._getCssText(styles);
             }
             cssTextNew += element.style.cssText;

--- a/ext/js/templates/anki-template-renderer.js
+++ b/ext/js/templates/anki-template-renderer.js
@@ -36,8 +36,9 @@ export class AnkiTemplateRenderer {
     /**
      * Creates a new instance of the class.
      * @param {Document} document
+     * @param {Window} window
      */
-    constructor(document) {
+    constructor(document, window) {
         /** @type {CssStyleApplier} */
         this._structuredContentStyleApplier = new CssStyleApplier('/data/structured-content-style.json');
         /** @type {CssStyleApplier} */
@@ -58,6 +59,8 @@ export class AnkiTemplateRenderer {
         this._temporaryElement = null;
         /** @type {Document} */
         this._document = document;
+        /** @type {Window} */
+        this._window = window;
     }
 
     /**
@@ -663,7 +666,7 @@ export class AnkiTemplateRenderer {
      */
     _createStructuredContentGenerator(data) {
         const contentManager = new AnkiTemplateRendererContentManager(this._mediaProvider, data);
-        const instance = new StructuredContentGenerator(contentManager, this._document);
+        const instance = new StructuredContentGenerator(contentManager, this._document, this._window);
         this._cleanupCallbacks.push(() => contentManager.unloadAll());
         return instance;
     }

--- a/ext/js/templates/anki-template-renderer.js
+++ b/ext/js/templates/anki-template-renderer.js
@@ -20,7 +20,7 @@ import {Handlebars} from '../../lib/handlebars.js';
 import {NodeFilter} from '../../lib/linkedom.js';
 import {createAnkiNoteData} from '../data/anki-note-data-creator.js';
 import {getPronunciationsOfType, isNonNounVerbOrAdjective} from '../dictionary/dictionary-data-util.js';
-import {createPronunciationDownstepPosition, createPronunciationGraph, createPronunciationGraphJJ, createPronunciationText} from '../display/pronunciation-generator.js';
+import {PronunciationGenerator} from '../display/pronunciation-generator.js';
 import {StructuredContentGenerator} from '../display/structured-content-generator.js';
 import {CssStyleApplier} from '../dom/css-style-applier.js';
 import {convertHiraganaToKatakana, convertKatakanaToHiragana, distributeFurigana, getKanaMorae, getPitchCategory, isMoraPitchHigh} from '../language/ja/japanese.js';
@@ -61,6 +61,8 @@ export class AnkiTemplateRenderer {
         this._document = document;
         /** @type {Window} */
         this._window = window;
+        /** @type {PronunciationGenerator} */
+        this._pronunciationGenerator = new PronunciationGenerator(this._document);
     }
 
     /**
@@ -755,14 +757,14 @@ export class AnkiTemplateRenderer {
             {
                 const nasalPositions = this._getValidNumberArray(options.hash.nasalPositions);
                 const devoicePositions = this._getValidNumberArray(options.hash.devoicePositions);
-                return this._getPronunciationHtml(createPronunciationText(morae, downstepPosition, nasalPositions, devoicePositions));
+                return this._getPronunciationHtml(this._pronunciationGenerator.createPronunciationText(morae, downstepPosition, nasalPositions, devoicePositions));
             }
             case 'graph':
-                return this._getPronunciationHtml(createPronunciationGraph(morae, downstepPosition));
+                return this._getPronunciationHtml(this._pronunciationGenerator.createPronunciationGraph(morae, downstepPosition));
             case 'graph-jj':
-                return this._getPronunciationHtml(createPronunciationGraphJJ(morae, downstepPosition));
+                return this._getPronunciationHtml(this._pronunciationGenerator.createPronunciationGraphJJ(morae, downstepPosition));
             case 'position':
-                return this._getPronunciationHtml(createPronunciationDownstepPosition(downstepPosition));
+                return this._getPronunciationHtml(this._pronunciationGenerator.createPronunciationDownstepPosition(downstepPosition));
             default:
                 return '';
         }

--- a/ext/js/templates/template-renderer-frame-main.js
+++ b/ext/js/templates/template-renderer-frame-main.js
@@ -21,7 +21,7 @@ import {TemplateRendererFrameApi} from './template-renderer-frame-api.js';
 
 /** Entry point. */
 async function main() {
-    const ankiTemplateRenderer = new AnkiTemplateRenderer(document);
+    const ankiTemplateRenderer = new AnkiTemplateRenderer(document, window);
     await ankiTemplateRenderer.prepare();
     const templateRendererFrameApi = new TemplateRendererFrameApi(ankiTemplateRenderer.templateRenderer);
     templateRendererFrameApi.prepare();

--- a/test/fixtures/anki-template-renderer-test.js
+++ b/test/fixtures/anki-template-renderer-test.js
@@ -27,9 +27,9 @@ vi.stubGlobal('fetch', fetch);
  */
 export async function createAnkiTemplateRendererTest() {
     const test = createDomTest(void 0);
-    // @ts-expect-error - Document is not accessible in this test and is not accessed, allow it to be undefined
+    // @ts-expect-error - Document and Window are not accessible in this test and is not accessed, allow it to be undefined
     // eslint-disable-next-line no-undefined
-    const ankiTemplateRenderer = new AnkiTemplateRenderer(undefined);
+    const ankiTemplateRenderer = new AnkiTemplateRenderer(undefined, undefined);
     await ankiTemplateRenderer.prepare();
     /** @type {import('vitest').TestAPI<{window: import('jsdom').DOMWindow, ankiTemplateRenderer: AnkiTemplateRenderer}>} */
     // eslint-disable-next-line sonarjs/prefer-immediate-return

--- a/test/utilities/anki.js
+++ b/test/utilities/anki.js
@@ -83,7 +83,7 @@ export function createTestAnkiNoteData(dictionaryEntry, mode, styles = '') {
  * @returns {Promise<import('anki').NoteFields[]>}
  */
 export async function getTemplateRenderResults(dictionaryEntries, mode, template, expect, styles = '') {
-    const ankiTemplateRenderer = new AnkiTemplateRenderer(document);
+    const ankiTemplateRenderer = new AnkiTemplateRenderer(document, window);
     await ankiTemplateRenderer.prepare();
     const clozePrefix = 'cloze-prefix';
     const clozeSuffix = 'cloze-suffix';


### PR DESCRIPTION
1. Previously the api passed through `domlessDocument` but it looks like we also need `domlessWindow` since a few parts of structured content generation use `window`
2. `linkedom` uses `css-select` for its css handling. There are some css selectors this doesn't support and so the api currently won't be able to support these. These selectors are now skipped and logged instead of erroring.
3. The pronunciation generator that renders all of the pitch accent stuff heavily relies on document and was just a collection of functions making this very messy to do. I've converted it to a class to avoid the mess of passing document into every single function and it now gets `domlessDocument` from the api.