### PR TITLE
Note potential data being sent on settings and add audio toggle to welcome page

### DIFF
--- a/PRIVACY-POLICY.md
+++ b/PRIVACY-POLICY.md
@@ -8,7 +8,7 @@ Some features require sending data to third party services. These features and w
 
 Required to play pronunciation audio for terms.
 
-Audio playback may send the **term, reading, and/or language** for any dictionary entry term where the `Play Audio` speaker button is pressed.
+Audio playback may send the **term, reading, and/or language** for any dictionary entry term where the `Play Audio` speaker button is pressed. Personally identifying information is never sent.
 
 The following audio sources are provided by default (availability may vary based on the selected language):
 
@@ -44,6 +44,6 @@ Local applications may request data from Yomitan through the Yomitan API for ext
 
 ## Mecab (disabled by default)
 
-[Mecab](https://taku910.github.io/mecab/) connectivity is available for text parsing. Yomitan may send **search query text** to Mecab for parsing.
+[Mecab](https://taku910.github.io/mecab/) connectivity is available for text parsing. Yomitan may send **search query text** to Mecab for parsing. Personally identifying information is never sent.
 
 Mecab does not distribute any data; all data stays on your device.

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -181,6 +181,9 @@
                         </div>
                         <div class="settings-item-description">
                             Enable support for sending local web requests to fetch data from Yomitan.
+                        </div>
+                        <div class="settings-item-description">
+                            This option may send data outside of Yomitan to local applications that request it.
                             <a tabindex="0" class="more-toggle more-only" data-parent-distance="4">More&hellip;</a>
                         </div>
                     </div>
@@ -1461,6 +1464,7 @@
             <div class="settings-item-left">
                 <div class="settings-item-label">Enable audio playback for terms</div>
                 <div class="settings-item-description">Show a clickable speaker icon next to search results.</div>
+                <div class="settings-item-description">This option may send term, reading, and/or language outside of Yomitan to fetch audio.</div>
             </div>
             <div class="settings-item-right">
                 <label class="toggle"><input type="checkbox" data-setting="audio.enabled"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
@@ -1562,8 +1566,9 @@
                     <div class="settings-item-label">
                         Parse sentences using <a href="https://en.wikipedia.org/wiki/MeCab" target="_blank" rel="noopener noreferrer">MeCab</a>
                     </div>
+                    <div class="settings-item-description">Sentence words are parsed using a third-party program. Japanese only.</div>
                     <div class="settings-item-description">
-                        Sentence words are parsed using a third-party program. Japanese only.
+                        This option may send search query data outside of Yomitan for parsing.
                         <a tabindex="0" class="more-toggle more-only" data-parent-distance="4">More&hellip;</a>
                     </div>
                 </div>
@@ -1694,6 +1699,7 @@
                     <div class="settings-item-description">
                         <span>Connection status:</span>
                         <span id="anki-error-message">&hellip;</span> <a tabindex="0" id="anki-error-message-details-toggle" hidden>Details&hellip;</a>
+                        <div class="settings-item-description">This option may send limited information about the current webpage, information contained in Yomitan dictionary entries, and/or relevant user settings outside of Yomitan to Anki.</div>
                     </div>
                 </div>
                 <div class="settings-item-right">

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -173,6 +173,16 @@
                 </select>
             </div>
         </div></div>
+        <div class="settings-item"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label">Enable audio playback for terms</div>
+                <div class="settings-item-description">Show a clickable speaker icon next to search results.</div>
+                <div class="settings-item-description">This option may send term, reading, and/or language outside of Yomitan to fetch audio.</div>
+            </div>
+            <div class="settings-item-right">
+                <label class="toggle"><input type="checkbox" data-setting="audio.enabled"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+            </div>
+        </div></div>
         <a href="/settings.html" rel="noopener" class="settings-item settings-item-button"><div class="settings-item-inner">
             <div class="settings-item-left">
                 <div class="settings-item-label">More customization options are available on the Settings page</div>

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -116,7 +116,7 @@
             <div class="settings-item-left">
                 <div class="settings-item-label">Enable audio playback for terms</div>
                 <div class="settings-item-description">Show a clickable speaker icon next to search results.</div>
-                <div class="settings-item-description">This option may send term, reading, and/or language outside of Yomitan to fetch audio.</div>
+                <div class="settings-item-description">This option may send term, reading, and/or language outside of Yomitan to fetch audio when the speaker icon is clicked. Personally identifying information is never sent.</div>
             </div>
             <div class="settings-item-right">
                 <label class="toggle"><input type="checkbox" data-setting="audio.enabled"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -109,6 +109,21 @@
         </div>
     </div>
 
+    <!-- Data Transmission -->
+    <h2><strong>Data Transmission</strong></h2>
+    <div class="settings-group">
+        <div class="settings-item"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label">Enable audio playback for terms</div>
+                <div class="settings-item-description">Show a clickable speaker icon next to search results.</div>
+                <div class="settings-item-description">This option may send term, reading, and/or language outside of Yomitan to fetch audio.</div>
+            </div>
+            <div class="settings-item-right">
+                <label class="toggle"><input type="checkbox" data-setting="audio.enabled"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+            </div>
+        </div></div>
+    </div>
+
     <h2>Here are some basics to get started</h2>
     <div class="settings-group">
         <a href="https://yomitan.wiki/" rel="noopener noreferrer" class="settings-item settings-item-button"><div class="settings-item-inner">
@@ -171,16 +186,6 @@
                     <option value="dark">Dark</option>
                     <option value="browser">Browser</option>
                 </select>
-            </div>
-        </div></div>
-        <div class="settings-item"><div class="settings-item-inner">
-            <div class="settings-item-left">
-                <div class="settings-item-label">Enable audio playback for terms</div>
-                <div class="settings-item-description">Show a clickable speaker icon next to search results.</div>
-                <div class="settings-item-description">This option may send term, reading, and/or language outside of Yomitan to fetch audio.</div>
-            </div>
-            <div class="settings-item-right">
-                <label class="toggle"><input type="checkbox" data-setting="audio.enabled"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
         <a href="/settings.html" rel="noopener" class="settings-item settings-item-button"><div class="settings-item-inner">


### PR DESCRIPTION
Mostly addresses the latest things mozilla is not happy with us about.

This is maybe missing at the moment: "If data collection starts or changes in an add-on update, or the consent and control is introduced in an update, it must be shown to all new and upgrading users."

We aren't introducing "consent and control" in this update and any handling of data is not changing. But I'm not sure the rabid privacy hounds at mozilla will see it this way. They may just want to take another bite at the billion dollar megacorp Yomitan because of the addition of the audio toggle on the welcome page possibly being seen as "consent and control is introduced".