### PR TITLE
Dedupe media in ankiFields api requests

### DIFF
--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -285,6 +285,7 @@ export class YomitanApi {
      * @returns {Promise<import('yomitan-api.js').apiDictionaryMediaDetails[]>}
      */
     async _fetchDictionaryMedia(dictionaryEntries) {
+        /** @type {import('yomitan-api.js').apiDictionaryMediaDetails[]} */
         const media = [];
         let mediaCount = 0;
         for (const dictionaryEntry of dictionaryEntries) {
@@ -294,6 +295,7 @@ export class YomitanApi {
                 targets: mediaRequestTargets,
             });
             for (const mediaFileData of mediaFilesData) {
+                if (media.some((x) => x.dictionary === mediaFileData.dictionary && x.path === mediaFileData.path)) { continue; }
                 const timestamp = Date.now();
                 const ankiFilename = generateAnkiNoteMediaFileName(`yomitan_dictionary_media_${mediaCount}`, getFileExtensionFromImageMediaType(mediaFileData.mediaType) ?? '', timestamp);
                 media.push({


### PR DESCRIPTION
Some dicts (such as pixiv dict) contain the same images in every entry. Yomitan typically does not send more than one entry when creating cards so this is not an issue. But with the API, users may request many entries at once.