### PR TITLE
Change default Yomitan API port to 19633

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -345,7 +345,7 @@
                                     },
                                     "yomitanApiServer": {
                                         "type": "string",
-                                        "default": "http://127.0.0.1:8766"
+                                        "default": "http://127.0.0.1:19633"
                                     }
                                 }
                             },

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -580,6 +580,7 @@ export class OptionsUtil {
             this._updateVersion66,
             this._updateVersion67,
             this._updateVersion68,
+            this._updateVersion69,
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1761,6 +1762,16 @@ export class OptionsUtil {
      */
     async _updateVersion68(options) {
         await this._applyAnkiFieldTemplatesPatch(options, '/data/templates/anki-field-templates-upgrade-v68.handlebars');
+    }
+
+    /**
+     *  - Change default Yomitan API port to 19633
+     *  @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion69(options) {
+        for (const profile of options.profiles) {
+            profile.options.general.yomitanApiServer = 'http://127.0.0.1:19633';
+        }
     }
 
     /**

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -198,7 +198,7 @@
                     </p>
                     <div class="margin-above flex-row-nowrap">
                         <button type="button" id="test-yomitan-api-button">Test</button>
-                        <input id="test-yomitan-url-input" class="flex-margin-left" type="text" placeholder="http://127.0.0.1:8766" spellcheck="false" autocomplete="off" data-setting="general.yomitanApiServer">
+                        <input id="test-yomitan-url-input" class="flex-margin-left" type="text" placeholder="http://127.0.0.1:19633" spellcheck="false" autocomplete="off" data-setting="general.yomitanApiServer">
                         <div id="test-yomitan-api-results" class="flex-margin-left" hidden></div>
                     </div>
                     <p class="margin-above">

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -313,7 +313,7 @@ function createProfileOptionsUpdatedTestData1() {
             sortFrequencyDictionaryOrder: 'descending',
             stickySearchHeader: false,
             enableYomitanApi: false,
-            yomitanApiServer: 'http://127.0.0.1:8766',
+            yomitanApiServer: 'http://127.0.0.1:19633',
         },
         audio: {
             enabled: true,
@@ -689,7 +689,7 @@ function createOptionsUpdatedTestData1() {
             },
         ],
         profileCurrent: 0,
-        version: 68,
+        version: 69,
         global: {
             database: {
                 prefixWildcardsSupported: false,


### PR DESCRIPTION
Apparently `8766` collides with asbplayer. With the great help of a random number generator, I have gotten port 19633. As far as I can tell nothing uses this.

Companion PR on the API repo https://github.com/Kuuuube/yomitan-api/pull/6.

This change in Yomitan doesn't matter at all for accessing the API. All it controls is the default field set for the test button.