### PR TITLE
Make getLanguageFromText more accurate and mostly avoid conflict with Japanese, Chinese, Cantonese

### DIFF
--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -1115,7 +1115,7 @@ export class DisplayGenerator {
         if (typeof language === 'string') {
             element.lang = language;
         } else {
-            const language2 = getLanguageFromText(content);
+            const language2 = getLanguageFromText(content, this._language);
             if (language2 !== null) {
                 element.lang = language2;
             }

--- a/ext/js/display/structured-content-generator.js
+++ b/ext/js/display/structured-content-generator.js
@@ -204,7 +204,7 @@ export class StructuredContentGenerator {
             if (content.length > 0) {
                 container.appendChild(this._createTextNode(content));
                 if (language === null) {
-                    const language2 = getLanguageFromText(content, language ?? '');
+                    const language2 = getLanguageFromText(content, language);
                     if (language2 !== null) {
                         container.lang = language2;
                     }

--- a/ext/js/display/structured-content-generator.js
+++ b/ext/js/display/structured-content-generator.js
@@ -204,7 +204,7 @@ export class StructuredContentGenerator {
             if (content.length > 0) {
                 container.appendChild(this._createTextNode(content));
                 if (language === null) {
-                    const language2 = getLanguageFromText(content);
+                    const language2 = getLanguageFromText(content, language ?? '');
                     if (language2 !== null) {
                         container.lang = language2;
                     }

--- a/ext/js/language/text-utilities.js
+++ b/ext/js/language/text-utilities.js
@@ -22,13 +22,13 @@ import {isStringPartiallyChinese} from './zh/chinese.js';
  * Returns the language that the string might be by using some heuristic checks.
  * Values returned are ISO codes. `null` is returned if no language can be determined.
  * @param {string} text
- * @param {string} language
+ * @param {?string} language
  * @returns {?string}
  */
 export function getLanguageFromText(text, language) {
     const partiallyJapanese = isStringPartiallyJapanese(text);
     const partiallyChinese = isStringPartiallyChinese(text);
-    if (!['zh', 'yue'].includes(language)) {
+    if (!['zh', 'yue'].includes(language ?? '')) {
         if (partiallyJapanese) { return 'ja'; }
         if (partiallyChinese) { return 'zh'; }
     }

--- a/ext/js/language/text-utilities.js
+++ b/ext/js/language/text-utilities.js
@@ -16,14 +16,21 @@
  */
 
 import {isStringPartiallyJapanese} from './ja/japanese.js';
+import {isStringPartiallyChinese} from './zh/chinese.js';
 
 /**
  * Returns the language that the string might be by using some heuristic checks.
  * Values returned are ISO codes. `null` is returned if no language can be determined.
  * @param {string} text
+ * @param {string} language
  * @returns {?string}
  */
-export function getLanguageFromText(text) {
-    if (isStringPartiallyJapanese(text)) { return 'ja'; }
-    return null;
+export function getLanguageFromText(text, language) {
+    const partiallyJapanese = isStringPartiallyJapanese(text);
+    const partiallyChinese = isStringPartiallyChinese(text);
+    if (!['zh', 'yue'].includes(language)) {
+        if (partiallyJapanese) { return 'ja'; }
+        if (partiallyChinese) { return 'zh'; }
+    }
+    return language;
 }


### PR DESCRIPTION
Fixes #2101

For the most part there are no issues with language tags being set (fixed in #979) but `getLanguageFromText` falls back to `ja` too easily. Most Chinese texts will cause `partiallyJapanese` to return `True` and likewise for Japanese texts on `isStringPartiallyChinese`.

Falling back to the user's selected language should be preferred in cases where `ja` cannot be confidently assigned. Ideally all dictionaries would have source and target languages defined but that is not the case.

This preserves the behavior of properly assigning the `ja` language to glossaries with the source language of `ja` but target language of something else. For example an `en` -> `ja` dictionary has a `ja` glossary but the user will need their language set to `en`. While also not incorrectly assigning `ja` to Chinese or Cantonese dictionaries.

This does cause a potential issue for `zh` -> `ja` dictionaries but I'm not sure there's any way to fix that beyond adding a new setting.