### PR TITLE
Return empty string for audio when not available on `ankiFields` api path

### DIFF
--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -415,7 +415,7 @@ export class YomitanApi {
                     },
                 },
                 media: {
-                    audio: {value: audioMediaFile},
+                    audio: audioMediaFile.length > 0 ? {value: audioMediaFile} : void 0,
                     textFurigana: [{
                         text: text,
                         readingMode: furiganaReadingMode,


### PR DESCRIPTION
Fixes #2095

`void 0` just equals undefined. https://eslint.org/docs/latest/rules/no-undefined