### PR TITLE
Disallow wildcard scanning outside of search page

### DIFF
--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -516,6 +516,7 @@ export class Frontend {
             sentenceParsingOptions,
             scanWithoutMousemove: scanningOptions.scanWithoutMousemove,
             scanResolution: scanningOptions.scanResolution,
+            pageType: this._pageType,
         });
         this._updateTextScannerEnabled();
 

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -2089,6 +2089,7 @@ export class Display extends EventDispatcher {
             preventMiddleMouseOnPage: false,
             preventMiddleMouseOnTextHover: false,
             sentenceParsingOptions,
+            pageType: this._pageType,
         });
 
         this._contentTextScanner.setEnabled(true);

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -272,6 +272,7 @@ export class TextScanner extends EventDispatcher {
         matchTypePrefix,
         scanWithoutMousemove,
         scanResolution,
+        pageType,
     }) {
         if (Array.isArray(inputs)) {
             this._inputs = inputs.map((input) => this._convertInput(input));
@@ -301,7 +302,7 @@ export class TextScanner extends EventDispatcher {
             this._preventMiddleMouseOnTextHover = preventMiddleMouseOnTextHover;
         }
         if (typeof matchTypePrefix === 'boolean') {
-            this._matchTypePrefix = matchTypePrefix;
+            this._matchTypePrefix = pageType === 'search' ? matchTypePrefix : false;
         }
         if (typeof scanWithoutMousemove === 'boolean') {
             this._scanWithoutMousemove = scanWithoutMousemove;

--- a/types/ext/text-scanner.d.ts
+++ b/types/ext/text-scanner.d.ts
@@ -23,6 +23,7 @@ import type * as Input from './input';
 import type * as Settings from './settings';
 import type * as TextSource from './text-source';
 import type {EventNames, EventArgument as BaseEventArgument} from './core';
+import {PageType} from 'frontend';
 
 export type SearchResultDetail = {
     documentTitle: string;
@@ -42,6 +43,7 @@ export type Options = {
     sentenceParsingOptions?: SentenceParsingOptions;
     scanWithoutMousemove?: boolean;
     scanResolution?: string;
+    pageType?: PageType;
 };
 
 export type InputOptionsOuter = {


### PR DESCRIPTION
Fixes #2139

Only the search page can perform wildcard searches. It is useless and can massively hurt performance to allow them to occur elsewhere.