### PR TITLE
Allow disabling default audio sources

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -407,7 +407,8 @@
                                     "volume",
                                     "autoPlay",
                                     "fallbackSoundType",
-                                    "sources"
+                                    "sources",
+                                    "enableDefaultAudioSources"
                                 ],
                                 "properties": {
                                     "enabled": {
@@ -466,6 +467,10 @@
                                             }
                                         },
                                         "default": []
+                                    },
+                                    "enableDefaultAudioSources": {
+                                        "type": "boolean",
+                                        "default": true
                                     }
                                 }
                             },

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -2339,7 +2339,7 @@ export class Backend {
         const {term, reading} = definitionDetails;
         if (term.length === 0 && reading.length === 0) { return null; }
 
-        const {sources, preferredAudioIndex, idleTimeout, languageSummary} = details;
+        const {sources, preferredAudioIndex, idleTimeout, languageSummary, enableDefaultAudioSources} = details;
         let data;
         let contentType;
         try {
@@ -2350,6 +2350,7 @@ export class Backend {
                 reading,
                 idleTimeout,
                 languageSummary,
+                enableDefaultAudioSources,
             ));
         } catch (e) {
             const error = this._getAudioDownloadError(e);

--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -328,7 +328,7 @@ export class YomitanApi {
             if (dictionaryEntry.type === 'kanji') { continue; }
             const headword = dictionaryEntry.headwords[0]; // Only one headword is accepted for Anki card creation
             try {
-                const audioData = await this._audioDownloader.downloadTermAudio(options.audio.sources, null, headword.term, headword.reading, idleTimeout, languageSummary);
+                const audioData = await this._audioDownloader.downloadTermAudio(options.audio.sources, null, headword.term, headword.reading, idleTimeout, languageSummary, options.audio.enableDefaultAudioSources);
                 const timestamp = Date.now();
                 const mediaType = audioData.contentType ?? '';
                 let extension = mediaType !== null ? getFileExtensionFromAudioMediaType(mediaType) : null;

--- a/ext/js/data/anki-note-builder.js
+++ b/ext/js/data/anki-note-builder.js
@@ -437,8 +437,8 @@ export class AnkiNoteBuilder {
         if (injectAudio && dictionaryEntryDetails.type !== 'kanji') {
             const audioOptions = mediaOptions.audio;
             if (typeof audioOptions === 'object' && audioOptions !== null) {
-                const {sources, preferredAudioIndex, idleTimeout, languageSummary} = audioOptions;
-                audioDetails = {sources, preferredAudioIndex, idleTimeout, languageSummary};
+                const {sources, preferredAudioIndex, idleTimeout, languageSummary, enableDefaultAudioSources} = audioOptions;
+                audioDetails = {sources, preferredAudioIndex, idleTimeout, languageSummary, enableDefaultAudioSources};
             }
         }
         if (injectScreenshot) {

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -580,6 +580,7 @@ export class OptionsUtil {
             this._updateVersion66,
             this._updateVersion67,
             this._updateVersion68,
+            this._updateVersion69,
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1761,6 +1762,16 @@ export class OptionsUtil {
      */
     async _updateVersion68(options) {
         await this._applyAnkiFieldTemplatesPatch(options, '/data/templates/anki-field-templates-upgrade-v68.handlebars');
+    }
+
+    /**
+     *  - Added audio.enableDefaultAudioSources
+     *  @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion69(options) {
+        for (const profile of options.profiles) {
+            profile.options.audio.enableDefaultAudioSources = true;
+        }
     }
 
     /**

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -1065,13 +1065,14 @@ export class DisplayAnki {
      */
     _getAnkiNoteMediaAudioDetails(details) {
         if (details.type !== 'term') { return null; }
-        const {sources, preferredAudioIndex} = this._displayAudio.getAnkiNoteMediaAudioDetails(details.term, details.reading);
+        const {sources, preferredAudioIndex, enableDefaultAudioSources} = this._displayAudio.getAnkiNoteMediaAudioDetails(details.term, details.reading);
         const languageSummary = this._display.getLanguageSummary();
         return {
             sources,
             preferredAudioIndex,
             idleTimeout: this._audioDownloadIdleTimeout,
             languageSummary,
+            enableDefaultAudioSources,
         };
     }
 

--- a/ext/js/display/display-audio.js
+++ b/ext/js/display/display-audio.js
@@ -67,6 +67,8 @@ export class DisplayAudio {
             ['custom', 'Custom URL'],
             ['custom-json', 'Custom URL (JSON)'],
         ]);
+        /** @type {?boolean} */
+        this._enableDefaultAudioSources = null;
         /** @type {(event: MouseEvent) => void} */
         this._onAudioPlayButtonClickBind = this._onAudioPlayButtonClick.bind(this);
         /** @type {(event: MouseEvent) => void} */
@@ -160,7 +162,8 @@ export class DisplayAudio {
                 sources.push(this._getSourceData(source));
             }
         }
-        return {sources, preferredAudioIndex};
+        const enableDefaultAudioSources = this._enableDefaultAudioSources ?? false;
+        return {sources, preferredAudioIndex, enableDefaultAudioSources};
     }
 
     // Private
@@ -171,14 +174,15 @@ export class DisplayAudio {
     _onOptionsUpdated({options}) {
         const {
             general: {language},
-            audio: {enabled, autoPlay, fallbackSoundType, volume, sources},
+            audio: {enabled, autoPlay, fallbackSoundType, volume, sources, enableDefaultAudioSources},
         } = options;
         this._autoPlay = enabled && autoPlay;
         this._fallbackSoundType = fallbackSoundType;
         this._playbackVolume = Number.isFinite(volume) ? Math.max(0, Math.min(1, volume / 100)) : 1;
+        this._enableDefaultAudioSources = enableDefaultAudioSources;
 
         /** @type {Set<import('settings').AudioSourceType>} */
-        const requiredAudioSources = getRequiredAudioSourceList(language);
+        const requiredAudioSources = enableDefaultAudioSources ? getRequiredAudioSourceList(language) : new Set();
         /** @type {Map<string, import('display-audio').AudioSource[]>} */
         const nameMap = new Map();
         this._audioSources.length = 0;

--- a/ext/js/display/display-audio.js
+++ b/ext/js/display/display-audio.js
@@ -19,6 +19,7 @@
 import {EventListenerCollection} from '../core/event-listener-collection.js';
 import {PopupMenu} from '../dom/popup-menu.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
+import {getRequiredAudioSourceList} from '../media/audio-downloader.js';
 import {AudioSystem} from '../media/audio-system.js';
 
 export class DisplayAudio {
@@ -177,7 +178,7 @@ export class DisplayAudio {
         this._playbackVolume = Number.isFinite(volume) ? Math.max(0, Math.min(1, volume / 100)) : 1;
 
         /** @type {Set<import('settings').AudioSourceType>} */
-        const requiredAudioSources = this._getRequiredAudioSources(language);
+        const requiredAudioSources = getRequiredAudioSourceList(language);
         /** @type {Map<string, import('display-audio').AudioSource[]>} */
         const nameMap = new Map();
         this._audioSources.length = 0;
@@ -193,24 +194,6 @@ export class DisplayAudio {
         data.audioEnabled = enabled.toString();
 
         this._cache.clear();
-    }
-
-    /**
-     * @param {string} language
-     * @returns {Set<import('settings').AudioSourceType>}
-     */
-    _getRequiredAudioSources(language) {
-        return language === 'ja' ?
-            new Set([
-                'jpod101',
-                'language-pod-101',
-                'jisho',
-            ]) :
-            new Set([
-                'lingua-libre',
-                'language-pod-101',
-                'wiktionary',
-            ]);
     }
 
     /** */

--- a/ext/js/media/audio-downloader.js
+++ b/ext/js/media/audio-downloader.js
@@ -123,17 +123,7 @@ export class AudioDownloader {
      */
     _getRequiredAudioSources(language, sources) {
         /** @type {Set<import('settings').AudioSourceType>} */
-        const requiredSources = language === 'ja' ?
-            new Set([
-                'jpod101',
-                'language-pod-101',
-                'jisho',
-            ]) :
-            new Set([
-                'lingua-libre',
-                'language-pod-101',
-                'wiktionary',
-            ]);
+        const requiredSources = getRequiredAudioSourceList(language);
 
         for (const {type} of sources) {
             requiredSources.delete(type);
@@ -636,4 +626,22 @@ export class AudioDownloader {
         });
         return await readResponseJson(response);
     }
+}
+
+/**
+ * @param {string} language
+ * @returns {Set<import('settings').AudioSourceType>}
+ */
+export function getRequiredAudioSourceList(language) {
+    return language === 'ja' ?
+        new Set([
+            'jpod101',
+            'language-pod-101',
+            'jisho',
+        ]) :
+        new Set([
+            'lingua-libre',
+            'language-pod-101',
+            'wiktionary',
+        ]);
 }

--- a/ext/js/media/audio-downloader.js
+++ b/ext/js/media/audio-downloader.js
@@ -86,11 +86,12 @@ export class AudioDownloader {
      * @param {string} reading
      * @param {?number} idleTimeout
      * @param {import('language').LanguageSummary} languageSummary
+     * @param {boolean} enableDefaultAudioSources
      * @returns {Promise<import('audio-downloader').AudioBinaryBase64>}
      */
-    async downloadTermAudio(sources, preferredAudioIndex, term, reading, idleTimeout, languageSummary) {
+    async downloadTermAudio(sources, preferredAudioIndex, term, reading, idleTimeout, languageSummary, enableDefaultAudioSources) {
         const errors = [];
-        const requiredAudioSources = this._getRequiredAudioSources(languageSummary.iso, sources);
+        const requiredAudioSources = enableDefaultAudioSources ? this._getRequiredAudioSources(languageSummary.iso, sources) : [];
         for (const source of [...sources, ...requiredAudioSources]) {
             let infoList = await this.getTermAudioInfoList(source, term, reading, languageSummary);
             if (typeof preferredAudioIndex === 'number') {

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -637,6 +637,17 @@
             <div class="settings-item">
                 <div class="settings-item-inner">
                     <div class="settings-item-left">
+                        <div class="settings-item-label">Enable Default Audio Sources</div>
+                        <div class="settings-item-description" id="default-audio-sources-settings-list"></div>
+                    </div>
+                    <div class="settings-item-right">
+                        <label class="toggle"><input type="checkbox" data-setting="audio.enableDefaultAudioSources"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                    </div>
+                </div>
+            </div>
+            <div class="settings-item">
+                <div class="settings-item-inner">
+                    <div class="settings-item-left">
                         <div class="settings-item-label">
                             When searching for audio, the sources are checked in order until the first
                             valid source is found. This allows for selecting a fallback source if the

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -690,7 +690,7 @@ function createOptionsUpdatedTestData1() {
             },
         ],
         profileCurrent: 0,
-        version: 68,
+        version: 69,
         global: {
             database: {
                 prefixWildcardsSupported: false,

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -342,6 +342,7 @@ function createProfileOptionsUpdatedTestData1() {
             volume: 100,
             autoPlay: false,
             fallbackSoundType: 'click',
+            enableDefaultAudioSources: true,
         },
         scanning: {
             selectText: true,

--- a/types/ext/anki-note-builder.d.ts
+++ b/types/ext/anki-note-builder.d.ts
@@ -94,6 +94,7 @@ export type AudioMediaOptions = {
     preferredAudioIndex: number | null;
     idleTimeout: number | null;
     languageSummary: Language.LanguageSummary;
+    enableDefaultAudioSources: boolean;
 };
 
 export type MediaOptions = {

--- a/types/ext/display-audio.d.ts
+++ b/types/ext/display-audio.d.ts
@@ -70,6 +70,7 @@ export type AudioSourceShort = {
 export type AudioMediaOptions = {
     sources: Audio.AudioSourceInfo[];
     preferredAudioIndex: number | null;
+    enableDefaultAudioSources: boolean;
 };
 
 export type PlayAudioResult = {

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -171,6 +171,7 @@ export type AudioOptions = {
     autoPlay: boolean;
     fallbackSoundType: FallbackSoundType;
     sources: AudioSourceOptions[];
+    enableDefaultAudioSources: boolean;
 };
 
 export type FallbackSoundType = 'none' | 'click' | 'bloop';


### PR DESCRIPTION
Fixes #2096

Although somewhat intentional... regression caused by #1152.

Not exposing options to individually turn each source on/off. It's extremely easy for users to disable default sources and add back the ones they want. And having a toggle for all of them at once avoids any issues with how to handle different languages having different audio sources assigned to them.

<img width="592" height="396" alt="image" src="https://github.com/user-attachments/assets/ecf24cb3-c34c-4fbf-8a98-0e9e7b242165" />
