### PR TITLE
Allow sentence-furigana and sentence-furigana plain to be seen by all languages

### DIFF
--- a/ext/js/data/anki-template-util.js
+++ b/ext/js/data/anki-template-util.js
@@ -57,6 +57,8 @@ export function getStandardFieldMarkers(type, language = 'ja') {
                 'search-query',
                 'popup-selection-text',
                 'sentence',
+                'sentence-furigana',
+                'sentence-furigana-plain',
                 'tags',
                 'url',
             ];
@@ -70,8 +72,6 @@ export function getStandardFieldMarkers(type, language = 'ja') {
                     'pitch-accent-graphs-jj',
                     'pitch-accent-positions',
                     'pitch-accent-categories',
-                    'sentence-furigana',
-                    'sentence-furigana-plain',
                 );
             }
             return markers;


### PR DESCRIPTION
These were hidden in the dropdown for all languages besides Japanese with #1933. The handlebars still worked but just couldn't be found as easily.

Partial fix for #1964, not renaming them for now.