### PR TITLE
Add data transmission consent modal for firefox

### DIFF
--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -890,7 +890,7 @@ select.short-height {
     margin-top: var(--modal-button-spacing);
 }
 .modal-footer-spaced {
-    justify-content: space-between;
+    justify-content: space-evenly;
 }
 .modal-body {
     flex: 1 1 auto;

--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -889,6 +889,9 @@ select.short-height {
     margin-right: var(--modal-button-spacing);
     margin-top: var(--modal-button-spacing);
 }
+.modal-footer-spaced {
+    justify-content: space-between;
+}
 .modal-body {
     flex: 1 1 auto;
     overflow: auto;

--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -1324,7 +1324,8 @@
         "global": {
             "type": "object",
             "required": [
-                "database"
+                "database",
+                "dataTransmissionConsentShown"
             ],
             "properties": {
                 "database": {
@@ -1338,6 +1339,10 @@
                             "default": false
                         }
                     }
+                },
+                "dataTransmissionConsentShown": {
+                    "type": "boolean",
+                    "default": false
                 }
             }
         }

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -582,6 +582,7 @@ export class OptionsUtil {
             this._updateVersion68,
             this._updateVersion69,
             this._updateVersion70,
+            this._updateVersion71,
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1784,6 +1785,14 @@ export class OptionsUtil {
         for (const profile of options.profiles) {
             profile.options.audio.enableDefaultAudioSources = true;
         }
+    }
+
+    /**
+     *  - Added global.dataTransmissionConsentShown
+     *  @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion71(options) {
+        options.global.dataTransmissionConsentShown = false;
     }
 
     /**

--- a/ext/js/pages/settings/data-transmission-consent-controller.js
+++ b/ext/js/pages/settings/data-transmission-consent-controller.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {querySelectorNotNull} from '../../dom/query-selector.js';
+import {ModalController} from './modal-controller.js';
+
+export class DataTransmissionConsentController {
+    /**
+     * @param {import('./settings-controller.js').SettingsController} settingsController
+     * @param {ModalController} modalController
+     */
+    constructor(settingsController, modalController) {
+        /** @type {import('./settings-controller.js').SettingsController} */
+        this._settingsController = settingsController;
+        /** @type {ModalController} */
+        this._modalController = modalController;
+        /** @type {?HTMLButtonElement} */
+        this._acceptDataTransmissionButton = null;
+        /** @type {?HTMLButtonElement} */
+        this._declineDataTransmissionButton = null;
+    }
+
+    /** */
+    async prepare() {
+        const firefoxDataTransmissionModal = this._modalController.getModal('firefox-data-transmission-consent');
+
+        if (firefoxDataTransmissionModal) {
+            this._acceptDataTransmissionButton = /** @type {HTMLButtonElement} */ (querySelectorNotNull(document, '#accept-data-transmission'));
+            this._declineDataTransmissionButton = /** @type {HTMLButtonElement} */ (querySelectorNotNull(document, '#decline-data-transmission'));
+
+            this._acceptDataTransmissionButton.addEventListener('click', this._onAccept.bind(this));
+            this._declineDataTransmissionButton.addEventListener('click', this._onDecline.bind(this));
+
+            const options = await this._settingsController.getOptionsFull();
+            firefoxDataTransmissionModal?.setVisible(!options.global.dataTransmissionConsentShown);
+        }
+    }
+
+    // Private
+
+    /** */
+    async _onAccept() {
+        await this._settingsController.setGlobalSetting('global.dataTransmissionConsentShown', true);
+    }
+
+    /** */
+    async _onDecline() {
+        await this._settingsController.setGlobalSetting('global.dataTransmissionConsentShown', true);
+        await this._settingsController.setProfileSetting('audio.enabled', false);
+    }
+}

--- a/ext/js/pages/settings/modal.js
+++ b/ext/js/pages/settings/modal.js
@@ -28,6 +28,8 @@ export class Modal extends PanelElement {
         this._contentNode = null;
         /** @type {boolean} */
         this._canCloseOnClick = false;
+        /** @type {boolean} */
+        this.forceInteract = node.classList.contains('force-interact');
     }
 
     /** */
