### PR TITLE
Add media support to Yomitan API

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -28,7 +28,7 @@ import {logErrorLevelToNumber} from '../core/log-utilities.js';
 import {log} from '../core/log.js';
 import {isObjectNotArray} from '../core/object-utilities.js';
 import {clone, deferPromise, promiseTimeout} from '../core/utilities.js';
-import {INVALID_NOTE_ID, isNoteDataValid} from '../data/anki-util.js';
+import {generateAnkiNoteMediaFileName, INVALID_NOTE_ID, isNoteDataValid} from '../data/anki-util.js';
 import {arrayBufferToBase64} from '../data/array-buffer-util.js';
 import {OptionsUtil} from '../data/options-util.js';
 import {getAllPermissions, hasPermissions, hasRequiredPermissionsForOptions} from '../data/permissions-util.js';
@@ -2361,7 +2361,7 @@ export class Backend {
 
         let extension = contentType !== null ? getFileExtensionFromAudioMediaType(contentType) : null;
         if (extension === null) { extension = '.mp3'; }
-        let fileName = this._generateAnkiNoteMediaFileName('yomitan_audio', extension, timestamp);
+        let fileName = generateAnkiNoteMediaFileName('yomitan_audio', extension, timestamp);
         fileName = fileName.replace(/\]/g, '');
         return await ankiConnect.storeMediaFile(fileName, data);
     }
@@ -2382,7 +2382,7 @@ export class Backend {
             throw new Error('Unknown media type for screenshot image');
         }
 
-        const fileName = this._generateAnkiNoteMediaFileName('yomitan_browser_screenshot', extension, timestamp);
+        const fileName = generateAnkiNoteMediaFileName('yomitan_browser_screenshot', extension, timestamp);
         return await ankiConnect.storeMediaFile(fileName, data);
     }
 
