### PR TITLE
search: fix IME composition commit triggering search

### DIFF
--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -275,7 +275,9 @@ export class SearchDisplayController {
      * @param {KeyboardEvent} e
      */
     _onSearchKeydown(e) {
-        if (e.isComposing) { return; }
+        // Keycode 229 is a special value for events processed by the IME.
+        // https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event#keydown_events_with_ime
+        if (e.isComposing || e.keyCode === 229) { return; }
         const {code, key} = e;
         if (!((code === 'Enter' || key === 'Enter' || code === 'NumpadEnter') && !e.shiftKey)) { return; }
 


### PR DESCRIPTION
IME composition commit, typically performed by pressing the Enter key, is used to finalise user input into raw text for the consumer application, which is Yomitan in this case.

On certain OS/browser/IME combinations, such as Debian Linux with Firefox/Chromium and Fcitx with Mozc the browser may emit keydown event before the actual IME composition state is updated by the browser. This means that checking solely for the isComposing state is not a reliable method in all environments.

Mozilla recommends ignoring all events with keycode 229, which is a special value used for IME-processed events. With this change proper operation is observed on both Firefox and Chromium on the same Debian setup that reproduced the issue.

https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event#keydown_events_with_ime