### PR TITLE
Add Korean to "Search text with non-Japanese, Chinese, or Cantonese characters" setting

### DIFF
--- a/ext/css/visibility-modifiers.css
+++ b/ext/css/visibility-modifiers.css
@@ -10,6 +10,9 @@
 :root:not([data-language=ja]):not([data-language=zh]):not([data-language=yue]) .jpzhyue-only {
     display: none;
 }
+:root:not([data-language=ja]):not([data-language=zh]):not([data-language=yue]):not([data-language=ko]) .jpzhyueko-only {
+    display: none;
+}
 :root:is([data-language=ja], [data-language=zh], [data-language=yue], [data-language=ko]) .not-jpzhyueko {
     display: none;
 }

--- a/ext/js/language/ja/japanese.js
+++ b/ext/js/language/ja/japanese.js
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {CJK_COMPATIBILITY, CJK_IDEOGRAPH_RANGES, isCodePointInRange, isCodePointInRanges} from '../CJK-util.js';
+import {CJK_COMPATIBILITY, CJK_IDEOGRAPH_RANGES, CJK_PUNCTUATION_RANGE, FULLWIDTH_CHARACTER_RANGES, isCodePointInRange, isCodePointInRanges} from '../CJK-util.js';
 
 
 const HIRAGANA_SMALL_TSU_CODE_POINT = 0x3063;
@@ -51,17 +51,9 @@ const JAPANESE_RANGES = [
 
     [0x30fb, 0x30fc], // Katakana punctuation
     [0xff61, 0xff65], // Kana punctuation
-    [0x3000, 0x303f], // CJK punctuation
 
-    [0xff10, 0xff19], // Fullwidth numbers
-    [0xff21, 0xff3a], // Fullwidth upper case Latin letters
-    [0xff41, 0xff5a], // Fullwidth lower case Latin letters
-
-    [0xff01, 0xff0f], // Fullwidth punctuation 1
-    [0xff1a, 0xff1f], // Fullwidth punctuation 2
-    [0xff3b, 0xff3f], // Fullwidth punctuation 3
-    [0xff5b, 0xff60], // Fullwidth punctuation 4
-    [0xffe0, 0xffee], // Currency markers
+    CJK_PUNCTUATION_RANGE,
+    ...FULLWIDTH_CHARACTER_RANGES,
 ];
 
 const SMALL_KANA_SET = new Set('ぁぃぅぇぉゃゅょゎァィゥェォャュョヮ');

--- a/ext/js/language/ko/korean.js
+++ b/ext/js/language/ko/korean.js
@@ -47,7 +47,8 @@ const KOREAN_RANGES = [
     HANGUL_JAMO_HALF_WIDTH_RANGE,
 ];
 
