### PR TITLE
Add parentheses to privacy policy and move into previous sentence to separate better from subsequent text

### DIFF
--- a/ext/settings.html
+++ b/ext/settings.html
@@ -183,8 +183,7 @@
                             Enable support for sending local web requests to fetch data from Yomitan.
                         </div>
                         <div class="settings-item-description">
-                            This option may send data outside of Yomitan to local applications that request it.
-                            <span data-show-for-browser="firefox firefox-mobile"><a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Privacy Policy</a></span>
+                            This option may send data outside of Yomitan to local applications that request it<span data-show-for-browser="firefox firefox-mobile"> (<a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Privacy Policy</a>)</span>.
                             <a tabindex="0" class="more-toggle more-only" data-parent-distance="4">More&hellip;</a>
                         </div>
                     </div>
@@ -1466,8 +1465,7 @@
                 <div class="settings-item-label">Enable audio playback for terms</div>
                 <div class="settings-item-description">Show a clickable speaker icon next to search results.</div>
                 <div class="settings-item-description">
-                    This option may send term, reading, and/or language outside of Yomitan to fetch audio.
-                    <span data-show-for-browser="firefox firefox-mobile"><a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Privacy Policy</a></span>
+                    This option may send term, reading, and/or language outside of Yomitan to fetch audio<span data-show-for-browser="firefox firefox-mobile"> (<a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Privacy Policy</a>)</span>.
                 </div>
             </div>
             <div class="settings-item-right">
@@ -1572,8 +1570,7 @@
                     </div>
                     <div class="settings-item-description">Sentence words are parsed using a third-party program. Japanese only.</div>
                     <div class="settings-item-description">
-                        This option may send search query data outside of Yomitan for parsing.
-                        <span data-show-for-browser="firefox firefox-mobile"><a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Privacy Policy</a></span>
+                        This option may send search query data outside of Yomitan for parsing<span data-show-for-browser="firefox firefox-mobile"> (<a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Privacy Policy</a>)</span>.
                         <a tabindex="0" class="more-toggle more-only" data-parent-distance="4">More&hellip;</a>
                     </div>
                 </div>
@@ -1705,8 +1702,7 @@
                         <span>Connection status:</span>
                         <span id="anki-error-message">&hellip;</span> <a tabindex="0" id="anki-error-message-details-toggle" hidden>Details&hellip;</a>
                         <div class="settings-item-description">
-                            This option may send limited information about the current webpage, information contained in Yomitan dictionary entries, and/or relevant user settings outside of Yomitan to Anki.
-                            <span data-show-for-browser="firefox firefox-mobile"><a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Privacy Policy</a></span>
+                            This option may send limited information about the current webpage, information contained in Yomitan dictionary entries, and/or relevant user settings outside of Yomitan to Anki<span data-show-for-browser="firefox firefox-mobile"> (<a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Privacy Policy</a>)</span>.
                         </div>
                     </div>
                 </div>

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -117,8 +117,7 @@
                 <div class="settings-item-label">Enable audio playback for terms</div>
                 <div class="settings-item-description">Show a clickable speaker icon next to search results.</div>
                 <div class="settings-item-description">
-                    This option may send term, reading, and/or language outside of Yomitan to fetch audio when the speaker icon is clicked. Personally identifying information is never sent.
-                    <span data-show-for-browser="firefox firefox-mobile"><a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Privacy Policy</a></span>
+                    This option may send term, reading, and/or language outside of Yomitan to fetch audio when the speaker icon is clicked. Personally identifying information is never sent<span data-show-for-browser="firefox firefox-mobile"> (<a href="https://addons.mozilla.org/en-US/firefox/addon/yomitan/privacy/">Privacy Policy</a>)</span>.
                     <div data-show-for-browser="firefox firefox-mobile">Disabling this option will disallow pronunciation audio playback for any terms searched.</div>
                 </div>
             </div>


### PR DESCRIPTION
Bad visual clarity between the privacy policy and the `More...` "button". Only applies to Firefox since these privacy policy listings don't appear on other browsers.

Before:
<img width="576" height="90" alt="image" src="https://github.com/user-attachments/assets/fc1034c0-1830-452c-a917-f422d8f0a7b3" />
After:
<img width="578" height="89" alt="image" src="https://github.com/user-attachments/assets/42e6476e-754e-432d-b079-6cbdefe79cb5" />