@@ -2405,7 +2405,7 @@ export class Backend {
 
         const fileName = dataUrl === this._ankiClipboardImageDataUrlCache && this._ankiClipboardImageFilenameCache ?
             this._ankiClipboardImageFilenameCache :
-            this._generateAnkiNoteMediaFileName('yomitan_clipboard_image', extension, timestamp);
+            generateAnkiNoteMediaFileName('yomitan_clipboard_image', extension, timestamp);
 
         const storedFileName = await ankiConnect.storeMediaFile(fileName, data);
 
@@ -2455,7 +2455,7 @@ export class Backend {
             if (media !== null) {
                 const {content, mediaType} = media;
                 const extension = getFileExtensionFromImageMediaType(mediaType);
-                fileName = this._generateAnkiNoteMediaFileName(
+                fileName = generateAnkiNoteMediaFileName(
                     `yomitan_dictionary_media_${i + 1}`,
                     extension !== null ? extension : '',
                     timestamp,
@@ -2533,47 +2533,6 @@ export class Backend {
             }
         }
         return error;
-    }
-
-    /**
-     * @param {string} prefix
-     * @param {string} extension
-     * @param {number} timestamp
-     * @returns {string}
-     */
-    _generateAnkiNoteMediaFileName(prefix, extension, timestamp) {
-        let fileName = prefix;
-
-        fileName += `_${this._ankNoteDateToString(new Date(timestamp))}`;
-        fileName += extension;
-
-        fileName = this._replaceInvalidFileNameCharacters(fileName);
-
-        return fileName;
-    }
-
-    /**
-     * @param {string} fileName
-     * @returns {string}
-     */
-    _replaceInvalidFileNameCharacters(fileName) {
-        // eslint-disable-next-line no-control-regex
-        return fileName.replace(/[<>:"/\\|?*\u0000-\u001F]/g, '-');
-    }
-
-    /**
-     * @param {Date} date
-     * @returns {string}
-     */
-    _ankNoteDateToString(date) {
-        const year = date.getUTCFullYear();
-        const month = date.getUTCMonth().toString().padStart(2, '0');
-        const day = date.getUTCDate().toString().padStart(2, '0');
-        const hours = date.getUTCHours().toString().padStart(2, '0');
-        const minutes = date.getUTCMinutes().toString().padStart(2, '0');
-        const seconds = date.getUTCSeconds().toString().padStart(2, '0');
-        const milliseconds = date.getUTCMilliseconds().toString().padStart(3, '0');
-        return `${year}-${month}-${day}-${hours}-${minutes}-${seconds}-${milliseconds}`;
     }
 
     /**

--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -262,24 +262,22 @@ export class YomitanApi {
      * @returns {Promise<import('anki-note-builder.js').CommonData[]>}
      */
     async _createCommonDatas(text, dictionaryEntries) {
-        /** @type {import('anki-templates.js').DictionaryMedia} */
-        const dictionaryEntriesMedia = {};
-        for (const dictionaryEntry of dictionaryEntries) {
-            const dictionaryEntryMedia = getDictionaryEntryMedia(dictionaryEntry);
-            for (const dictionaryMedia of dictionaryEntryMedia) {
-                const pathSplit = dictionaryMedia.path.split('/');
-                const dictionaryEntriesMedia2 = (
-                    Object.hasOwn(dictionaryEntriesMedia, dictionaryMedia.dictionary) ?
-                    (dictionaryEntriesMedia[dictionaryMedia.dictionary]) :
-                    (dictionaryEntriesMedia[dictionaryMedia.dictionary] = {})
-                );
-                dictionaryEntriesMedia2[dictionaryMedia.path] = {value: pathSplit[pathSplit.length - 1]};
-            }
-        }
-
         /** @type {import('anki-note-builder.js').CommonData[]} */
         const commonDatas = [];
         for (const dictionaryEntry of dictionaryEntries) {
+        /** @type {import('anki-templates.js').DictionaryMedia} */
+            const dictionaryMedia = {};
+            const dictionaryEntryMedias = getDictionaryEntryMedia(dictionaryEntry);
+            for (const dictionaryEntryMedia of dictionaryEntryMedias) {
+                const pathSplit = dictionaryEntryMedia.path.split('/');
+                const dictionaryEntryMedia2 = (
+                    Object.hasOwn(dictionaryMedia, dictionaryEntryMedia.dictionary) ?
+                    (dictionaryMedia[dictionaryEntryMedia.dictionary]) :
+                    (dictionaryMedia[dictionaryEntryMedia.dictionary] = {})
+                );
+                dictionaryEntryMedia2[dictionaryEntryMedia.path] = {value: pathSplit[pathSplit.length - 1]};
+            }
+
             commonDatas.push({
                 dictionaryEntry: dictionaryEntry,
                 resultOutputMode: 'group',
@@ -306,7 +304,7 @@ export class YomitanApi {
                 media: {
                     audio: {value: ''},
                     textFurigana: [],
-                    dictionaryMedia: dictionaryEntriesMedia,
+                    dictionaryMedia: dictionaryMedia,
                 },
                 dictionaryStylesMap: new Map(),
             });

--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -23,6 +23,7 @@ import {parseJson, readResponseJson} from '../core/json.js';
 import {log} from '../core/log.js';
 import {toError} from '../core/to-error.js';
 import {getDynamicTemplates} from '../data/anki-template-util.js';
+import {getDictionaryEntryMedia} from '../pages/settings/anki-deck-generator-controller.js';
 import {AnkiTemplateRenderer} from '../templates/anki-template-renderer.js';
 
 /** */
@@ -261,6 +262,21 @@ export class YomitanApi {
      * @returns {Promise<import('anki-note-builder.js').CommonData[]>}
      */
     async _createCommonDatas(text, dictionaryEntries) {
+        /** @type {import('anki-templates.js').DictionaryMedia} */
+        const dictionaryEntriesMedia = {};
+        for (const dictionaryEntry of dictionaryEntries) {
+            const dictionaryEntryMedia = getDictionaryEntryMedia(dictionaryEntry);
+            for (const dictionaryMedia of dictionaryEntryMedia) {
+                const pathSplit = dictionaryMedia.path.split('/');
+                const dictionaryEntriesMedia2 = (
+                    Object.hasOwn(dictionaryEntriesMedia, dictionaryMedia.dictionary) ?
+                    (dictionaryEntriesMedia[dictionaryMedia.dictionary]) :
+                    (dictionaryEntriesMedia[dictionaryMedia.dictionary] = {})
+                );
+                dictionaryEntriesMedia2[dictionaryMedia.path] = {value: pathSplit[pathSplit.length - 1]};
+            }
+        }
+
         /** @type {import('anki-note-builder.js').CommonData[]} */
         const commonDatas = [];
         for (const dictionaryEntry of dictionaryEntries) {
@@ -286,6 +302,11 @@ export class YomitanApi {
                         text: text,
                         offset: 0,
                     },
+                },
+                media: {
+                    audio: {value: ''},
+                    textFurigana: [],
+                    dictionaryMedia: dictionaryEntriesMedia,
                 },
                 dictionaryStylesMap: new Map(),
             });

--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -408,7 +408,7 @@ export class YomitanApi {
                     query: text,
                     fullQuery: text,
                     sentence: {
-                        text: text,
+                        text: '',
                         offset: 0,
                     },
                 },

--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -187,7 +187,7 @@ export class YomitanApi {
                         if (maxEntries > 0) {
                             dictionaryEntries = dictionaryEntries.slice(0, maxEntries);
                         }
-                        const dictionaryMedia = await this._fetchMedia(dictionaryEntries);
+                        const dictionaryMedia = await this._fetchDictionaryMedia(dictionaryEntries);
                         const commonDatas = await this._createCommonDatas(text, dictionaryEntries, dictionaryMedia);
                         // @ts-expect-error - `parseHTML` can return `null` but this input has been validated to not be `null`
                         const domlessDocument = parseHTML('').document;
@@ -266,7 +266,7 @@ export class YomitanApi {
      * @param {import('dictionary.js').DictionaryEntry[]} dictionaryEntries
      * @returns {Promise<import('yomitan-api.js').apiMediaDetails[]>}
      */
-    async _fetchMedia(dictionaryEntries) {
+    async _fetchDictionaryMedia(dictionaryEntries) {
         const media = [];
         let mediaCount = 0;
         for (const dictionaryEntry of dictionaryEntries) {

--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -187,8 +187,8 @@ export class YomitanApi {
                         if (maxEntries > 0) {
                             dictionaryEntries = dictionaryEntries.slice(0, maxEntries);
                         }
-                        const media = await this._fetchMedia(dictionaryEntries);
-                        const commonDatas = await this._createCommonDatas(text, dictionaryEntries, media);
+                        const dictionaryMedia = await this._fetchMedia(dictionaryEntries);
+                        const commonDatas = await this._createCommonDatas(text, dictionaryEntries, dictionaryMedia);
                         // @ts-expect-error - `parseHTML` can return `null` but this input has been validated to not be `null`
                         const domlessDocument = parseHTML('').document;
                         // @ts-expect-error - `parseHTML` can return `null` but this input has been validated to not be `null`
@@ -208,7 +208,10 @@ export class YomitanApi {
                             }
                             ankiFieldsResults.push(ankiFieldsResult);
                         }
-                        result = ankiFieldsResults;
+                        result = {
+                            fields: ankiFieldsResults,
+                            dictionaryMedia: dictionaryMedia,
+                        };
                         break;
                     }
                     default:

--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -137,7 +137,10 @@ export class YomitanApi {
 
             try {
                 /** @type {?object} */
-                const parsedBody = body.length > 0 ? parseJson(body) : null;
+                const parsedBody = body.length > 0 ? parseJson(body) : {};
+                if (parsedBody === null) {
+                    throw new Error('Invalid request body');
+                }
 
                 let result = null;
                 let statusCode = 200;

--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -23,6 +23,8 @@ import {parseJson, readResponseJson} from '../core/json.js';
 import {log} from '../core/log.js';
 import {toError} from '../core/to-error.js';
 import {getDynamicTemplates} from '../data/anki-template-util.js';
+import {generateAnkiNoteMediaFileName} from '../data/anki-util.js';
+import {getFileExtensionFromImageMediaType} from '../media/media-util.js';
 import {getDictionaryEntryMedia} from '../pages/settings/anki-deck-generator-controller.js';
 import {AnkiTemplateRenderer} from '../templates/anki-template-renderer.js';
 
@@ -264,18 +266,21 @@ export class YomitanApi {
     async _createCommonDatas(text, dictionaryEntries) {
         /** @type {import('anki-note-builder.js').CommonData[]} */
         const commonDatas = [];
+        let mediaCount = 0;
         for (const dictionaryEntry of dictionaryEntries) {
-        /** @type {import('anki-templates.js').DictionaryMedia} */
+            /** @type {import('anki-templates.js').DictionaryMedia} */
             const dictionaryMedia = {};
             const dictionaryEntryMedias = getDictionaryEntryMedia(dictionaryEntry);
             for (const dictionaryEntryMedia of dictionaryEntryMedias) {
-                const pathSplit = dictionaryEntryMedia.path.split('/');
+                const timestamp = Date.now();
+                const ankiFilename = generateAnkiNoteMediaFileName(`yomitan_dictionary_media_${mediaCount}`, getFileExtensionFromImageMediaType(dictionaryEntryMedia.path) ?? '', timestamp);
+                mediaCount += 1;
                 const dictionaryEntryMedia2 = (
                     Object.hasOwn(dictionaryMedia, dictionaryEntryMedia.dictionary) ?
                     (dictionaryMedia[dictionaryEntryMedia.dictionary]) :
                     (dictionaryMedia[dictionaryEntryMedia.dictionary] = {})
                 );
-                dictionaryEntryMedia2[dictionaryEntryMedia.path] = {value: pathSplit[pathSplit.length - 1]};
+                dictionaryEntryMedia2[dictionaryEntryMedia.path] = {value: ankiFilename};
             }
 
             commonDatas.push({

--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -272,8 +272,15 @@ export class YomitanApi {
             const dictionaryMedia = {};
             const dictionaryEntryMedias = getDictionaryEntryMedia(dictionaryEntry);
             for (const dictionaryEntryMedia of dictionaryEntryMedias) {
+                const mediaRequestTargets = [{
+                    path: dictionaryEntryMedia.path,
+                    dictionary: dictionaryEntryMedia.dictionary,
+                }];
+                const mediaFileData = await this._invoke('getMedia', {
+                    targets: mediaRequestTargets,
+                });
                 const timestamp = Date.now();
-                const ankiFilename = generateAnkiNoteMediaFileName(`yomitan_dictionary_media_${mediaCount}`, getFileExtensionFromImageMediaType(dictionaryEntryMedia.path) ?? '', timestamp);
+                const ankiFilename = generateAnkiNoteMediaFileName(`yomitan_dictionary_media_${mediaCount}`, getFileExtensionFromImageMediaType(mediaFileData[0].mediaType) ?? '', timestamp);
                 mediaCount += 1;
                 const dictionaryEntryMedia2 = (
                     Object.hasOwn(dictionaryMedia, dictionaryEntryMedia.dictionary) ?

--- a/ext/js/core/utilities.js
+++ b/ext/js/core/utilities.js
@@ -282,36 +282,3 @@ export function sanitizeCSS(css) {
 export function addScopeToCss(css, scopeSelector) {
     return scopeSelector + ' {' + css + '\n}';
 }
-
-/**
- * Older browser versions do not support nested css and cannot use the normal `addScopeToCss`.
- * All major web browsers should be fine but Anki is still distributing Chromium 112 on some platforms as of Anki version 24.11.
- * Chromium 120+ is required for full support.
- * @param {string} css
- * @param {string} scopeSelector
- * @returns {string}
- */
-export function addScopeToCssLegacy(css, scopeSelector) {
-    const stylesheet = new CSSStyleSheet();
-    // nodejs must fall back to the normal version of the function
-    if (typeof stylesheet.replaceSync === 'undefined') {
-        return addScopeToCss(css, scopeSelector);
-    }
-    stylesheet.replaceSync(css);
-    const newCSSRules = [];
-    for (const cssRule of stylesheet.cssRules) {
-        // ignore non-style rules
-        if (!(cssRule instanceof CSSStyleRule)) {
-            continue;
-        }
-
-        const newSelectors = [];
-        for (const selector of cssRule.selectorText.split(',')) {
-            newSelectors.push(scopeSelector + ' ' + selector);
-        }
-        const newRule = cssRule.cssText.replace(cssRule.selectorText, newSelectors.join(', '));
-        newCSSRules.push(newRule);
-    }
-    stylesheet.replaceSync(newCSSRules.join('\n'));
-    return [...stylesheet.cssRules].map((rule) => rule.cssText || '').join('\n');
-}

--- a/ext/js/data/anki-note-builder.js
+++ b/ext/js/data/anki-note-builder.js
@@ -521,70 +521,70 @@ export class AnkiNoteBuilder {
                 break;
             }
             if (data !== null) {
-                const valueHtml = this._createFuriganaHtml(data, readingMode);
-                const valuePlain = this._createFuriganaPlain(data, readingMode);
+                const valueHtml = createFuriganaHtml(data, readingMode);
+                const valuePlain = createFuriganaPlain(data, readingMode);
                 results.push({text, readingMode, detailsHtml: {value: valueHtml}, detailsPlain: {value: valuePlain}});
             }
         }
         return results;
     }
+}
 
-    /**
-     * @param {import('api').ParseTextLine[]} data
-     * @param {?import('anki-templates').TextFuriganaReadingMode} readingMode
-     * @returns {string}
-     */
-    _createFuriganaHtml(data, readingMode) {
-        let result = '';
-        for (const term of data) {
-            result += '<span class="term">';
-            for (const {text, reading} of term) {
-                if (reading.length > 0) {
-                    const reading2 = this._convertReading(reading, readingMode);
-                    result += `<ruby>${text}<rt>${reading2}</rt></ruby>`;
-                } else {
-                    result += text;
-                }
-            }
-            result += '</span>';
-        }
-        return result;
-    }
-
-    /**
-     * @param {import('api').ParseTextLine[]} data
-     * @param {?import('anki-templates').TextFuriganaReadingMode} readingMode
-     * @returns {string}
-     */
-    _createFuriganaPlain(data, readingMode) {
-        let result = '';
-        for (const term of data) {
-            for (const {text, reading} of term) {
-                if (reading.length > 0) {
-                    const reading2 = this._convertReading(reading, readingMode);
-                    result += ` ${text}[${reading2}]`;
-                } else {
-                    result += text;
-                }
+/**
+ * @param {import('api').ParseTextLine[]} data
+ * @param {?import('anki-templates').TextFuriganaReadingMode} readingMode
+ * @returns {string}
+ */
+export function createFuriganaHtml(data, readingMode) {
+    let result = '';
+    for (const term of data) {
+        result += '<span class="term">';
+        for (const {text, reading} of term) {
+            if (reading.length > 0) {
+                const reading2 = convertReading(reading, readingMode);
+                result += `<ruby>${text}<rt>${reading2}</rt></ruby>`;
+            } else {
+                result += text;
             }
         }
-        result = result.trimStart();
-        return result;
+        result += '</span>';
     }
+    return result;
+}
 
-    /**
-     * @param {string} reading
-     * @param {?import('anki-templates').TextFuriganaReadingMode} readingMode
-     * @returns {string}
-     */
-    _convertReading(reading, readingMode) {
-        switch (readingMode) {
-            case 'hiragana':
-                return convertKatakanaToHiragana(reading);
-            case 'katakana':
-                return convertHiraganaToKatakana(reading);
-            default:
-                return reading;
+/**
+ * @param {import('api').ParseTextLine[]} data
+ * @param {?import('anki-templates').TextFuriganaReadingMode} readingMode
+ * @returns {string}
+ */
+export function createFuriganaPlain(data, readingMode) {
+    let result = '';
+    for (const term of data) {
+        for (const {text, reading} of term) {
+            if (reading.length > 0) {
+                const reading2 = convertReading(reading, readingMode);
+                result += ` ${text}[${reading2}]`;
+            } else {
+                result += text;
+            }
         }
+    }
+    result = result.trimStart();
+    return result;
+}
+
+/**
+ * @param {string} reading
+ * @param {?import('anki-templates').TextFuriganaReadingMode} readingMode
+ * @returns {string}
+ */
+function convertReading(reading, readingMode) {
+    switch (readingMode) {
+        case 'hiragana':
+            return convertKatakanaToHiragana(reading);
+        case 'katakana':
+            return convertHiraganaToKatakana(reading);
+        default:
+            return reading;
     }
 }

--- a/ext/js/data/anki-note-data-creator.js
+++ b/ext/js/data/anki-note-data-creator.js
@@ -17,7 +17,7 @@
  */
 
 import {getAnkiCompactGlossStyles} from '../../data/anki-compact-gloss-style.js';
-import {addScopeToCssLegacy} from '../core/utilities.js';
+import {addScopeToCss} from '../core/utilities.js';
 import {getDisambiguations, getGroupedPronunciations, getPronunciationsOfType, getTermFrequency, groupTermTags} from '../dictionary/dictionary-data-util.js';
 import {distributeFurigana, distributeFuriganaInflected} from '../language/ja/japanese.js';
 
@@ -589,7 +589,7 @@ function getTermDictionaryEntryCommonInfo(dictionaryEntry, type, dictionaryStyle
  * @returns {string}
  */
 function addGlossaryScopeToCss(css) {
-    return addScopeToCssLegacy(css, '.yomitan-glossary');
+    return addScopeToCss(css, '.yomitan-glossary');
 }
 
 /**
@@ -602,7 +602,7 @@ function addDictionaryScopeToCss(css, dictionaryTitle) {
         .replace(/\\/g, '\\\\')
         .replace(/"/g, '\\"');
 
-    return addScopeToCssLegacy(css, `[data-dictionary="${escapedTitle}"]`);
+    return addScopeToCss(css, `[data-dictionary="${escapedTitle}"]`);
 }
 
 /**

--- a/ext/js/data/anki-util.js
+++ b/ext/js/data/anki-util.js
@@ -84,3 +84,45 @@ export function isNoteDataValid(note) {
 }
 
 export const INVALID_NOTE_ID = -1;
+
+
+/**
+ * @param {string} prefix
+ * @param {string} extension
+ * @param {number} timestamp
+ * @returns {string}
+ */
+export function generateAnkiNoteMediaFileName(prefix, extension, timestamp) {
+    let fileName = prefix;
+
+    fileName += `_${ankNoteDateToString(new Date(timestamp))}`;
+    fileName += extension;
+
+    fileName = replaceInvalidFileNameCharacters(fileName);
+
+    return fileName;
+}
+
+/**
+ * @param {string} fileName
+ * @returns {string}
+ */
+function replaceInvalidFileNameCharacters(fileName) {
+    // eslint-disable-next-line no-control-regex
+    return fileName.replace(/[<>:"/\\|?*\u0000-\u001F]/g, '-');
+}
+
+/**
+ * @param {Date} date
+ * @returns {string}
+ */
+function ankNoteDateToString(date) {
+    const year = date.getUTCFullYear();
+    const month = date.getUTCMonth().toString().padStart(2, '0');
+    const day = date.getUTCDate().toString().padStart(2, '0');
+    const hours = date.getUTCHours().toString().padStart(2, '0');
+    const minutes = date.getUTCMinutes().toString().padStart(2, '0');
+    const seconds = date.getUTCSeconds().toString().padStart(2, '0');
+    const milliseconds = date.getUTCMilliseconds().toString().padStart(3, '0');
+    return `${year}-${month}-${day}-${hours}-${minutes}-${seconds}-${milliseconds}`;
+}

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -26,7 +26,7 @@ import {ExtensionError} from '../core/extension-error.js';
 import {log} from '../core/log.js';
 import {safePerformance} from '../core/safe-performance.js';
 import {toError} from '../core/to-error.js';
-import {addScopeToCssLegacy, clone, deepEqual, promiseTimeout} from '../core/utilities.js';
+import {addScopeToCss, clone, deepEqual, promiseTimeout} from '../core/utilities.js';
 import {setProfile} from '../data/profiles-util.js';
 import {PopupMenu} from '../dom/popup-menu.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
@@ -1260,7 +1260,7 @@ export class Display extends EventDispatcher {
         for (const {name, enabled, styles = ''} of dictionaries) {
             if (enabled) {
                 const escapedTitle = name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-                customCss += '\n' + addScopeToCssLegacy(styles, `[data-dictionary="${escapedTitle}"]`);
+                customCss += '\n' + addScopeToCss(styles, `[data-dictionary="${escapedTitle}"]`);
             }
         }
         this.setCustomCss(customCss);

--- a/ext/js/pages/settings/anki-deck-generator-controller.js
+++ b/ext/js/pages/settings/anki-deck-generator-controller.js
@@ -607,6 +607,7 @@ export function getDictionaryEntryMedia(dictionaryEntry) {
     if (dictionaryEntry.type !== 'term') {
         return [];
     }
+    /** @type {Array<import('anki-note-builder').RequirementDictionaryMedia>} */
     const media = [];
     const definitions = dictionaryEntry.definitions;
     for (const definition of definitions) {

--- a/ext/js/pages/settings/anki-deck-generator-controller.js
+++ b/ext/js/pages/settings/anki-deck-generator-controller.js
@@ -611,7 +611,7 @@ export function getDictionaryEntryMedia(dictionaryEntry) {
     const media = [];
     const definitions = dictionaryEntry.definitions;
     for (const definition of definitions) {
-        const paths = findAllPaths(definition);
+        const paths = [...new Set(findAllPaths(definition))];
         for (const path of paths) {
             media.push({dictionary: definition.dictionary, path: path, type: 'dictionaryMedia'});
         }

--- a/types/ext/yomitan-api.d.ts
+++ b/types/ext/yomitan-api.d.ts
@@ -35,12 +35,20 @@ export type remoteVersionResponse = {
     version: number;
 };
 
-export type apiMediaDetails = {
+export type apiDictionaryMediaDetails = {
     dictionary: string;
     path: string;
     mediaType: string;
     width: number;
     height: number;
     content: TContentType;
+    ankiFilename: string;
+};
+
+export type apiAudioMediaDetails = {
+    term: string;
+    reading: string;
+    mediaType: string;
+    content: AudioBinaryBase64;
     ankiFilename: string;
 };

--- a/types/ext/yomitan-api.d.ts
+++ b/types/ext/yomitan-api.d.ts
@@ -28,6 +28,7 @@ export type ankiFieldsInput = {
     type: 'term' | 'kanji';
     markers: [string];
     maxEntries: number;
+    includeMedia?: boolean;
 };
 
 export type remoteVersionResponse = {

--- a/types/ext/yomitan-api.d.ts
+++ b/types/ext/yomitan-api.d.ts
@@ -33,3 +33,13 @@ export type ankiFieldsInput = {
 export type remoteVersionResponse = {
     version: number;
 };
+
+export type apiMediaDetails = {
+    dictionary: string;
+    path: string;
+    mediaType: string;
+    width: number;
+    height: number;
+    content: TContentType;
+    ankiFilename: string;
+};


### PR DESCRIPTION
**This is a breaking change.** Previously, `ankiFields` returned an array of fields matching what was requested. This makes it unreasonable to include any extra data. Considering the API is still rather new it seems silly to add in jank to preserve compatibility. The new structure is:

```json
{
    "fields": [],
    "dictionaryMedia": [],
    "audioMedia": []
}
```

Users migrating from the old format will simply have to access the `fields` field instead of accessing the returned json object directly. Full documentation on the new format is here https://github.com/Kuuuube/yomitan-api/pull/2.

A few notes on these changes:
1. `addScopeToCssLegacy` has been removed due to causing issues with the api's domless requirements. This was added as a workaround for Anki due to it shipping with an incredibly old version of Chromium incapable of handling the full CSS nesting used in `addScopeToCss`. Anki has since updated and has supported this for about 6 months now. It seems like a good time to let this go.
2. `generateAnkiNoteMediaFileName`, `createFuriganaHtml`, `createFuriganaPlain`, and `getDictionaryEntryMedia` have been moved out of their classes to allow the API to access them. They are all stateless functions and do not require a class.
