### PR TITLE
Preserve uppercase when converting romaji to katakana using uppercase romaji

### DIFF
--- a/ext/js/language/ja/japanese-wanakana.js
+++ b/ext/js/language/ja/japanese-wanakana.js
@@ -79,7 +79,7 @@ export function convertToKana(text) {
     for (const [romaji, kana] of Object.entries(ROMAJI_TO_HIRAGANA)) {
         newText = newText.replaceAll(romaji, kana);
         // Uppercase text converts to katakana
-        newText = newText.replaceAll(romaji.toUpperCase(), convertHiraganaToKatakana(kana));
+        newText = newText.replaceAll(romaji.toUpperCase(), convertHiraganaToKatakana(kana).toUpperCase());
     }
     return fillSokuonGaps(newText);
 }

--- a/test/japanese-util.test.js
+++ b/test/japanese-util.test.js
@@ -174,6 +174,8 @@ describe('Japanese utility functions', () => {
             [['nnnnano', 7], {kanaString: 'んんあの', newSelectionStart: 4}], // nnnnano| -> んんあの|
             [['ny', 2], {kanaString: 'ny', newSelectionStart: 2}], // ny| -> ny|
             [['nya', 3], {kanaString: 'にゃ', newSelectionStart: 2}], // nya| -> にゃ|
+            [['tt', 2], {kanaString: 'っt', newSelectionStart: 2}], // tt| -> っt|
+            [['TT', 2], {kanaString: 'ッT', newSelectionStart: 2}], // TT| -> ッT|
         ];
 
         test.each(data)('%s -> %o', (dataValue, expected) => {


### PR DESCRIPTION
With `Automatic kana conversion` enabled on the search page lowercase romaji = hiragana and uppercase romaji = katakana.

`TTU` should convert to `ッツ`. And it does but not when typed one character at a time.
The intermediate steps as each character is typed being:
`T` -> `T`
`TT` -> `ッT` (This was being incorrectly converted to `ッt`)
`ッTU` -> `ッツ`

Same goes for all the sokuon conversions.