-/** * @param {number} codePoint
+/**
+ * @param {number} codePoint
  * @returns {boolean}
  */
 export function isCodePointKorean(codePoint) {

--- a/ext/js/language/ko/korean.js
+++ b/ext/js/language/ko/korean.js
@@ -28,7 +28,7 @@ const HANGUL_JAMO_EXTENDED_A_RANGE = [0xa960, 0xa97f];
 /** @type {import('CJK-util').CodepointRange} */
 const HANGUL_JAMO_EXTENDED_B_RANGE = [0xd7b0, 0xd7ff];
 /** @type {import('CJK-util').CodepointRange} */
-const HANGUL_JAMO_HALF_WIDTH_RANGE = [0xffa0, 0xffdc];
+const HANGUL_JAMO_HALF_WIDTH_RANGE = [0xffa0, 0xffdf];
 
 /**
  * Korean character ranges, roughly ordered in order of expected frequency.

--- a/ext/js/language/ko/korean.js
+++ b/ext/js/language/ko/korean.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024-2025  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {CJK_IDEOGRAPH_RANGES, CJK_PUNCTUATION_RANGE, FULLWIDTH_CHARACTER_RANGES, isCodePointInRanges} from '../CJK-util.js';
+
+/** @type {import('CJK-util').CodepointRange} */
+const HANGUL_JAMO_RANGE = [0x1100, 0x11ff];
+/** @type {import('CJK-util').CodepointRange} */
+const HANGUL_COMPATIBILITY_JAMO_RANGE = [0x3130, 0x318f];
+/** @type {import('CJK-util').CodepointRange} */
+const HANGUL_SYLLABLES_RANGE = [0xac00, 0xd7af];
+/** @type {import('CJK-util').CodepointRange} */
+const HANGUL_JAMO_EXTENDED_A_RANGE = [0xa960, 0xa97f];
+/** @type {import('CJK-util').CodepointRange} */
+const HANGUL_JAMO_EXTENDED_B_RANGE = [0xd7b0, 0xd7ff];
+/** @type {import('CJK-util').CodepointRange} */
+const HANGUL_JAMO_HALF_WIDTH_RANGE = [0xffa0, 0xffdc];
+
+/**
+ * Korean character ranges, roughly ordered in order of expected frequency.
+ * @type {import('CJK-util').CodepointRange[]}
+ */
+const KOREAN_RANGES = [
+    ...CJK_IDEOGRAPH_RANGES,
+    CJK_PUNCTUATION_RANGE,
+    ...FULLWIDTH_CHARACTER_RANGES,
+
+    HANGUL_JAMO_RANGE,
+    HANGUL_COMPATIBILITY_JAMO_RANGE,
+    HANGUL_SYLLABLES_RANGE,
+    HANGUL_JAMO_EXTENDED_A_RANGE,
+    HANGUL_JAMO_EXTENDED_B_RANGE,
+    HANGUL_JAMO_HALF_WIDTH_RANGE,
+];
+
+/** * @param {number} codePoint
+ * @returns {boolean}
+ */
+export function isCodePointKorean(codePoint) {
+    return isCodePointInRanges(codePoint, KOREAN_RANGES);
+}

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -23,6 +23,7 @@ import {LanguageTransformer} from './language-transformer.js';
 import {getAllLanguageReadingNormalizers, getAllLanguageTextProcessors} from './languages.js';
 import {MultiLanguageTransformer} from './multi-language-transformer.js';
 import {isCodePointChinese} from './zh/chinese.js';
+import {isCodePointKorean} from './ko/korean.js';
 
 /**
  * Class which finds term and kanji dictionary entries for text.
@@ -139,7 +140,7 @@ export class Translator {
      */
     async findKanji(text, options) {
         if (options.removeNonJapaneseCharacters) {
-            text = this._getJapaneseChineseOnlyText(text);
+            text = this._getJapaneseChineseKoreanOnlyText(text);
         }
         const {enabledDictionaryMap} = options;
         /** @type {Set<string>} */
@@ -229,8 +230,8 @@ export class Translator {
      */
     async _findTermsInternal(text, options, tagAggregator, primaryReading) {
         const {removeNonJapaneseCharacters, enabledDictionaryMap} = options;
-        if (removeNonJapaneseCharacters && (['ja', 'zh', 'yue'].includes(options.language))) {
-            text = this._getJapaneseChineseOnlyText(text);
+        if (removeNonJapaneseCharacters && (['ja', 'zh', 'yue', 'ko'].includes(options.language))) {
+            text = this._getJapaneseChineseKoreanOnlyText(text);
         }
         if (text.length === 0) {
             return {dictionaryEntries: [], originalTextLength: 0};
@@ -653,11 +654,11 @@ export class Translator {
      * @param {string} text
      * @returns {string}
      */
-    _getJapaneseChineseOnlyText(text) {
+    _getJapaneseChineseKoreanOnlyText(text) {
         let length = 0;
         for (const c of text) {
             const codePoint = /** @type {number} */ (c.codePointAt(0));
-            if (!isCodePointJapanese(codePoint) && !isCodePointChinese(codePoint)) {
+            if (!isCodePointJapanese(codePoint) && !isCodePointChinese(codePoint) && !isCodePointKorean(codePoint)) {
                 return text.substring(0, length);
             }
             length += c.length;

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -477,10 +477,10 @@
                 <label class="toggle"><input type="checkbox" data-setting="scanning.selectText"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
-        <div class="settings-item jpzhyue-only"><div class="settings-item-inner">
+        <div class="settings-item jpzhyueko-only"><div class="settings-item-inner">
             <div class="settings-item-left">
-                <div class="settings-item-label">Search text with non-Japanese, Chinese, or Cantonese characters</div>
-                <div class="settings-item-description">Only applies when language is set to Japanese, Chinese, or Cantonese.</div>
+                <div class="settings-item-label">Search text with non-Japanese, Chinese, or Korean characters</div>
+                <div class="settings-item-description">Only applies when language is set to Japanese, Chinese, Cantonese, or Korean.</div>
             </div>
             <div class="settings-item-right">
                 <label class="toggle"><input type="checkbox" data-setting="scanning.alphanumeric"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>


### PR DESCRIPTION
Fixes #1833 by adding Korean to the "Search text with non-Japanese, Chinese, or Cantonese characters" setting. Source I used for the codepoints is https://en.wikipedia.org/wiki/Hangul#Unicode

Also refactored japanese.js codepoint ranges to use CJK-util.js ranges