### PR TITLE
Added loading builds instructions for firefox and edge on CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,29 @@ Immediately you should see the "Welcome" page!
 
 Note: Yomitan may or may not update when you make and save new code changes locally. It depends on what file you've changed. Yomitan runs as collection of two programs. There is the background process called the "service worker" and there is the frontend called the "content_script". The frontend will reload on save, but to update the backend you need to click on the update icon next to the extension in `chrome://extensions/`. If you make changes to the manifest you will need to rerun `npm run build` to regenerate the manifest file.
 
+### Loading a build into Firefox browser
+
+After building, you can load the compiled extension into the Firefox browser.
+
+- Navigate to the Debugging page, type `about:debugging` into the url
+- Click on "This Firefox" on the left
+- Click on "Load Temporary Add-on" on the right
+- Navigate to the `yomitan-firefox-dev.zip` in your builds folder
+
+Immediately you should see the "Welcome" page!
+
+### Loading an unpacked build into Microsoft Edge browser
+
+After building, you can load the compiled extension into the Edge browser.
+
+- Unpack the `yomitan-edge.zip`
+- Navigate to the extension page using the "..." on the top right and clicking on "Manage extensions"
+- Turn on the toggle on the left that says "Developer Mode"
+- Click "Load unpacked" on the top right
+- Select the unpacked `yomitan-edge` folder
+
+Immediately you should see the "Welcome" page!
+
 ### Build Tools
 
 The build process can use the [7-zip](https://www.7-zip.org/) archiving tool to create the packed zip builds

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,15 @@ After building, you can load the compiled extension into the Firefox browser.
 
 Immediately you should see the "Welcome" page!
 
+Note: The "Load Temporary Add-on" option is temporary and the build will need to be loaded again after browser restarts. Sometimes testing extension features between browser restarts will be necessary so here are the steps to bypass this restriction.
+
+- Download Firefox Developer or Nightly
+- Navigate to the Config page, type `about:config` into the url
+- Look up `xpinstall.signatures.required` setting on the search bar at the top
+- Toggle the value to "false"
+- Navigate to the "Extensions" page using "Manage extensions"
+- Either use drag and drop or "Install Add-on from File" to load the dev build
+
 ### Loading an unpacked build into Microsoft Edge browser
 
 After building, you can load the compiled extension into the Edge browser.

--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -415,7 +415,7 @@ export class YomitanApi {
                     },
                 },
                 media: {
-                    audio: {value: audioMediaFile},
+                    audio: audioMediaFile.length > 0 ? {value: audioMediaFile} : void 0,
                     textFurigana: [{
                         text: text,
                         readingMode: furiganaReadingMode,


### PR DESCRIPTION
For my issue #2104.
Added a short loading builds instructions for firefox and edge browsers on the CONTRIBUTING to go along with Chrome. Tried to keep it very similar to the loading Chrome build section.