### PR TITLE
Remove separate handling for avg freq in popup and combine with Anki handling

### DIFF
--- a/ext/js/data/anki-note-data-creator.js
+++ b/ext/js/data/anki-note-data-creator.js
@@ -171,13 +171,16 @@ function getPublicContext(context) {
 
 /**
  * @param {import('dictionary').TermDictionaryEntry|import('dictionary').KanjiDictionaryEntry} dictionaryEntry
+ * @param {number?} requestedHeadwordIndex
  * @returns {import('anki-templates').FrequencyNumber[]}
  */
-function getFrequencyNumbers(dictionaryEntry) {
+function getFrequencyNumbers(dictionaryEntry, requestedHeadwordIndex) {
     let previousDictionary;
     const frequencies = [];
-    for (const {dictionary, frequency, displayValue} of dictionaryEntry.frequencies) {
-        if (dictionary === previousDictionary) {
+    for (const dictionaryEntryFrequency of dictionaryEntry.frequencies) {
+        const {dictionary, frequency, displayValue} = dictionaryEntryFrequency;
+        const wrongHeadwordIndex = Number.isInteger(requestedHeadwordIndex) && ('headwordIndex' in dictionaryEntryFrequency) && dictionaryEntryFrequency.headwordIndex !== requestedHeadwordIndex;
+        if (dictionary === previousDictionary || wrongHeadwordIndex) {
             continue;
         }
         previousDictionary = dictionary;
@@ -201,10 +204,11 @@ function getFrequencyNumbers(dictionaryEntry) {
 
 /**
  * @param {import('dictionary').TermDictionaryEntry|import('dictionary').KanjiDictionaryEntry} dictionaryEntry
+ * @param {number?} headwordIndex
  * @returns {number}
  */
-function getFrequencyHarmonic(dictionaryEntry) {
-    const frequencies = getFrequencyNumbers(dictionaryEntry);
+export function getFrequencyHarmonic(dictionaryEntry, headwordIndex) {
+    const frequencies = getFrequencyNumbers(dictionaryEntry, headwordIndex);
 
     if (frequencies.length === 0) {
         return -1;
@@ -219,10 +223,11 @@ function getFrequencyHarmonic(dictionaryEntry) {
 
 /**
  * @param {import('dictionary').TermDictionaryEntry|import('dictionary').KanjiDictionaryEntry} dictionaryEntry
+ * @param {number?} headwordIndex
  * @returns {number}
  */
-function getFrequencyAverage(dictionaryEntry) {
-    const frequencies = getFrequencyNumbers(dictionaryEntry);
+function getFrequencyAverage(dictionaryEntry, headwordIndex) {
+    const frequencies = getFrequencyNumbers(dictionaryEntry, headwordIndex);
 
     if (frequencies.length === 0) {
         return -1;
@@ -339,8 +344,8 @@ function getKanjiDefinition(dictionaryEntry, context) {
     const stats = createCachedValue(getKanjiStats.bind(null, dictionaryEntry));
     const tags = createCachedValue(convertTags.bind(null, dictionaryEntry.tags));
     const frequencies = createCachedValue(getKanjiFrequencies.bind(null, dictionaryEntry));
-    const frequencyHarmonic = createCachedValue(getFrequencyHarmonic.bind(null, dictionaryEntry));
-    const frequencyAverage = createCachedValue(getFrequencyAverage.bind(null, dictionaryEntry));
+    const frequencyHarmonic = createCachedValue(getFrequencyHarmonic.bind(null, dictionaryEntry, null));
+    const frequencyAverage = createCachedValue(getFrequencyAverage.bind(null, dictionaryEntry, null));
     const cloze = createCachedValue(getCloze.bind(null, dictionaryEntry, context));
 
     return {
@@ -441,9 +446,9 @@ function getTermDefinition(dictionaryEntry, context, resultOutputMode, dictionar
     const termTags = createCachedValue(getTermTags.bind(null, dictionaryEntry, type));
     const expressions = createCachedValue(getTermExpressions.bind(null, dictionaryEntry));
     const frequencies = createCachedValue(getTermFrequencies.bind(null, dictionaryEntry));
-    const frequencyNumbers = createCachedValue(getFrequencyNumbers.bind(null, dictionaryEntry));
-    const frequencyHarmonic = createCachedValue(getFrequencyHarmonic.bind(null, dictionaryEntry));
-    const frequencyAverage = createCachedValue(getFrequencyAverage.bind(null, dictionaryEntry));
+    const frequencyNumbers = createCachedValue(getFrequencyNumbers.bind(null, dictionaryEntry, null));
+    const frequencyHarmonic = createCachedValue(getFrequencyHarmonic.bind(null, dictionaryEntry, null));
+    const frequencyAverage = createCachedValue(getFrequencyAverage.bind(null, dictionaryEntry, null));
     const pitches = createCachedValue(getTermPitches.bind(null, dictionaryEntry));
     const phoneticTranscriptions = createCachedValue(getTermPhoneticTranscriptions.bind(null, dictionaryEntry));
     const glossary = createCachedValue(getTermGlossaryArray.bind(null, dictionaryEntry, type));

--- a/ext/js/dictionary/dictionary-data-util.js
+++ b/ext/js/dictionary/dictionary-data-util.js
@@ -16,6 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import {getFrequencyHarmonic} from '../data/anki-note-data-creator.js';
+
+
 /**
  * @param {import('dictionary').TermDictionaryEntry} dictionaryEntry
  * @returns {import('dictionary-data-util').TagGroup[]}
@@ -84,8 +87,6 @@ export function groupTermFrequencies(dictionaryEntry, dictionaryInfo) {
 
     const results = [];
 
-    /** @type {import('dictionary').AverageFrequencyListGroup} */
-    const averages = new Map();
     for (const [dictionary, map2] of map1.entries()) {
         /** @type {import('dictionary-data-util').TermFrequency[]} */
         const frequencies = [];
@@ -97,92 +98,33 @@ export function groupTermFrequencies(dictionaryEntry, dictionaryInfo) {
                 values: [...values.values()],
             };
             frequencies.push(termFrequency);
-
-            const averageFrequencyData = makeAverageFrequencyData(termFrequency, averages.get(term));
-            if (averageFrequencyData) {
-                averages.set(term, averageFrequencyData);
-            }
         }
         const currentDictionaryInfo = dictionaryInfo.find(({title}) => title === dictionary);
         const freqCount = currentDictionaryInfo?.counts?.termMeta.freq ?? 0;
         results.push({dictionary, frequencies, dictionaryAlias, freqCount});
     }
 
-    results.push({dictionary: 'Average', frequencies: makeAverageFrequencyArray(averages), dictionaryAlias: 'Average', freqCount: 1});
-
-    return results;
-}
-
-/**
- * @param {import('dictionary-data-util').TermFrequency} termFrequency
- * @param {import('dictionary').AverageFrequencyListTerm | undefined} averageTerm
- * @returns {import('dictionary').AverageFrequencyListTerm | undefined}
- */
-function makeAverageFrequencyData(termFrequency, averageTerm) {
-    const valuesArray = [...termFrequency.values.values()];
-    const newReading = termFrequency.reading ?? '';
-
-    /** @type {import('dictionary').AverageFrequencyListTerm} */
-    const termMap = typeof averageTerm === 'undefined' ? new Map() : averageTerm;
-
-    const frequencyData = termMap.get(newReading) ?? {currentAvg: 1, count: 0};
-
-    if (valuesArray[0].frequency === null) { return; }
-
-    frequencyData.currentAvg = frequencyData.count / frequencyData.currentAvg + 1 / valuesArray[0].frequency;
-    frequencyData.currentAvg = (frequencyData.count + 1) / frequencyData.currentAvg;
-    frequencyData.count += 1;
-
-    termMap.set(newReading, frequencyData);
-    return termMap;
-}
-
-/**
- * @param {import('dictionary').AverageFrequencyListGroup} averages
- * @returns {import('dictionary-data-util').TermFrequency[]}
- */
-function makeAverageFrequencyArray(averages) {
-    // Merge readings if one is null and there's only two readings
-    // More than one non-null reading cannot be merged since it cannot be determined which reading to merge with
-    for (const currentTerm of averages.keys()) {
-        const readingsMap = averages.get(currentTerm);
-        if (!readingsMap) { continue; } // Skip if readingsMap is undefined
-
-        const readingArray = [...readingsMap.keys()];
-        const nullIndex = readingArray.indexOf('');
-
-        if (readingArray.length === 2 && nullIndex >= 0) {
-            const key1 = readingArray[0];
-            const key2 = readingArray[1];
-
-            const value1 = readingsMap.get(key1);
-            const value2 = readingsMap.get(key2);
-
-            if (!value1 || !value2) { continue; } // Skip if any value is undefined
-
-            const avg1 = value1.currentAvg;
-            const count1 = value1.count;
-            const avg2 = value2.currentAvg;
-            const count2 = value2.count;
-
-            const newcount = count1 + count2;
-            const newavg = newcount / (count1 / avg1 + count2 / avg2);
-
-            const validKey = nullIndex === 0 ? key2 : key1;
-            readingsMap.set(validKey, {currentAvg: newavg, count: newcount});
-            readingsMap.delete('');
-        }
+    const averageFrequencies = [];
+    for (let i = 0; i < dictionaryEntry.headwords.length; i++) {
+        const averageFrequency = getFrequencyHarmonic(dictionaryEntry, i);
+        averageFrequencies.push({
+            term: dictionaryEntry.headwords[i].term,
+            reading: dictionaryEntry.headwords[i].reading,
+            values: [{
+                frequency: averageFrequency,
+                displayValue: averageFrequency.toString(),
+            }],
+        });
     }
 
-    // Convert averages Map back to array format
-    return [...averages.entries()].flatMap(([termName, termMap]) => [...termMap.entries()].map(([readingName, data]) => ({
-        term: termName,
-        reading: readingName,
-        values: [{
-            frequency: Math.round(data.currentAvg),
-            displayValue: Math.round(data.currentAvg).toString(),
-        }],
-    })));
+    results.push({
+        dictionary: 'Average',
+        frequencies: averageFrequencies,
+        dictionaryAlias: 'Average',
+        freqCount: averageFrequencies.length,
+    });
+
+    return results;
 }
 
 /**

--- a/types/ext/dictionary.d.ts
+++ b/types/ext/dictionary.d.ts
@@ -532,27 +532,3 @@ export type TermSource = {
      */
     isPrimary: boolean;
 };
-
-/**
- * Dictionaries containing the harmonic mean frequency of specific term-reading pairs.
- */
-export type AverageFrequencyListGroup = Map<string, AverageFrequencyListTerm>;
-
-/**
- * Contains the average frequency of a term, with all its readings.
- */
-export type AverageFrequencyListTerm = Map<string, AverageFrequencyListReading>;
-
-/**
- * The number of dictionary frequencies used to compute the average.
- */
-export type AverageFrequencyListReading = {
-    /**
-     * The current average frequency.
-     */
-    currentAvg: number;
-    /**
-     * The number of dictionary frequencies used to compute the average.
-     */
-    count: number;
-};


### PR DESCRIPTION
Fixes #2128

Some dicts were getting counted twice. Not worth fixing when the existing Anki implementation works properly.

Just added filtering for headword index since the popup needs to differentiate between frequencies when there are multiple headwords present which happens with certain term grouping settings:
<img width="429" height="84" alt="image" src="https://github.com/user-attachments/assets/bc45820e-0c77-4173-acdb-e7736c0fb644" />

This rips out most of the code added by #1479.