### PR TITLE
Check chrome.omnibox before trying to set the listener

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1491,6 +1491,7 @@ export class Backend {
     /** */
     _attachOmniboxListener() {
         try {
+            if (!chrome.omnibox) { return; }
             chrome.omnibox.onInputEntered.addListener((text) => {
                 const newURL = 'search.html?query=' + encodeURIComponent(text);
                 void chrome.tabs.create({url: newURL});


### PR DESCRIPTION
Fixes #2093

Nothing technically broken here just stops it from throwing an error if undefined as it will always be undefined in some cases such as firefox android.