### PR TITLE
Add custom target tags functionality

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -947,6 +947,7 @@
                                     "fieldTemplates",
                                     "suspendNewCards",
                                     "displayTagsAndFlags",
+                                    "targetTags",
                                     "noteGuiMode",
                                     "apiKey",
                                     "downloadTimeout"
@@ -1098,8 +1099,15 @@
                                     },
                                     "displayTagsAndFlags": {
                                         "type": "string",
-                                        "enum": ["never", "always", "non-standard"],
+                                        "enum": ["never", "always", "non-standard", "custom"],
                                         "default": "never"
+                                    },
+                                    "targetTags": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "default": []
                                     },
                                     "noteGuiMode": {
                                         "type": "string",

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -582,6 +582,7 @@ export class OptionsUtil {
             this._updateVersion68,
             this._updateVersion69,
             this._updateVersion70,
+            this._updateVersion71,
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1783,6 +1784,16 @@ export class OptionsUtil {
     async _updateVersion70(options) {
         for (const profile of options.profiles) {
             profile.options.audio.enableDefaultAudioSources = true;
+        }
+    }
+
+    /**
+     *  - Added anki.targetTags
+     *  @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion71(options) {
+        for (const profile of options.profiles) {
+            profile.options.anki.targetTags = [];
         }
     }
 

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -91,6 +91,8 @@ export class DisplayAnki {
         this._audioDownloadIdleTimeout = null;
         /** @type {string[]} */
         this._noteTags = [];
+        /** @type {string[]} */
+        this._targetTags = [];
         /** @type {import('settings').AnkiCardFormat[]} */
         this._cardFormats = [];
         /** @type {import('settings').DictionariesOptions} */
@@ -196,6 +198,7 @@ export class DisplayAnki {
             dictionaries,
             anki: {
                 tags,
+                targetTags,
                 duplicateScope,
                 duplicateScopeCheckAllModels,
                 duplicateBehavior,
@@ -224,6 +227,7 @@ export class DisplayAnki {
         this._scanLength = scanLength;
         this._noteGuiMode = noteGuiMode;
         this._noteTags = [...tags];
+        this._targetTags = [...targetTags];
         this._audioDownloadIdleTimeout = (Number.isFinite(downloadTimeout) && downloadTimeout > 0 ? downloadTimeout : null);
         this._cardFormats = cardFormats;
         this._dictionaries = dictionaries;
@@ -504,6 +508,16 @@ export class DisplayAnki {
         }
         if (this._displayTagsAndFlags === 'non-standard') {
             for (const tag of this._noteTags) {
+                displayTags.delete(tag);
+            }
+        } else if (this._displayTagsAndFlags === 'custom') {
+            const tagsToRemove = [];
+            for (const tag of displayTags) {
+                if (typeof tag === 'string' && !this._targetTags.includes(tag)) {
+                    tagsToRemove.push(tag);
+                }
+            }
+            for (const tag of tagsToRemove) {
                 displayTags.delete(tag);
             }
         }

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1983,10 +1983,17 @@
                     </div>
                 </div>
                 <div class="settings-item-right">
-                    <select data-setting="anki.displayTagsAndFlags">
+                    <select data-setting="anki.displayTagsAndFlags"
+                        data-transform='{
+                            "type": "setVisibility",
+                            "selector": "#anki-target-tags-option",
+                            "condition": {"op": "===", "value": "custom"}
+                        }'
+                    >
                         <option value="never">Never</option>
                         <option value="always">Always</option>
                         <option value="non-standard">Non-standard</option>
+                        <option value="custom">Custom</option>
                     </select>
                 </div>
             </div>
@@ -1994,7 +2001,8 @@
                 <p>
                     When coming across a word that is already in an Anki deck, two buttons can appear that show
                     the tags and flags the card has. If set to <em>Non-standard</em>, all tags that are included in the
-                    <em>Card tags</em> option will be filtered out from the list. If no tags remain after filtering,
+                    <em>Card tags</em> option will be filtered out from the list. If set to <em>Custom</em>, only tags that are included in the
+                    <em>Target tags</em> option will be shown. If no tags remain after filtering,
                     then the tags button will not be shown. If no flags are found, the flags button will not be shown.
                 </p>
                 <p>
@@ -2002,6 +2010,20 @@
                 </p>
             </div>
         </div>
+        <div class="settings-item advanced-only" id="anki-target-tags-option" hidden><div class="settings-item-inner settings-item-inner-wrappable">
+            <div class="settings-item-left">
+                <div class="settings-item-label">Target tags</div>
+                <div class="settings-item-description">List of space or comma separated tags.</div>
+            </div>
+            <div class="settings-item-right">
+                <input type="text" spellcheck="false" autocomplete="off" data-setting="anki.targetTags"
+                    data-transform='[
+                        {"type": "splitTags", "step": "pre"},
+                        {"type": "joinTags", "step": "post"}
+                    ]'
+                >
+            </div>
+        </div></div>
         <div class="settings-item settings-item-button" data-modal-action="show,anki-cards"><div class="settings-item-inner">
             <div class="settings-item-left">
                 <div class="settings-item-label">Configure Anki flashcards&hellip;</div>

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -529,6 +529,7 @@ function createProfileOptionsUpdatedTestData1() {
             duplicateScope: 'collection',
             duplicateScopeCheckAllModels: false,
             displayTagsAndFlags: 'never',
+            targetTags: [],
             checkForDuplicates: true,
             fieldTemplates: null,
             suspendNewCards: false,
@@ -691,7 +692,7 @@ function createOptionsUpdatedTestData1() {
             },
         ],
         profileCurrent: 0,
-        version: 70,
+        version: 71,
         global: {
             database: {
                 prefixWildcardsSupported: false,

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -303,6 +303,7 @@ export type AnkiOptions = {
     fieldTemplates: string | null;
     suspendNewCards: boolean;
     displayTagsAndFlags: AnkiDisplayTagsAndFlags;
+    targetTags: string[];
     noteGuiMode: AnkiNoteGuiMode;
     apiKey: string;
     downloadTimeout: number;
@@ -429,7 +430,7 @@ export type AnkiDuplicateScope = 'collection' | 'deck' | 'deck-root';
 
 export type AnkiDuplicateBehavior = 'prevent' | 'overwrite' | 'new';
 
-export type AnkiDisplayTagsAndFlags = 'never' | 'always' | 'non-standard';
+export type AnkiDisplayTagsAndFlags = 'never' | 'always' | 'non-standard' | 'custom';
 
 export type AnkiNoteGuiMode = 'browse' | 'edit';
 


### PR DESCRIPTION
Fixes #2127 

This adds a new setting "Custom" to "Show card tags and flags" that allows users to enter target tags. When used, tags will only be shown for words with card matching one of the tags.