### PR TITLE
Allow specifying exact pitch values in pitch dicts

### DIFF
--- a/ext/data/schemas/dictionary-term-meta-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-term-meta-bank-v3-schema.json
@@ -112,9 +112,18 @@
                                     "additionalProperties": false,
                                     "properties": {
                                         "position": {
-                                            "type": "integer",
-                                            "description": "Mora position of the pitch accent downstep. A value of 0 indicates that the word does not have a downstep (heiban).",
-                                            "minimum": 0
+                                            "oneOf": [
+                                                {
+                                                    "type": "integer",
+                                                    "description": "Mora position of the pitch accent downstep. A value of 0 indicates that the word does not have a downstep (heiban).",
+                                                    "minimum": 0
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "description": "Pitch level of each mora with H representing high and L representing low. For example: HHLL for a 4 mora word.",
+                                                    "pattern": "^[HL]+$"
+                                                }
+                                            ]
                                         },
                                         "nasal": {
                                             "oneOf": [

--- a/ext/data/templates/anki-field-templates-upgrade-v66.handlebars
+++ b/ext/data/templates/anki-field-templates-upgrade-v66.handlebars
@@ -1,0 +1,9 @@
+{{<<<<<<<}}
+{{#*inline "pitch-accent-item"}}
+    {{~pronunciation format=format reading=reading downstepPosition=position nasalPositions=nasalPositions devoicePositions=devoicePositions~}}
+{{/inline}}
+{{=======}}
+{{#*inline "pitch-accent-item"}}
+    {{~pronunciation format=format reading=reading pitchPositions=positions nasalPositions=nasalPositions devoicePositions=devoicePositions~}}
+{{/inline}}
+{{>>>>>>>}}

--- a/ext/data/templates/default-anki-field-templates.handlebars
+++ b/ext/data/templates/default-anki-field-templates.handlebars
@@ -234,7 +234,7 @@
 
 {{! Pitch Accents }}
 {{#*inline "pitch-accent-item"}}
-    {{~pronunciation format=format reading=reading downstepPosition=position nasalPositions=nasalPositions devoicePositions=devoicePositions~}}
+    {{~pronunciation format=format reading=reading pitchPositions=positions nasalPositions=nasalPositions devoicePositions=devoicePositions~}}
 {{/inline}}
 
 {{#*inline "pitch-accent-item-disambiguation"}}

--- a/ext/js/data/anki-note-data-creator.js
+++ b/ext/js/data/anki-note-data-creator.js
@@ -249,12 +249,12 @@ function getPitches(dictionaryEntry) {
             for (const groupedPronunciation of pronunciations) {
                 const {pronunciation} = groupedPronunciation;
                 if (pronunciation.type !== 'pitch-accent') { continue; }
-                const {position, nasalPositions, devoicePositions, tags} = pronunciation;
+                const {positions, nasalPositions, devoicePositions, tags} = pronunciation;
                 const {terms, reading, exclusiveTerms, exclusiveReadings} = groupedPronunciation;
                 pitches.push({
                     expressions: terms,
                     reading,
-                    position,
+                    positions,
                     nasalPositions,
                     devoicePositions,
                     tags: convertPitchTags(tags),
@@ -662,10 +662,10 @@ function getTermPitches(dictionaryEntry) {
  */
 function getTermPitchesInner(pitches) {
     const results = [];
-    for (const {position, tags} of pitches) {
+    for (const {positions, tags} of pitches) {
         const cachedTags = createCachedValue(convertTags.bind(null, tags));
         results.push({
-            position,
+            positions,
             get tags() { return getCachedValue(cachedTags); },
         });
     }

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -577,6 +577,7 @@ export class OptionsUtil {
             this._updateVersion63,
             this._updateVersion64,
             this._updateVersion65,
+            this._updateVersion66,
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1734,6 +1735,14 @@ export class OptionsUtil {
             profile.options.general.enableYomitanApi = false;
             profile.options.general.yomitanApiServer = 'http://127.0.0.1:8766';
         }
+    }
+
+    /**
+     *  - Changed pitch-accent-item param name
+     *  @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion66(options) {
+        await this._applyAnkiFieldTemplatesPatch(options, '/data/templates/anki-field-templates-upgrade-v66.handlebars');
     }
 
     /**

--- a/ext/js/dictionary/dictionary-data-util.js
+++ b/ext/js/dictionary/dictionary-data-util.js
@@ -461,7 +461,7 @@ function arePronunciationsEquivalent({pronunciation: pronunciation1}, pronunciat
             // This cast is valid based on the type check at the start of the function.
             const pitchAccent2 = /** @type {import('dictionary').PitchAccent} */ (pronunciation2);
             return (
-                pronunciation1.position === pitchAccent2.position &&
+                pronunciation1.positions === pitchAccent2.positions &&
                 areArraysEqual(pronunciation1.nasalPositions, pitchAccent2.nasalPositions) &&
                 areArraysEqual(pronunciation1.devoicePositions, pitchAccent2.devoicePositions)
             );

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -799,13 +799,13 @@ export class DisplayGenerator {
      * @returns {HTMLElement}
      */
     _createPronunciationPitchAccent(pitchAccent, details) {
-        const {position, nasalPositions, devoicePositions, tags} = pitchAccent;
+        const {positions, nasalPositions, devoicePositions, tags} = pitchAccent;
         const {reading, exclusiveTerms, exclusiveReadings} = details;
         const morae = getKanaMorae(reading);
 
         const node = this._instantiate('pronunciation');
 
-        node.dataset.pitchAccentDownstepPosition = `${position}`;
+        node.dataset.pitchAccentDownstepPosition = `${positions}`;
         node.dataset.pronunciationType = pitchAccent.type;
         if (nasalPositions.length > 0) { node.dataset.nasalMoraPosition = nasalPositions.join(' '); }
         if (devoicePositions.length > 0) { node.dataset.devoiceMoraPosition = devoicePositions.join(' '); }
@@ -818,15 +818,15 @@ export class DisplayGenerator {
         this._createPronunciationDisambiguations(n, exclusiveTerms, exclusiveReadings);
 
         n = this._querySelector(node, '.pronunciation-downstep-notation-container');
-        n.appendChild(this._pronunciationGenerator.createPronunciationDownstepPosition(position));
+        n.appendChild(this._pronunciationGenerator.createPronunciationDownstepPosition(positions));
 
         n = this._querySelector(node, '.pronunciation-text-container');
 
         n.lang = this._language;
-        n.appendChild(this._pronunciationGenerator.createPronunciationText(morae, position, nasalPositions, devoicePositions));
+        n.appendChild(this._pronunciationGenerator.createPronunciationText(morae, positions, nasalPositions, devoicePositions));
 
         n = this._querySelector(node, '.pronunciation-graph-container');
-        n.appendChild(this._pronunciationGenerator.createPronunciationGraph(morae, position));
+        n.appendChild(this._pronunciationGenerator.createPronunciationGraph(morae, positions));
 
         return node;
     }
@@ -1138,7 +1138,7 @@ export class DisplayGenerator {
             if (termPronunciation.headwordIndex !== headwordIndex) { continue; }
             for (const pronunciation of termPronunciation.pronunciations) {
                 if (pronunciation.type !== 'pitch-accent') { continue; }
-                const category = getPitchCategory(reading, pronunciation.position, isVerbOrAdjective);
+                const category = getPitchCategory(reading, pronunciation.positions, isVerbOrAdjective);
                 if (category !== null) {
                     categories.add(category);
                 }

--- a/ext/js/language/ja/japanese.js
+++ b/ext/js/language/ja/japanese.js
@@ -352,24 +352,28 @@ export function isStringPartiallyJapanese(str) {
 
 /**
  * @param {number} moraIndex
- * @param {number} pitchAccentDownstepPosition
+ * @param {number | string} pitchAccentValue
  * @returns {boolean}
  */
-export function isMoraPitchHigh(moraIndex, pitchAccentDownstepPosition) {
-    switch (pitchAccentDownstepPosition) {
+export function isMoraPitchHigh(moraIndex, pitchAccentValue) {
+    if (typeof pitchAccentValue === 'string') {
+        return pitchAccentValue[moraIndex] === 'H';
+    }
+    switch (pitchAccentValue) {
         case 0: return (moraIndex > 0);
         case 1: return (moraIndex < 1);
-        default: return (moraIndex > 0 && moraIndex < pitchAccentDownstepPosition);
+        default: return (moraIndex > 0 && moraIndex < pitchAccentValue);
     }
 }
 
 /**
  * @param {string} text
- * @param {number} pitchAccentDownstepPosition
+ * @param {number | string} pitchAccentValue
  * @param {boolean} isVerbOrAdjective
  * @returns {?import('japanese-util').PitchCategory}
  */
-export function getPitchCategory(text, pitchAccentDownstepPosition, isVerbOrAdjective) {
+export function getPitchCategory(text, pitchAccentValue, isVerbOrAdjective) {
+    const pitchAccentDownstepPosition = typeof pitchAccentValue === 'string' ? getDownstepPositions(pitchAccentValue)[0] : pitchAccentValue;
     if (pitchAccentDownstepPosition === 0) {
         return 'heiban';
     }
@@ -383,6 +387,24 @@ export function getPitchCategory(text, pitchAccentDownstepPosition, isVerbOrAdje
         return pitchAccentDownstepPosition >= getKanaMoraCount(text) ? 'odaka' : 'nakadaka';
     }
     return null;
+}
+
+/**
+ * @param {string} pitchString
+ * @returns {number[]}
+ */
+export function getDownstepPositions(pitchString) {
+    const downsteps = [];
+    const moraCount = pitchString.length;
+    for (let i = 0; i < moraCount; i++) {
+        if (i > 0 && pitchString[i - 1] === 'H' && pitchString[i] === 'L') {
+            downsteps.push(i);
+        }
+    }
+    if (downsteps.length === 0) {
+        downsteps.push(-1);
+    }
+    return downsteps;
 }
 
 /**

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -1258,7 +1258,7 @@ export class Translator {
                                 const devoicePositions = this._toNumberArray(devoice);
                                 pitches.push({
                                     type: 'pitch-accent',
-                                    position,
+                                    positions: position,
                                     nasalPositions,
                                     devoicePositions,
                                     tags: tags2,

--- a/ext/js/templates/anki-template-renderer.js
+++ b/ext/js/templates/anki-template-renderer.js
@@ -555,8 +555,8 @@ export class AnkiTemplateRenderer {
             const {reading, wordClasses} = headwords[headwordIndex];
             const isVerbOrAdjective = isNonNounVerbOrAdjective(wordClasses);
             const pitches = getPronunciationsOfType(pronunciations, 'pitch-accent');
-            for (const {position} of pitches) {
-                const category = getPitchCategory(reading, position, isVerbOrAdjective);
+            for (const {positions} of pitches) {
+                const category = getPitchCategory(reading, positions, isVerbOrAdjective);
                 if (category !== null) {
                     categories.add(category);
                 }
@@ -741,12 +741,12 @@ export class AnkiTemplateRenderer {
      * @type {import('template-renderer').HelperFunction<string>}
      */
     _pronunciation(_args, _context, options) {
-        const {format, reading, downstepPosition} = options.hash;
+        const {format, reading, pitchPositions} = options.hash;
 
         if (
             typeof reading !== 'string' ||
             reading.length === 0 ||
-            typeof downstepPosition !== 'number'
+            (typeof pitchPositions !== 'number' && typeof pitchPositions !== 'string')
         ) {
             return '';
         }
@@ -757,14 +757,14 @@ export class AnkiTemplateRenderer {
             {
                 const nasalPositions = this._getValidNumberArray(options.hash.nasalPositions);
                 const devoicePositions = this._getValidNumberArray(options.hash.devoicePositions);
-                return this._getPronunciationHtml(this._pronunciationGenerator.createPronunciationText(morae, downstepPosition, nasalPositions, devoicePositions));
+                return this._getPronunciationHtml(this._pronunciationGenerator.createPronunciationText(morae, pitchPositions, nasalPositions, devoicePositions));
             }
             case 'graph':
-                return this._getPronunciationHtml(this._pronunciationGenerator.createPronunciationGraph(morae, downstepPosition));
+                return this._getPronunciationHtml(this._pronunciationGenerator.createPronunciationGraph(morae, pitchPositions));
             case 'graph-jj':
-                return this._getPronunciationHtml(this._pronunciationGenerator.createPronunciationGraphJJ(morae, downstepPosition));
+                return this._getPronunciationHtml(this._pronunciationGenerator.createPronunciationGraphJJ(morae, pitchPositions));
             case 'position':
-                return this._getPronunciationHtml(this._pronunciationGenerator.createPronunciationDownstepPosition(downstepPosition));
+                return this._getPronunciationHtml(this._pronunciationGenerator.createPronunciationDownstepPosition(pitchPositions));
             default:
                 return '';
         }

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -689,7 +689,7 @@ function createOptionsUpdatedTestData1() {
             },
         ],
         profileCurrent: 0,
-        version: 65,
+        version: 66,
         global: {
             database: {
                 prefixWildcardsSupported: false,

--- a/types/ext/anki-templates.d.ts
+++ b/types/ext/anki-templates.d.ts
@@ -88,7 +88,7 @@ export type PitchGroup = {
 export type Pitch = {
     expressions: string[];
     reading: string;
-    position: number;
+    positions: number | string;
     nasalPositions: number[];
     devoicePositions: number[];
     tags: PitchTag[];
@@ -263,7 +263,7 @@ export type TermPitchAccent = {
 };
 
 export type PitchAccent = {
-    position: number;
+    positions: number | string;
     tags: Tag[];
 };
 

--- a/types/ext/dictionary-data.d.ts
+++ b/types/ext/dictionary-data.d.ts
@@ -162,7 +162,7 @@ export type TermMetaFrequency = [
 export type TermMetaPitchData = {
     reading: string;
     pitches: {
-        position: number;
+        position: number | string;
         nasal?: number | number[];
         devoice?: number | number[];
         tags?: string[];

--- a/types/ext/dictionary.d.ts
+++ b/types/ext/dictionary.d.ts
@@ -415,7 +415,7 @@ export type PitchAccent = {
     /**
      * Position of the downstep, as a number of mora.
      */
-    position: number;
+    positions: number | string;
     /**
      * Positions of morae with a nasal sound.
      */


### PR DESCRIPTION
The current pitch downstep format disallows certain nonstandard pitches and words/phrases with multiple downsteps.

One obvious but wrong idea to fix this may be to simply allow multiple downsteps. This falls apart when trying to handle both odaka or nakadaka pitches and something non-standard like HLHHL. To cover all bases, dictionary creators must be allowed to specify exactly where they want to high and low pitches.

Test dictionary (search `打ち込む`): [test.zip](https://github.com/user-attachments/files/20788764/test.zip)
![image](https://github.com/user-attachments/assets/7024d935-d13a-412d-a2ba-df902362bba6)

Currently using `-1` for the pitch position display and handlebar if there is no downstep. And the pitch category handlebar helper will return null in this case.

This will need some tests written for it. I'll get to that at some point.