### PR TITLE
Fix problems with CSS nesting in Yomitan API and Anki note data

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -206,7 +206,7 @@ export class Backend {
         ]));
 
         /** @type {YomitanApi} */
-        this._yomitanApi = new YomitanApi(this._apiMap);
+        this._yomitanApi = new YomitanApi(this._apiMap, this._offscreen);
     }
 
     /**

--- a/ext/js/background/offscreen-proxy.js
+++ b/ext/js/background/offscreen-proxy.js
@@ -316,21 +316,3 @@ export class ClipboardReaderProxy {
         return await this._offscreen.sendMessagePromise({action: 'clipboardGetImageOffscreen'});
     }
 }
-
-export class DomProxy {
-    /**
-     * @param {OffscreenProxy} offscreen
-     */
-    constructor(offscreen) {
-        /** @type {OffscreenProxy} */
-        this._offscreen = offscreen;
-    }
-
-    /**
-     * @param {string} css
-     * @returns {Promise<string>}
-     */
-    async sanitizeCSSOffscreen(css) {
-        return await this._offscreen.sendMessagePromise({action: 'sanitizeCSSOffscreen', params: {css}});
-    }
-}

--- a/ext/js/background/offscreen-proxy.js
+++ b/ext/js/background/offscreen-proxy.js
@@ -316,3 +316,21 @@ export class ClipboardReaderProxy {
         return await this._offscreen.sendMessagePromise({action: 'clipboardGetImageOffscreen'});
     }
 }
+
+export class DomProxy {
+    /**
+     * @param {OffscreenProxy} offscreen
+     */
+    constructor(offscreen) {
+        /** @type {OffscreenProxy} */
+        this._offscreen = offscreen;
+    }
+
+    /**
+     * @param {string} css
+     * @returns {Promise<string>}
+     */
+    async sanitizeCSSOffscreen(css) {
+        return await this._offscreen.sendMessagePromise({action: 'sanitizeCSSOffscreen', params: {css}});
+    }
+}

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -21,6 +21,7 @@ import {ClipboardReader} from '../comm/clipboard-reader.js';
 import {createApiMap, invokeApiMapHandler} from '../core/api-map.js';
 import {ExtensionError} from '../core/extension-error.js';
 import {log} from '../core/log.js';
+import {sanitizeCSS} from '../core/utilities.js';
 import {arrayBufferToBase64} from '../data/array-buffer-util.js';
 import {DictionaryDatabase} from '../dictionary/dictionary-database.js';
 import {WebExtension} from '../extension/web-extension.js';
