### PR TITLE
Only allow glossaryLayoutMode 'compact-popup-anki' to trigger compact glossaries for non structured content dicts

### DIFF
--- a/ext/js/data/anki-note-data-creator.js
+++ b/ext/js/data/anki-note-data-creator.js
@@ -63,7 +63,7 @@ export function createAnkiNoteData(marker, {
         compactTags,
         group: (resultOutputMode === 'group'),
         merge: (resultOutputMode === 'merge'),
-        compactGlossaries: (['compact', 'compact-popup-anki'].includes(glossaryLayoutMode)),
+        compactGlossaries: (glossaryLayoutMode === 'compact-popup-anki'),
         get uniqueExpressions() { return getCachedValue(uniqueExpressions); },
         get uniqueReadings() { return getCachedValue(uniqueReadings); },
         get pitches() { return getCachedValue(pitches); },


### PR DESCRIPTION
Previously `compact` was allowed to do this as well. This creates a split between structured and non structured dicts where structured required `compact-popup-anki` but non structured would be compacted with either `compact` or `compact-popup-anki`.