### PR TITLE
Use term reading for all occurences in sentence furigana

### DIFF
--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -420,10 +420,10 @@ export class YomitanApi {
                         text: text,
                         readingMode: furiganaReadingMode,
                         detailsHtml: {
-                            value: createFuriganaHtml(furiganaData, furiganaReadingMode),
+                            value: createFuriganaHtml(furiganaData, furiganaReadingMode, null),
                         },
                         detailsPlain: {
-                            value: createFuriganaPlain(furiganaData, furiganaReadingMode),
+                            value: createFuriganaPlain(furiganaData, furiganaReadingMode, null),
                         },
                     }],
                     dictionaryMedia: dictionaryMedia,


### PR DESCRIPTION
Fixes #2111 

~It allows the user to turn on a toggle to~ uses the selected dictionary terms reading for all occurrences of the term within the parsed text.


This override is applied only to term definitions using the internal Yomitan text parser. It does not affect:

1. Kanji definitions
2. Entries parsed using the MeCab text parser
3. Furigana creation outside of the context of an Anki note