### PR TITLE
Clarify usage of Flags type in Profile Conditions

### DIFF
--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -427,8 +427,8 @@
                         If no conditions are specified, the profile will only be used if it is selected as the default profile.
                     </p>
                     <p>
-                        Note: The Flags type only works with a text input of "clipboard" (remove quotations).
-                        This allows usage of another profile in the search window created by copying text
+                        The Flags type only works with an input of <code>clipboard</code>.
+                        This allows the usage of another profile in the search window created by copying text.
                     </p>
                     <p>
                         <a tabindex="0" class="more-toggle" data-parent-distance="3">Hide&hellip;</a>

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -427,6 +427,10 @@
                         If no conditions are specified, the profile will only be used if it is selected as the default profile.
                     </p>
                     <p>
+                        Note: The Flags type only works with a text input of "clipboard" (remove quotations).
+                        This allows usage of another profile in the search window created by copying text
+                    </p>
+                    <p>
                         <a tabindex="0" class="more-toggle" data-parent-distance="3">Hide&hellip;</a>
                     </p>
                 </div>

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -427,8 +427,8 @@
                         If no conditions are specified, the profile will only be used if it is selected as the default profile.
                     </p>
                     <p>
-                        The Flags type only works with an input of <code>clipboard</code>.
-                        This allows the usage of another profile in the search window created by copying text.
+                        When using the Flags condition, <code>clipboard</code> is the only valid input. 
+                        This lets the search page apply another profile’s settings when text is copied, provided <code>Enable search page clipboard text monitoring</code> is enabled.
                     </p>
                     <p>
                         <a tabindex="0" class="more-toggle" data-parent-distance="3">Hide&hellip;</a>

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -427,7 +427,7 @@
                         If no conditions are specified, the profile will only be used if it is selected as the default profile.
                     </p>
                     <p>
-                        When using the Flags condition, <code>clipboard</code> is the only valid input. 
+                        When using the Flags condition, <code>clipboard</code> is the only valid input.
                         This lets the search page apply another profile’s settings when text is copied, provided <code>Enable search page clipboard text monitoring</code> is enabled.
                     </p>
                     <p>


### PR DESCRIPTION
Addresses issue #1124. Let me know if I should fix the description. 

On a side note, I've noticed that every time I use the flags to trigger profile change upon copying to clipboard, the search window always displays the profile that is set as the default as the profile in the search window. 
Example: I have the Clipboard and No Clipboard profiles. Clipboard has the Flag condition for when "clipboard" is included as a tag. No Clipboard is set as the default profile. Upon copying text the search window is created, and No Clipboard will be displayed as the profile in use because it is the default profile even though Clipboard's settings are used. It's pretty minor, though.

Also in https://github.com/FooSoft/yomichan/issues/1504#issuecomment-793132798 , it's mentioned to use the `\s+` regex to filter out white space. Is it worth putting in Translation > Custom Text Replacement Patterns?

<img width="602" height="334" alt="image" src="https://github.com/user-attachments/assets/4c58d189-15d9-45c2-8a15-eb12db49cf9b" />