### PR TITLE
Add options to parse and dedupe input for the Anki Note Generator

### DIFF
--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -1832,6 +1832,11 @@ code.anki-field-marker {
     width: 100%;
 }
 
+#generate-anki-notes-buttons-wrapper {
+    display: flex;
+    justify-content: space-between;
+}
+
 .code {
     flex: 0 0 auto;
     width: 100%;

--- a/ext/js/pages/settings/anki-deck-generator-controller.js
+++ b/ext/js/pages/settings/anki-deck-generator-controller.js
@@ -93,6 +93,8 @@ export class AnkiDeckGeneratorController {
         this._defaultFieldTemplates = await this._settingsController.application.api.getDefaultAnkiFieldTemplates();
 
         /** @type {HTMLButtonElement} */
+        const parseWordsButton = querySelectorNotNull(document, '#generate-anki-notes-parse-button');
+        /** @type {HTMLButtonElement} */
         const dedupeWordsButton = querySelectorNotNull(document, '#generate-anki-notes-dedupe-button');
         /** @type {HTMLButtonElement} */
         const testRenderButton = querySelectorNotNull(document, '#generate-anki-notes-test-render-button');
@@ -110,6 +112,7 @@ export class AnkiDeckGeneratorController {
         this._sendToAnkiConfirmModal = this._modalController.getModal('generate-anki-notes-send-to-anki');
         this._exportConfirmModal = this._modalController.getModal('generate-anki-notes-export');
 
+        parseWordsButton.addEventListener('click', this._onParse.bind(this), false);
         dedupeWordsButton.addEventListener('click', this._onDedupe.bind(this), false);
         testRenderButton.addEventListener('click', this._onRender.bind(this), false);
         sendToAnkiButton.addEventListener('click', this._onSendToAnki.bind(this), false);
@@ -130,6 +133,28 @@ export class AnkiDeckGeneratorController {
     }
 
     // Private
+
+    /** */
+    async _onParse() {
+        // const words = this._wordInputTextarea.value.split('\n');
+        const options = await this._settingsController.getOptions();
+        const optionsContext = this._settingsController.getOptionsContext();
+        const parserResult = await this._application.api.parseText(this._wordInputTextarea.value, optionsContext, options.scanning.length, !options.parsing.enableMecabParser, options.parsing.enableMecabParser);
+        const parsedText = parserResult[0].content;
+
+        const parsedParts = [];
+        for (const parsedTextLine of parsedText) {
+            let combinedSegments = '';
+            for (const parsedTextSegment of parsedTextLine) {
+                combinedSegments += parsedTextSegment.text;
+            }
+            combinedSegments = combinedSegments.trim();
+            if (combinedSegments.length > 0) {
+                parsedParts.push(combinedSegments);
+            }
+        }
+        this._wordInputTextarea.value = parsedParts.join('\n');
+    }
 
     /** */
     _onDedupe() {

--- a/ext/js/pages/settings/anki-deck-generator-controller.js
+++ b/ext/js/pages/settings/anki-deck-generator-controller.js
@@ -93,6 +93,8 @@ export class AnkiDeckGeneratorController {
         this._defaultFieldTemplates = await this._settingsController.application.api.getDefaultAnkiFieldTemplates();
 
         /** @type {HTMLButtonElement} */
+        const dedupeWordsButton = querySelectorNotNull(document, '#generate-anki-notes-dedupe-button');
+        /** @type {HTMLButtonElement} */
         const testRenderButton = querySelectorNotNull(document, '#generate-anki-notes-test-render-button');
         /** @type {HTMLButtonElement} */
         const sendToAnkiButton = querySelectorNotNull(document, '#generate-anki-notes-send-to-anki-button');
@@ -108,6 +110,7 @@ export class AnkiDeckGeneratorController {
         this._sendToAnkiConfirmModal = this._modalController.getModal('generate-anki-notes-send-to-anki');
         this._exportConfirmModal = this._modalController.getModal('generate-anki-notes-export');
 
+        dedupeWordsButton.addEventListener('click', this._onDedupe.bind(this), false);
         testRenderButton.addEventListener('click', this._onRender.bind(this), false);
         sendToAnkiButton.addEventListener('click', this._onSendToAnki.bind(this), false);
         this._sendToAnkiButtonConfirmButton.addEventListener('click', this._onSendToAnkiConfirm.bind(this), false);
@@ -127,6 +130,11 @@ export class AnkiDeckGeneratorController {
     }
 
     // Private
+
+    /** */
+    _onDedupe() {
+        this._wordInputTextarea.value = [...new Set(this._wordInputTextarea.value.split('\n'))].join('\n');
+    }
 
     /** */
     async _setupModelSelection() {

--- a/ext/js/pages/settings/anki-deck-generator-controller.js
+++ b/ext/js/pages/settings/anki-deck-generator-controller.js
@@ -136,7 +136,6 @@ export class AnkiDeckGeneratorController {
 
     /** */
     async _onParse() {
-        // const words = this._wordInputTextarea.value.split('\n');
         const options = await this._settingsController.getOptions();
         const optionsContext = this._settingsController.getOptionsContext();
         const parserResult = await this._application.api.parseText(this._wordInputTextarea.value, optionsContext, options.scanning.length, !options.parsing.enableMecabParser, options.parsing.enableMecabParser);

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -1317,6 +1317,7 @@
                         <div>Active Anki model: <code id="generate-anki-notes-active-model"></code></div>
                     </div>
                     <div>
+                        <button type="button" class="low-emphasis" id="generate-anki-notes-parse-button">Parse Words</button>
                         <button type="button" class="low-emphasis" id="generate-anki-notes-dedupe-button">Dedupe Words</button>
                     </div>
                 </div>

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -1310,9 +1310,16 @@
             </div>
             <textarea autocomplete="off" spellcheck="false" id="generate-anki-notes-textarea" class="no-wrap margin-above" data-tab-action="indent,4"></textarea>
             <div class="generate-anki-notes-test-container margin-above">
-                <div>Active Anki Flashcard Format: <select id="generate-anki-flashcard-format"></select></div>
-                <div>Active Anki deck: <code id="generate-anki-notes-active-deck"></code></div>
-                <div>Active Anki model: <code id="generate-anki-notes-active-model"></code></div>
+                <div id="generate-anki-notes-buttons-wrapper">
+                    <div>
+                        <div>Active Anki Flashcard Format: <select id="generate-anki-flashcard-format"></select></div>
+                        <div>Active Anki deck: <code id="generate-anki-notes-active-deck"></code></div>
+                        <div>Active Anki model: <code id="generate-anki-notes-active-model"></code></div>
+                    </div>
+                    <div>
+                        <button type="button" class="low-emphasis" id="generate-anki-notes-dedupe-button">Dedupe Words</button>
+                    </div>
+                </div>
                 <div class="generate-anki-notes-test-table margin-above">
                     <div class="generate-anki-notes-test-table-header">Test word</div>
                     <div></div>

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -1317,8 +1317,8 @@
                         <div>Active Anki model: <code id="generate-anki-notes-active-model"></code></div>
                     </div>
                     <div>
-                        <button type="button" class="low-emphasis" id="generate-anki-notes-parse-button">Parse Words</button>
-                        <button type="button" class="low-emphasis" id="generate-anki-notes-dedupe-button">Dedupe Words</button>
+                        <button type="button" class="low-emphasis" id="generate-anki-notes-parse-button" title="Split text into a newline separated list of words">Parse Words</button>
+                        <button type="button" class="low-emphasis" id="generate-anki-notes-dedupe-button" title="Remove duplicate lines">Dedupe Words</button>
                     </div>
                 </div>
                 <div class="generate-anki-notes-test-table margin-above">


### PR DESCRIPTION
Fixes #1637

This gets asked for sometimes since migaku has a similar feature. The idea being that the user can copy/paste a block of text into the note generator, parse it, dedupe it, and generate cards.

![image](https://github.com/user-attachments/assets/6621b0a9-00bd-4829-8ddb-989e7dad9921)