### PR TITLE
Default text parser uses the selected terms reading for all occurencences of the term within the parsed sentence

### DIFF
--- a/ext/js/data/anki-note-builder.js
+++ b/ext/js/data/anki-note-builder.js
@@ -455,7 +455,11 @@ export class AnkiNoteBuilder {
             const textParsingOptions = mediaOptions.textParsing;
             if (typeof textParsingOptions === 'object' && textParsingOptions !== null) {
                 const {optionsContext, scanLength} = textParsingOptions;
-                textFuriganaPromise = this._getTextFurigana(textFuriganaDetails, optionsContext, scanLength);
+                const readingOverride =
+                    dictionaryEntryDetails.type === "term" && dictionaryEntryDetails.reading.length > 0
+                        ? { term: dictionaryEntryDetails.term, reading: dictionaryEntryDetails.reading }
+                        : undefined;
+                textFuriganaPromise = this._getTextFurigana(textFuriganaDetails, optionsContext, scanLength, readingOverride);
             }
         }
 
@@ -508,9 +512,10 @@ export class AnkiNoteBuilder {
      * @param {import('anki-note-builder').TextFuriganaDetails[]} entries
      * @param {import('settings').OptionsContext} optionsContext
      * @param {number} scanLength
+     * @param {{term: string, reading: string}=} readingOverride
      * @returns {Promise<import('anki-templates').TextFuriganaSegment[]>}
      */
-    async _getTextFurigana(entries, optionsContext, scanLength) {
+    async _getTextFurigana(entries, optionsContext, scanLength, readingOverride) {
         const results = [];
         for (const {text, readingMode} of entries) {
             const parseResults = await this._api.parseText(text, optionsContext, scanLength, true, false);
@@ -521,8 +526,8 @@ export class AnkiNoteBuilder {
                 break;
             }
             if (data !== null) {
-                const valueHtml = createFuriganaHtml(data, readingMode);
-                const valuePlain = createFuriganaPlain(data, readingMode);
+                const valueHtml = createFuriganaHtml(data, readingMode, readingOverride);
+                const valuePlain = createFuriganaPlain(data, readingMode, readingOverride);
                 results.push({text, readingMode, detailsHtml: {value: valueHtml}, detailsPlain: {value: valuePlain}});
             }
         }
@@ -533,16 +538,17 @@ export class AnkiNoteBuilder {
 /**
  * @param {import('api').ParseTextLine[]} data
  * @param {?import('anki-templates').TextFuriganaReadingMode} readingMode
+ * @param {{term: string, reading: string}=} readingOverride
  * @returns {string}
  */
-export function createFuriganaHtml(data, readingMode) {
+export function createFuriganaHtml(data, readingMode, readingOverride) {
     let result = '';
     for (const term of data) {
         result += '<span class="term">';
         for (const {text, reading} of term) {
             if (reading.length > 0) {
-                const reading2 = convertReading(reading, readingMode);
-                result += `<ruby>${text}<rt>${reading2}</rt></ruby>`;
+                const reading2 = getReading(text, reading, readingMode, readingOverride)
+            result += `<ruby>${text}<rt>${reading2}</rt></ruby>`;
             } else {
                 result += text;
             }
@@ -555,14 +561,15 @@ export function createFuriganaHtml(data, readingMode) {
 /**
  * @param {import('api').ParseTextLine[]} data
  * @param {?import('anki-templates').TextFuriganaReadingMode} readingMode
+ * @param {{term: string, reading: string}=} readingOverride
  * @returns {string}
  */
-export function createFuriganaPlain(data, readingMode) {
+export function createFuriganaPlain(data, readingMode, readingOverride) {
     let result = '';
     for (const term of data) {
         for (const {text, reading} of term) {
             if (reading.length > 0) {
-                const reading2 = convertReading(reading, readingMode);
+                const reading2 = getReading(text, reading, readingMode, readingOverride)
                 result += ` ${text}[${reading2}]`;
             } else {
                 result += text;
@@ -587,4 +594,16 @@ function convertReading(reading, readingMode) {
         default:
             return reading;
     }
+}
+
+/**
+ * @param {string} text
+ * @param {string} reading
+ * @param {?import('anki-templates').TextFuriganaReadingMode} readingMode
+ * @param {{term: string, reading: string}=} readingOverride
+ * @returns {string}
+ */
+function getReading(text, reading, readingMode, readingOverride) {
+    const shouldOverride = readingOverride?.term === text;
+    return convertReading(shouldOverride ? readingOverride.reading : reading, readingMode);
 }


### PR DESCRIPTION
This PR addresses issue #2111 

It updates anki-note-builder.js to use the selected dictionary reading for a term when rendering furigana in the parsed sentence. If the term appears in the sentence, its reading will be overridden to match the one selected by the user from the dictionary entry.

This override is applied only to term definitions using the internal Yomitan text parser. It does not affect:

1. Kanji definitions
2. Entries parsed using the MeCab text parser