### PR TITLE
Re-inflate newlines in media for Anki when rendering templates

### DIFF
--- a/ext/js/templates/template-renderer-media-provider.js
+++ b/ext/js/templates/template-renderer-media-provider.js
@@ -56,7 +56,7 @@ export class TemplateRendererMediaProvider {
         const data = this._getMediaData(media, args, namedArgs);
         if (data !== null) {
             const result = this._getFormattedValue(data, namedArgs);
-            if (typeof result === 'string') { return result.replaceAll('\n', '<br>'); }
+            if (typeof result === 'string') { return result.replaceAll('\n', '<br>\n'); }
         }
         const defaultValue = namedArgs.default;
         return defaultValue === null || typeof defaultValue === 'string' ? defaultValue : '';

--- a/ext/js/templates/template-renderer-media-provider.js
+++ b/ext/js/templates/template-renderer-media-provider.js
@@ -56,7 +56,7 @@ export class TemplateRendererMediaProvider {
         const data = this._getMediaData(media, args, namedArgs);
         if (data !== null) {
             const result = this._getFormattedValue(data, namedArgs);
-            if (typeof result === 'string') { return result; }
+            if (typeof result === 'string') { return result.replaceAll('\n', '<br>'); }
         }
         const defaultValue = namedArgs.default;
         return defaultValue === null || typeof defaultValue === 'string' ? defaultValue : '';


### PR DESCRIPTION
Newlines in html are ignored so they need to be <br> tags for Anki.

This mainly applies to `clipboardText` and `popupSelectionText`. Other string media such as `textFurigana` shouldn't have newlines.