@@ -52,7 +54,7 @@ export class Modal extends PanelElement {
      * @param {MouseEvent} e
      */
     _onModalContainerMouseDown(e) {
-        this._canCloseOnClick = (e.currentTarget === e.target);
+        this._canCloseOnClick = (e.currentTarget === e.target) && !this.forceInteract;
     }
 
     /**

--- a/ext/js/pages/settings/settings-display-controller.js
+++ b/ext/js/pages/settings/settings-display-controller.js
@@ -318,7 +318,7 @@ export class SettingsDisplayController {
         }
 
         const modal = this._modalController.getTopVisibleModal();
-        if (modal !== null) {
+        if (modal !== null && !modal.forceInteract) {
             modal.setVisible(false);
         }
     }

--- a/ext/js/pages/welcome-main.js
+++ b/ext/js/pages/welcome-main.js
@@ -20,6 +20,7 @@ import {Application} from '../application.js';
 import {DocumentFocusController} from '../dom/document-focus-controller.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
 import {ExtensionContentController} from './common/extension-content-controller.js';
+import {DataTransmissionConsentController} from './settings/data-transmission-consent-controller.js';
 import {DictionaryController} from './settings/dictionary-controller.js';
 import {DictionaryImportController} from './settings/dictionary-import-controller.js';
 import {GenericSettingController} from './settings/generic-setting-controller.js';
@@ -61,7 +62,7 @@ async function checkNeedsCustomTemplatesWarning() {
 }
 
 await Application.main(true, async (application) => {
-    const modalController = new ModalController(['shared-modals']);
+    const modalController = new ModalController(['shared-modals', 'settings-modals']);
     await modalController.prepare();
 
     const settingsController = new SettingsController(application);
@@ -108,6 +109,9 @@ await Application.main(true, async (application) => {
 
     const recommendedSettingsController = new RecommendedSettingsController(settingsController);
     preparePromises.push(recommendedSettingsController.prepare());
+
+    const dataTransmissionConsentController = new DataTransmissionConsentController(settingsController, modalController);
+    preparePromises.push(dataTransmissionConsentController.prepare());
 
     await Promise.all(preparePromises);
 

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -1644,12 +1644,11 @@
     <div id="firefox-data-transmission-consent-modal" data-show-for-browser="firefox firefox-mobile" class="modal" tabindex="-1" role="dialog" hidden><div class="modal-content">
         <div class="modal-header"><div class="modal-title">Data Transmission Consent</div></div>
         <div class="modal-body">
-            <p>To comply with <a href="https://extensionworkshop.com/documentation/publish/add-on-policies/">Firefox Add-On Policies</a>, Yomitan is required to ask for your permission to enable the term audio playback setting by default.</p>
-            <p>Yomitan data is stored locally on your device. Yomitan does not sell or externally collect any user data. Some features require sending data to third party services.</p>
-            <p><b>Declining data transmission will disallow pronunciation audio playback for any terms searched.</b></p>
-            <p>Audio playback may send the term, reading, and/or language for any dictionary entry term where the Play Audio speaker button is pressed. <b>Personally identifying information is never sent.</b></p>
-            <p>Full details on Yomitan's use of data transmission are provided in the <a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Yomitan Privacy Policy</a>.</p>
-        </div>
+            <p>To comply with <a href="https://extensionworkshop.com/documentation/publish/add-on-policies/">Firefox Add-On Policies</a>, Yomitan is required to get your verification that you are comfortable with any default data transmission the extension does.</p>
+            <p>Yomitan does very little data transmission, as Yomitan data is stored locally on your device. Yomitan does not sell or externally collect any user data.</p>
+            <p><b>The only place data transmission is done by default is when the audio icon in the Yomitan popup is clicked to play the audio for a term; in this case a request will be sent to the audio provider configured in your settings.</b></p>
+            <p>This request may contain the term, reading, and/or language for the given dictionary entry term. <b>Personally identifying information is never sent.</b></p>
+            <p>Full details on Yomitan's use of data transmission are provided in the <a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Yomitan Privacy Policy</a>.</p>        </div>
         <div class="modal-footer modal-footer-spaced">
             <button type="button" class="danger low-emphasis" data-modal-action="hide" id="decline-data-transmission">Decline data transmission<br>(disable audio playback)</button>
             <button type="button" class="low-emphasis" data-modal-action="hide" id="accept-data-transmission">Agree to data transmission<br>(enable audio playback)</button>

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -1641,7 +1641,7 @@
     </div></div>
 
     <!-- Firefox Data Transmission Consent -->
-    <div id="firefox-data-transmission-consent-modal" data-show-for-browser="firefox firefox-mobile" class="modal" tabindex="-1" role="dialog" hidden><div class="modal-content">
+    <div id="firefox-data-transmission-consent-modal" data-show-for-browser="firefox firefox-mobile" class="modal force-interact" tabindex="-1" role="dialog" hidden><div class="modal-content">
         <div class="modal-header"><div class="modal-title">Data Transmission Consent</div></div>
         <div class="modal-body">
             <p>To comply with <a href="https://extensionworkshop.com/documentation/publish/add-on-policies/">Firefox Add-On Policies</a>, Yomitan is required to get your verification that you are comfortable with any default data transmission the extension does.</p>

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -1639,6 +1639,22 @@
             <button type="button" class="danger" id="hotkey-list-reset" data-modal-action="hide">Reset All</button>
         </div>
     </div></div>
+
+    <!-- Firefox Data Transmission Consent -->
+    <div id="firefox-data-transmission-consent-modal" class="modal" tabindex="-1" role="dialog" hidden><div class="modal-content">
+        <div class="modal-header"><div class="modal-title">Data Transmission Consent</div></div>
+        <div class="modal-body">
+            <p>To comply with <a href="https://extensionworkshop.com/documentation/publish/add-on-policies/">Firefox Add-On Policies</a>, Yomitan is required to ask for your permission to enable the term audio playback setting by default.</p>
+            <p>Yomitan data is stored locally on your device. Yomitan does not sell or externally collect any user data. Some features require sending data to third party services.</p>
+            <p><b>Declining data transmission will disallow pronunciation audio playback for any terms searched.</b></p>
+            <p>Audio playback may send the term, reading, and/or language for any dictionary entry term where the Play Audio speaker button is pressed. <b>Personally identifying information is never sent.</b></p>
+            <p>Full details on Yomitan's use of data transmission are provided in the <a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Yomitan Privacy Policy</a>.</p>
+        </div>
+        <div class="modal-footer modal-footer-spaced">
+            <button type="button" class="danger low-emphasis" data-modal-action="hide" id="decline-data-transmission">Decline data transmission<br>(disable audio playback)</button>
+            <button type="button" class="low-emphasis" data-modal-action="hide" id="accept-data-transmission">Agree to data transmission<br>(enable audio playback)</button>
+        </div>
+    </div></div>
 </template>
 
 </body></html>

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -1641,7 +1641,7 @@
     </div></div>
 
     <!-- Firefox Data Transmission Consent -->
-    <div id="firefox-data-transmission-consent-modal" class="modal" tabindex="-1" role="dialog" hidden><div class="modal-content">
+    <div id="firefox-data-transmission-consent-modal" data-show-for-browser="firefox firefox-mobile" class="modal" tabindex="-1" role="dialog" hidden><div class="modal-content">
         <div class="modal-header"><div class="modal-title">Data Transmission Consent</div></div>
         <div class="modal-body">
             <p>To comply with <a href="https://extensionworkshop.com/documentation/publish/add-on-policies/">Firefox Add-On Policies</a>, Yomitan is required to ask for your permission to enable the term audio playback setting by default.</p>

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -23,6 +23,21 @@
 <div class="content-left"></div>
 <div class="content-center">
 
+    <div id="firefox-data-transmission-consent" class="modal" tabindex="-1" role="dialog"><div class="modal-content">
+        <div class="modal-header"><div class="modal-title">Data Transmission Consent</div></div>
+        <div class="modal-body">
+            <p>To comply with <a href="https://extensionworkshop.com/documentation/publish/add-on-policies/">Firefox Add-On Policies</a>, Yomitan is required to ask for your permission to enable the term audio playback setting by default.</p>
+            <p>Yomitan data is stored locally on your device. Yomitan does not sell or externally collect any user data. Some features require sending data to third party services.</p>
+            <p><b>Declining data transmission will disallow pronunciation audio playback for any terms searched.</b></p>
+            <p>Audio playback may send the term, reading, and/or language for any dictionary entry term where the Play Audio speaker button is pressed. <b>Personally identifying information is never sent.</b></p>
+            <p>Full details on Yomitan's use of data transmission are provided in the <a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Yomitan Privacy Policy</a>.</p>
+        </div>
+        <div class="modal-footer modal-footer-spaced">
+            <button type="button" class="danger low-emphasis" data-modal-action="hide" id="decline-data-transmission">Decline data transmission<br>(disable audio playback)</button>
+            <button type="button" class="low-emphasis" data-modal-action="hide" id="accept-data-transmission">Agree to data transmission<br>(enable audio playback)</button>
+        </div>
+    </div></div>
+
     <span tabindex="-1" id="content-scroll-focus"></span>
 
     <h1>Welcome to Yomitan!</h1>

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -22,22 +22,6 @@
 <div class="content-outer"><div class="content scrollbar">
 <div class="content-left"></div>
 <div class="content-center">
-
-    <div id="firefox-data-transmission-consent" class="modal" tabindex="-1" role="dialog"><div class="modal-content">
-        <div class="modal-header"><div class="modal-title">Data Transmission Consent</div></div>
-        <div class="modal-body">
-            <p>To comply with <a href="https://extensionworkshop.com/documentation/publish/add-on-policies/">Firefox Add-On Policies</a>, Yomitan is required to ask for your permission to enable the term audio playback setting by default.</p>
-            <p>Yomitan data is stored locally on your device. Yomitan does not sell or externally collect any user data. Some features require sending data to third party services.</p>
-            <p><b>Declining data transmission will disallow pronunciation audio playback for any terms searched.</b></p>
-            <p>Audio playback may send the term, reading, and/or language for any dictionary entry term where the Play Audio speaker button is pressed. <b>Personally identifying information is never sent.</b></p>
-            <p>Full details on Yomitan's use of data transmission are provided in the <a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Yomitan Privacy Policy</a>.</p>
-        </div>
-        <div class="modal-footer modal-footer-spaced">
-            <button type="button" class="danger low-emphasis" data-modal-action="hide" id="decline-data-transmission">Decline data transmission<br>(disable audio playback)</button>
-            <button type="button" class="low-emphasis" data-modal-action="hide" id="accept-data-transmission">Agree to data transmission<br>(enable audio playback)</button>
-        </div>
-    </div></div>
-
     <span tabindex="-1" id="content-scroll-focus"></span>
 
     <h1>Welcome to Yomitan!</h1>

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -691,11 +691,12 @@ function createOptionsUpdatedTestData1() {
             },
         ],
         profileCurrent: 0,
-        version: 70,
+        version: 71,
         global: {
             database: {
                 prefixWildcardsSupported: false,
             },
+            dataTransmissionConsentShown: false,
         },
     };
 }

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -63,6 +63,7 @@ export type Options = {
 
 export type GlobalOptions = {
     database: GlobalDatabaseOptions;
+    dataTransmissionConsentShown: boolean;
 };
 
 export type GlobalDatabaseOptions = {


### PR DESCRIPTION
Only shows on Firefox so test on Firefox or manually edit the HTML to show it on Chromium browsers.

Using a global setting for checking if it has been shown instead of a profile setting. Seems pointless to do this per profile.

<img width="592" height="394" alt="image" src="https://github.com/user-attachments/assets/99f2a4a4-2f24-4e6e-bed2-0a39fddb499b" />