@@ -62,6 +63,7 @@ export class Offscreen {
             ['getTermFrequenciesOffscreen',    this._getTermFrequenciesHandler.bind(this)],
             ['clearDatabaseCachesOffscreen',   this._clearDatabaseCachesHandler.bind(this)],
             ['createAndRegisterPortOffscreen', this._createAndRegisterPort.bind(this)],
+            ['sanitizeCSSOffscreen',           this._sanitizeCSSOffscreen.bind(this)],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
 
@@ -196,6 +198,11 @@ export class Offscreen {
     /** @type {import('offscreen').McApiHandler<'connectToDatabaseWorker'>} */
     async _connectToDatabaseWorkerHandler(_params, ports) {
         await this._dictionaryDatabase.connectToDatabaseWorker(ports[0]);
+    }
+
+    /** @type {import('offscreen').ApiHandler<'sanitizeCSSOffscreen'>} */
+    _sanitizeCSSOffscreen(params) {
+        return sanitizeCSS(params.css);
     }
 
     /**

--- a/ext/js/core/utilities.js
+++ b/ext/js/core/utilities.js
@@ -298,10 +298,6 @@ export function addScopeToCss(css, scopeSelector) {
 export function addScopeToCssLegacy(css, scopeSelector) {
     try {
         const stylesheet = new CSSStyleSheet();
-        // nodejs must fall back to the normal version of the function
-        if (typeof stylesheet.replaceSync === 'undefined') {
-            return addScopeToCss(css, scopeSelector);
-        }
         stylesheet.replaceSync(css);
         const newCSSRules = [];
         for (const cssRule of stylesheet.cssRules) {

--- a/ext/js/core/utilities.js
+++ b/ext/js/core/utilities.js
@@ -16,6 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import {log} from './log.js';
+import {toError} from './to-error.js';
+
 
 /**
  * Converts any string into a form that can be passed into the RegExp constructor.
@@ -281,4 +284,43 @@ export function sanitizeCSS(css) {
  */
 export function addScopeToCss(css, scopeSelector) {
     return scopeSelector + ' {' + css + '\n}';
+}
+
+/**
+ * Older browser versions do not support nested css and cannot use the normal `addScopeToCss`.
+ * All major web browsers should be fine but Anki is still distributing Chromium 112 on some platforms as of Anki version 24.11.
+ * As of Anki 25.02, nesting is supported. However, many users take issue with changes around this time and refuse to update.
+ * Chromium 120+ is required for full support.
+ * @param {string} css
+ * @param {string} scopeSelector
+ * @returns {string}
+ */
+export function addScopeToCssLegacy(css, scopeSelector) {
+    try {
+        const stylesheet = new CSSStyleSheet();
+        // nodejs must fall back to the normal version of the function
+        if (typeof stylesheet.replaceSync === 'undefined') {
+            return addScopeToCss(css, scopeSelector);
+        }
+        stylesheet.replaceSync(css);
+        const newCSSRules = [];
+        for (const cssRule of stylesheet.cssRules) {
+            // ignore non-style rules
+            if (!(cssRule instanceof CSSStyleRule)) {
+                continue;
+            }
+
+            const newSelectors = [];
+            for (const selector of cssRule.selectorText.split(',')) {
+                newSelectors.push(scopeSelector + ' ' + selector);
+            }
+            const newRule = cssRule.cssText.replace(cssRule.selectorText, newSelectors.join(', '));
+            newCSSRules.push(newRule);
+        }
+        stylesheet.replaceSync(newCSSRules.join('\n'));
+        return [...stylesheet.cssRules].map((rule) => rule.cssText || '').join('\n');
+    } catch (e) {
+        log.log('addScopeToCssLegacy failed, falling back on addScopeToCss: ' + toError(e).message);
+        return addScopeToCss(css, scopeSelector);
+    }
 }

--- a/ext/js/data/anki-note-data-creator.js
+++ b/ext/js/data/anki-note-data-creator.js
@@ -17,7 +17,7 @@
  */
 
 import {getAnkiCompactGlossStyles} from '../../data/anki-compact-gloss-style.js';
-import {addScopeToCss} from '../core/utilities.js';
+import {addScopeToCssLegacy} from '../core/utilities.js';
 import {getDisambiguations, getGroupedPronunciations, getPronunciationsOfType, getTermFrequency, groupTermTags} from '../dictionary/dictionary-data-util.js';
 import {distributeFurigana, distributeFuriganaInflected} from '../language/ja/japanese.js';
 
@@ -589,7 +589,7 @@ function getTermDictionaryEntryCommonInfo(dictionaryEntry, type, dictionaryStyle
  * @returns {string}
  */
 function addGlossaryScopeToCss(css) {
-    return addScopeToCss(css, '.yomitan-glossary');
+    return addScopeToCssLegacy(css, '.yomitan-glossary');
 }
 
 /**
@@ -602,7 +602,7 @@ function addDictionaryScopeToCss(css, dictionaryTitle) {
         .replace(/\\/g, '\\\\')
         .replace(/"/g, '\\"');
 
-    return addScopeToCss(css, `[data-dictionary="${escapedTitle}"]`);
+    return addScopeToCssLegacy(css, `[data-dictionary="${escapedTitle}"]`);
 }
 
 /**

--- a/types/ext/offscreen.d.ts
+++ b/types/ext/offscreen.d.ts
@@ -99,6 +99,12 @@ type ApiSurface = {
         params: void;
         return: void;
     };
+    sanitizeCSSOffscreen: {
+        params: {
+            css: string;
+        };
+        return: string;
+    };
 };
 
 export type ApiMessage<TName extends ApiNames> = (


### PR DESCRIPTION
Fixes #2125

- Problem 1:

`addScopeToCssLegacy` requires a DOM so it doesn't really work with the API. But it works with old versions of browsers such as what Anki was using prior to version 25.02.

`addScopeToCss` works no problem with the api since it's just string concatenation. However, it breaks on older versions of Anki and browsers.

`addScopeToCssLegacy` now has a fallback to `addScopeToCss` that will trigger when DOM is not present to allow the API (and certain nodejs tests) to continue using `addScopeToCss`.

This change only targets Anki and the Yomitan API. Browser rendering is untouched and will continue to use `addScopeToCss`. (using an over 2 year old browser is ridiculous (https://caniuse.com/css-nesting))

- Problem 2:

CSS nesting and certain selectors are unsupported by CSSOM.js (which is also unmaintained...), a dependency of LinkeDOM for handling the DOM in a DOMless state.

This is no problem for Yomitan API adding scope to CSS (it's just string concatenation no real parsing) but any dictionary with CSS that wants to use nesting within their own CSS file has to be able to pass the API's CSS sanitization. CSSOM cannot help sanitize any nested CSS, not even nested CSS using the `&` nesting selector.

I've added sanitization to the offscreen page so the API can communicate with a page that has a DOM in order to do sanitization.

In the future, it may be necessary to move the API's Anki rendering entirely to the offscreen page and remove LinkeDOM entirely, but that can be left to another PR.
