### PR TITLE
Sample sentence audio

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -1995,6 +1995,13 @@ button.footer-notification-close-button {
 .popup-menu-item-group[data-is-primary-card-audio=true]>.popup-menu-item-audio-button~.popup-menu-item-set-primary-audio-button:focus .popup-menu-item-icon {
     opacity: 1;
 }
+.popup-menu-item-group[data-is-sentence-card-audio=true]>.popup-menu-item-audio-button~.popup-menu-item-set-primary-audio-button .popup-menu-item-icon,
+.popup-menu-item-group[data-is-sentence-card-audio=true]>.popup-menu-item-audio-button~.popup-menu-item-set-primary-audio-button:hover .popup-menu-item-icon,
+.popup-menu-item-group[data-is-sentence-card-audio=true]>.popup-menu-item-audio-button~.popup-menu-item-set-primary-audio-button:active .popup-menu-item-icon,
+.popup-menu-item-group[data-is-sentence-card-audio=true]>.popup-menu-item-audio-button~.popup-menu-item-set-primary-audio-button:focus .popup-menu-item-icon {
+    opacity: 1;
+    background-color:cornflowerblue;
+}
 
 
 /* Anki errors */

--- a/ext/data/schemas/custom-audio-list-schema.json
+++ b/ext/data/schemas/custom-audio-list-schema.json
@@ -26,6 +26,9 @@
                     },
                     "url": {
                         "type": "string"
+                    },
+                    "sentence": {
+                        "type": "string"
                     }
                 }
             }

--- a/ext/data/templates/default-anki-field-templates.handlebars
+++ b/ext/data/templates/default-anki-field-templates.handlebars
@@ -36,6 +36,16 @@
     {{~/if~}}
 {{/inline}}
 
+{{#*inline "sample-sentence-audio"}}
+    {{~#if (hasMedia "sampleSentenceAudio")~}}
+        [sound:{{getMedia "sampleSentenceAudio"}}]
+    {{~/if~}}
+{{/inline}}
+
+{{#*inline "sample-sentence-text"}}
+    {{~#if (hasMedia "sampleSentenceText")}}{{{getMedia "sampleSentenceText"}}}{{/if~}}
+{{/inline}}
+
 {{#*inline "character"}}
     {{~definition.character~}}
 {{/inline}}

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -125,13 +125,14 @@ export class API {
      * @param {import('api').ApiParam<'injectAnkiNoteMedia', 'timestamp'>} timestamp
      * @param {import('api').ApiParam<'injectAnkiNoteMedia', 'definitionDetails'>} definitionDetails
      * @param {import('api').ApiParam<'injectAnkiNoteMedia', 'audioDetails'>} audioDetails
+     * @param {import('api').ApiParam<'injectAnkiNoteMedia', 'sampleSentenceAudioDetails'>} sampleSentenceAudioDetails
      * @param {import('api').ApiParam<'injectAnkiNoteMedia', 'screenshotDetails'>} screenshotDetails
      * @param {import('api').ApiParam<'injectAnkiNoteMedia', 'clipboardDetails'>} clipboardDetails
      * @param {import('api').ApiParam<'injectAnkiNoteMedia', 'dictionaryMediaDetails'>} dictionaryMediaDetails
      * @returns {Promise<import('api').ApiReturn<'injectAnkiNoteMedia'>>}
      */
-    injectAnkiNoteMedia(timestamp, definitionDetails, audioDetails, screenshotDetails, clipboardDetails, dictionaryMediaDetails) {
-        return this._invoke('injectAnkiNoteMedia', {timestamp, definitionDetails, audioDetails, screenshotDetails, clipboardDetails, dictionaryMediaDetails});
+    injectAnkiNoteMedia(timestamp, definitionDetails, audioDetails, sampleSentenceAudioDetails, screenshotDetails, clipboardDetails, dictionaryMediaDetails) {
+        return this._invoke('injectAnkiNoteMedia', {timestamp, definitionDetails, audioDetails, sampleSentenceAudioDetails, screenshotDetails, clipboardDetails, dictionaryMediaDetails});
     }
 
     /**

--- a/ext/js/data/anki-note-builder.js
+++ b/ext/js/data/anki-note-builder.js
@@ -395,6 +395,8 @@ export class AnkiNoteBuilder {
 
         // Parse requirements
         let injectAudio = false;
+        let injectSampleSentenceAudio = false;
+        let injectSampleSentenceText = false;
         let injectScreenshot = false;
         let injectClipboardImage = false;
         let injectClipboardText = false;
@@ -407,6 +409,8 @@ export class AnkiNoteBuilder {
             const {type} = requirement;
             switch (type) {
                 case 'audio': injectAudio = true; break;
+                case 'sampleSentenceAudio': injectSampleSentenceAudio = true; break;
+                case 'sampleSentenceText': injectSampleSentenceText = true; break;
                 case 'screenshot': injectScreenshot = true; break;
                 case 'clipboardImage': injectClipboardImage = true; break;
                 case 'clipboardText': injectClipboardText = true; break;
@@ -430,6 +434,8 @@ export class AnkiNoteBuilder {
         const dictionaryEntryDetails = this.getDictionaryEntryDetailsForNote(dictionaryEntry);
         /** @type {?import('api').InjectAnkiNoteMediaAudioDetails} */
         let audioDetails = null;
+        /** @type {?import('api').InjectAnkiNoteMediaSampleSentenceAudioDetails} */
+        let sampleSentenceAudioDetails = null;
         /** @type {?import('api').InjectAnkiNoteMediaScreenshotDetails} */
         let screenshotDetails = null;
         /** @type {import('api').InjectAnkiNoteMediaClipboardDetails} */
@@ -439,6 +445,16 @@ export class AnkiNoteBuilder {
             if (typeof audioOptions === 'object' && audioOptions !== null) {
                 const {sources, preferredAudioIndex, idleTimeout, languageSummary, enableDefaultAudioSources} = audioOptions;
                 audioDetails = {sources, preferredAudioIndex, idleTimeout, languageSummary, enableDefaultAudioSources};
+            }
+        }
+        if ((injectSampleSentenceAudio || injectSampleSentenceText) && dictionaryEntryDetails.type !== 'kanji') {
+            const sampleSentenceAudioOptions = mediaOptions.sampleSentenceAudio;
+            if (typeof sampleSentenceAudioOptions === 'object' && sampleSentenceAudioOptions !== null) {
+                const {sources, preferredAudioIndex, idleTimeout, languageSummary, enableDefaultAudioSources} = sampleSentenceAudioOptions;
+                sampleSentenceAudioDetails = {
+                    details: {sources, preferredAudioIndex, idleTimeout, languageSummary, enableDefaultAudioSources},
+                    downloadAudio: injectSampleSentenceAudio,
+                }
             }
         }
         if (injectScreenshot) {
@@ -465,11 +481,21 @@ export class AnkiNoteBuilder {
             timestamp,
             dictionaryEntryDetails,
             audioDetails,
+            sampleSentenceAudioDetails,
             screenshotDetails,
             clipboardDetails,
             dictionaryMediaDetails,
         );
-        const {audioFileName, screenshotFileName, clipboardImageFileName, clipboardText, dictionaryMedia: dictionaryMediaArray, errors} = injectedMedia;
+        const {
+            audioFileName,
+            sampleSentenceAudioFileName,
+            sampleSentenceText,
+            screenshotFileName,
+            clipboardImageFileName,
+            clipboardText,
+            dictionaryMedia: dictionaryMediaArray,
+            errors
+        } = injectedMedia;
         const textFurigana = textFuriganaPromise !== null ? await textFuriganaPromise : [];
 
         // Format results
@@ -486,6 +512,8 @@ export class AnkiNoteBuilder {
         }
         const media = {
             audio: (typeof audioFileName === 'string' ? {value: audioFileName} : void 0),
+            sampleSentenceAudio: (typeof sampleSentenceAudioFileName === 'string' ? {value: sampleSentenceAudioFileName} : void 0),
+            sampleSentenceText: (typeof sampleSentenceText === 'string' ? {value: sampleSentenceText} : void 0),
             screenshot: (typeof screenshotFileName === 'string' ? {value: screenshotFileName} : void 0),
             clipboardImage: (typeof clipboardImageFileName === 'string' ? {value: clipboardImageFileName} : void 0),
             clipboardText: (typeof clipboardText === 'string' ? {value: clipboardText} : void 0),

--- a/ext/js/data/anki-template-util.js
+++ b/ext/js/data/anki-template-util.js
@@ -59,6 +59,8 @@ export function getStandardFieldMarkers(type, language = 'ja') {
                 'sentence',
                 'sentence-furigana',
                 'sentence-furigana-plain',
+                'sample-sentence-audio',
+                'sample-sentence-text',
                 'tags',
                 'url',
             ];

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -830,6 +830,8 @@ export class DisplayAnki {
             const {type} = requirement;
             switch (type) {
                 case 'audio':
+                case 'sampleSentenceAudio':
+                case 'sampleSentenceText':
                 case 'clipboardImage':
                     break;
                 default:
@@ -1008,6 +1010,7 @@ export class DisplayAnki {
         const contentOrigin = this._display.getContentOrigin();
         const details = this._ankiNoteBuilder.getDictionaryEntryDetailsForNote(dictionaryEntry);
         const audioDetails = this._getAnkiNoteMediaAudioDetails(details);
+        const sampleSentenceAudioDetails = this._getAnkiNoteMediaAudioDetails(details, true);
         const optionsContext = this._display.getOptionsContext();
         const dictionaryStylesMap = this._ankiNoteBuilder.getDictionaryStylesMap(this._dictionaries);
 
@@ -1024,6 +1027,7 @@ export class DisplayAnki {
             compactTags: this._compactTags,
             mediaOptions: {
                 audio: audioDetails,
+                sampleSentenceAudio: sampleSentenceAudioDetails,
                 screenshot: {
                     format: this._screenshotFormat,
                     quality: this._screenshotQuality,
@@ -1063,11 +1067,12 @@ export class DisplayAnki {
 
     /**
      * @param {import('api').InjectAnkiNoteMediaDefinitionDetails} details
+     * @param {boolean} isSentence
      * @returns {?import('anki-note-builder').AudioMediaOptions}
      */
-    _getAnkiNoteMediaAudioDetails(details) {
+    _getAnkiNoteMediaAudioDetails(details, isSentence = false) {
         if (details.type !== 'term') { return null; }
-        const {sources, preferredAudioIndex, enableDefaultAudioSources} = this._displayAudio.getAnkiNoteMediaAudioDetails(details.term, details.reading);
+        const {sources, preferredAudioIndex, enableDefaultAudioSources} = this._displayAudio.getAnkiNoteMediaAudioDetails(details.term, details.reading, isSentence);
         const languageSummary = this._display.getLanguageSummary();
         return {
             sources,

--- a/ext/js/display/display-audio.js
+++ b/ext/js/display/display-audio.js
@@ -144,13 +144,14 @@ export class DisplayAudio {
     /**
      * @param {string} term
      * @param {string} reading
+     * @param {boolean} isSentence
      * @returns {import('display-audio').AudioMediaOptions}
      */
-    getAnkiNoteMediaAudioDetails(term, reading) {
+    getAnkiNoteMediaAudioDetails(term, reading, isSentence = false) {
         /** @type {import('display-audio').AudioSourceShort[]} */
         const sources = [];
         let preferredAudioIndex = null;
-        const primaryCardAudio = this._getPrimaryCardAudio(term, reading);
+        const primaryCardAudio = this._getPrimaryCardAudio(term, reading, isSentence);
         if (primaryCardAudio !== null) {
             const {index, subIndex} = primaryCardAudio;
             const source = this._audioSources[index];
@@ -351,7 +352,7 @@ export class DisplayAudio {
         const headwordIndex = this._getAudioPlayButtonHeadwordIndex(button);
         const dictionaryEntryIndex = this._display.getElementDictionaryEntryIndex(button);
 
-        const {detail: {action, item, menu, shiftKey}} = e;
+        const {detail: {action, item, menu, shiftKey, ctrlKey}} = e;
         switch (action) {
             case 'playAudioFromSource':
                 if (shiftKey) {
@@ -361,7 +362,11 @@ export class DisplayAudio {
                 break;
             case 'setPrimaryAudio':
                 e.preventDefault();
-                this._setPrimaryAudio(dictionaryEntryIndex, headwordIndex, item, menu, true);
+                if (ctrlKey) {
+                    this._setPrimaryAudio(dictionaryEntryIndex, headwordIndex, item, menu, true, true);
+                } else {
+                    this._setPrimaryAudio(dictionaryEntryIndex, headwordIndex, item, menu, true);
+                }
                 break;
         }
     }
@@ -379,6 +384,7 @@ export class DisplayAudio {
             cacheEntry = {
                 sourceMap: new Map(),
                 primaryCardAudio: null,
+                sentenceCardAudio: null,
             };
             this._cache.set(key, cacheEntry);
         }
@@ -419,7 +425,7 @@ export class DisplayAudio {
 
         const headword = this._getHeadword(dictionaryEntryIndex, headwordIndex);
         if (headword === null) {
-            return {audio: null, source: null, subIndex: 0, valid: false};
+            return {audio: null, source: null, subIndex: 0, isSentence: false, valid: false};
         }
 
         const buttons = this._getAudioPlayButtons(dictionaryEntryIndex, headwordIndex);
@@ -434,10 +440,11 @@ export class DisplayAudio {
             let title;
             let source = null;
             let subIndex = 0;
+            let isSentence = false;
             const info = await this._createTermAudio(term, reading, sources, audioInfoListIndex);
             const valid = (info !== null);
             if (valid) {
-                ({audio, source, subIndex} = info);
+                ({audio, source, subIndex, isSentence} = info);
                 const sourceIndex = sources.indexOf(source);
                 title = `From source ${1 + sourceIndex}: ${source.name}`;
             } else {
@@ -471,7 +478,7 @@ export class DisplayAudio {
                 }
             }
 
-            return {audio, source, subIndex, valid};
+            return {audio, source, subIndex, isSentence, valid};
         } finally {
             progressIndicatorVisible.clearOverride(overrideToken);
         }
@@ -489,9 +496,9 @@ export class DisplayAudio {
 
         try {
             const token = this._entriesToken;
-            const {valid} = await this._playAudio(dictionaryEntryIndex, headwordIndex, [source], subIndex);
+            const {valid, isSentence} = await this._playAudio(dictionaryEntryIndex, headwordIndex, [source], subIndex);
             if (valid && token === this._entriesToken) {
-                this._setPrimaryAudio(dictionaryEntryIndex, headwordIndex, item, null, false);
+                this._setPrimaryAudio(dictionaryEntryIndex, headwordIndex, item, null, false, isSentence);
             }
         } catch (e) {
             // NOP
@@ -504,8 +511,9 @@ export class DisplayAudio {
      * @param {?HTMLElement} item
      * @param {?PopupMenu} menu
      * @param {boolean} canToggleOff
+     * @param {boolean} isSentence
      */
-    _setPrimaryAudio(dictionaryEntryIndex, headwordIndex, item, menu, canToggleOff) {
+    _setPrimaryAudio(dictionaryEntryIndex, headwordIndex, item, menu, canToggleOff, isSentence = false) {
         if (item === null) { return; }
         const {source, subIndex} = this._getMenuItemSourceInfo(item);
         if (source === null || !source.downloadable) { return; }
@@ -518,16 +526,34 @@ export class DisplayAudio {
         const cacheEntry = this._getCacheItem(term, reading, true);
         if (typeof cacheEntry === 'undefined') { return; }
 
-        let {primaryCardAudio} = cacheEntry;
-        primaryCardAudio = (
-            !canToggleOff ||
-            primaryCardAudio === null ||
-            primaryCardAudio.index !== index ||
-            primaryCardAudio.subIndex !== subIndex ?
-            {index: index, subIndex} :
-            null
-        );
+        let {primaryCardAudio, sentenceCardAudio} = cacheEntry;
+        if (!isSentence) {
+            primaryCardAudio = (
+                !canToggleOff ||
+                primaryCardAudio === null ||
+                primaryCardAudio.index !== index ||
+                primaryCardAudio.subIndex !== subIndex ?
+                {index: index, subIndex} :
+                null
+            );
+            if (sentenceCardAudio !== null && sentenceCardAudio.index === index && sentenceCardAudio.subIndex === subIndex) {
+                sentenceCardAudio = null;
+            }
+        } else {
+            sentenceCardAudio = (
+                !canToggleOff ||
+                sentenceCardAudio === null ||
+                sentenceCardAudio.index !== index ||
+                sentenceCardAudio.subIndex !== subIndex ?
+                {index: index, subIndex} :
+                null
+            );
+            if (primaryCardAudio !== null && primaryCardAudio.index === index && primaryCardAudio.subIndex === subIndex) {
+                primaryCardAudio = null;
+            }
+        }
         cacheEntry.primaryCardAudio = primaryCardAudio;
+        cacheEntry.sentenceCardAudio = sentenceCardAudio;
 
         if (menu !== null) {
             this._updateMenuPrimaryCardAudio(menu.bodyNode, term, reading);
@@ -598,10 +624,10 @@ export class DisplayAudio {
                 sourceInfo.infoList = infoList;
             }
 
-            const {audio, index: subIndex, cacheUpdated: cacheUpdated2} = await this._createAudioFromInfoList(source, infoList, audioInfoListIndex);
+            const {audio, index: subIndex, cacheUpdated: cacheUpdated2, isSentence} = await this._createAudioFromInfoList(source, infoList, audioInfoListIndex);
             if (cacheUpdated || cacheUpdated2) { this._updateOpenMenu(); }
             if (audio !== null) {
-                return {audio, source, subIndex};
+                return {audio, source, subIndex, isSentence};
             }
         }
 
@@ -627,6 +653,7 @@ export class DisplayAudio {
             audio: null,
             index: -1,
             cacheUpdated: false,
+            isSentence: false,
         };
         for (let i = start; i < end; ++i) {
             const item = infoList[i];
@@ -652,6 +679,9 @@ export class DisplayAudio {
 
                 item.audio = audio;
             }
+
+            const {sentence} = item.info;
+            result.isSentence = typeof sentence === 'string' && sentence.length > 0;
 
             if (audio !== null) {
                 result.audio = audio;
@@ -953,11 +983,12 @@ export class DisplayAudio {
     /**
      * @param {string} term
      * @param {string} reading
+     * @param {boolean} isSentence
      * @returns {?import('display-audio').PrimaryCardAudio}
      */
-    _getPrimaryCardAudio(term, reading) {
+    _getPrimaryCardAudio(term, reading, isSentence = false) {
         const cacheEntry = this._getCacheItem(term, reading, false);
-        return typeof cacheEntry !== 'undefined' ? cacheEntry.primaryCardAudio : null;
+        return typeof cacheEntry !== 'undefined' ? isSentence ? cacheEntry.sentenceCardAudio : cacheEntry.primaryCardAudio : null;
     }
 
     /**
@@ -969,6 +1000,9 @@ export class DisplayAudio {
         const primaryCardAudio = this._getPrimaryCardAudio(term, reading);
         const primaryCardAudioIndex = (primaryCardAudio !== null ? primaryCardAudio.index : null);
         const primaryCardAudioSubIndex = (primaryCardAudio !== null ? primaryCardAudio.subIndex : null);
+        const sentenceCardAudio = this._getPrimaryCardAudio(term, reading, true);
+        const sentenceCardAudioIndex = (sentenceCardAudio !== null ? sentenceCardAudio.index : null);
+        const sentenceCardAudioSubIndex = (sentenceCardAudio !== null ? sentenceCardAudio.subIndex : null);
         const itemGroups = /** @type {NodeListOf<HTMLElement>} */ (menuBodyNode.querySelectorAll('.popup-menu-item-group'));
         for (const node of itemGroups) {
             const {index, subIndex} = node.dataset;
@@ -976,7 +1010,9 @@ export class DisplayAudio {
             const indexNumber = Number.parseInt(index, 10);
             const subIndexNumber = typeof subIndex === 'string' ? Number.parseInt(subIndex, 10) : null;
             const isPrimaryCardAudio = (indexNumber === primaryCardAudioIndex && subIndexNumber === primaryCardAudioSubIndex);
+            const isSentenceCardAudio = (indexNumber === sentenceCardAudioIndex && subIndexNumber === sentenceCardAudioSubIndex);
             node.dataset.isPrimaryCardAudio = `${isPrimaryCardAudio}`;
+            node.dataset.isSentenceCardAudio = `${isSentenceCardAudio}`;
         }
     }
 

--- a/ext/js/templates/template-renderer-media-provider.js
+++ b/ext/js/templates/template-renderer-media-provider.js
@@ -98,6 +98,8 @@ export class TemplateRendererMediaProvider {
         const type = args[0];
         switch (type) {
             case 'audio': return this._getSimpleMediaData(media, 'audio');
+            case 'sampleSentenceAudio': return this._getSimpleMediaData(media, 'sampleSentenceAudio');
+            case 'sampleSentenceText': return this._getSimpleMediaData(media, 'sampleSentenceText');
             case 'screenshot': return this._getSimpleMediaData(media, 'screenshot');
             case 'clipboardImage': return this._getSimpleMediaData(media, 'clipboardImage');
             case 'clipboardText': return this._getSimpleMediaData(media, 'clipboardText');

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -1054,6 +1054,14 @@
                         <td>Kana reading for the term, or empty for terms where the expression is the reading.</td>
                     </tr>
                     <tr>
+                        <td><code class="anki-field-marker">{sample-sentence-audio}</code></td>
+                        <td>Audio of a sample sentence containing the term from one of the audio sources (if available).</td>
+                    </tr>
+                    <tr>
+                        <td><code class="anki-field-marker">{sample-sentence-text}</code></td>
+                        <td>Sample sentence containing the term from one of the audio sources (if available).</td>
+                    </tr>
+                    <tr>
                         <td><code class="anki-field-marker">{single-glossary-DICT-NAME}</code></td>
                         <td>
                             Same as <code class="anki-field-marker">{glossary}</code>, but with entries from only a single dictionary.

--- a/types/ext/anki-note-builder.d.ts
+++ b/types/ext/anki-note-builder.d.ts
@@ -70,7 +70,7 @@ export type GetRenderingDataDetails = {
 export type CommonData = AnkiTemplatesInternal.CreateDetails;
 
 export type RequirementGeneric = {
-    type: 'audio' | 'screenshot' | 'clipboardImage' | 'clipboardText' | 'popupSelectionText';
+    type: 'audio' | 'sampleSentenceAudio' | 'sampleSentenceText' | 'screenshot' | 'clipboardImage' | 'clipboardText' | 'popupSelectionText';
 };
 
 export type RequirementTextFurigana = {
@@ -99,6 +99,7 @@ export type AudioMediaOptions = {
 
 export type MediaOptions = {
     audio: AudioMediaOptions | null;
+    sampleSentenceAudio: AudioMediaOptions | null;
     screenshot: {
         format: Settings.AnkiScreenshotFormat;
         quality: number;
@@ -131,6 +132,7 @@ export type MinimalApi = {
         timestamp: Api.ApiParam<'injectAnkiNoteMedia', 'timestamp'>,
         definitionDetails: Api.ApiParam<'injectAnkiNoteMedia', 'definitionDetails'>,
         audioDetails: Api.ApiParam<'injectAnkiNoteMedia', 'audioDetails'>,
+        sampleSentenceAudioDetails: Api.ApiParam<'injectAnkiNoteMedia', 'sampleSentenceAudioDetails'>,
         screenshotDetails: Api.ApiParam<'injectAnkiNoteMedia', 'screenshotDetails'>,
         clipboardDetails: Api.ApiParam<'injectAnkiNoteMedia', 'clipboardDetails'>,
         dictionaryMediaDetails: Api.ApiParam<'injectAnkiNoteMedia', 'dictionaryMediaDetails'>,

--- a/types/ext/anki-templates.d.ts
+++ b/types/ext/anki-templates.d.ts
@@ -29,6 +29,8 @@ export type Context = {
 
 export type Media = {
     audio?: MediaObject;
+    sampleSentenceAudio?: MediaObject;
+    sampleSentenceText?: MediaObject;
     screenshot?: MediaObject;
     clipboardImage?: MediaObject;
     clipboardText?: MediaObject;
@@ -41,6 +43,8 @@ export type MediaObject = {value: string};
 
 export type MediaSimpleType = (
     'audio' |
+    'sampleSentenceAudio' |
+    'sampleSentenceText' |
     'screenshot' |
     'clipboardImage' |
     'clipboardText' |

--- a/types/ext/api.d.ts
+++ b/types/ext/api.d.ts
@@ -80,6 +80,11 @@ export type InjectAnkiNoteMediaDefinitionDetails = InjectAnkiNoteMediaTermDefini
 
 export type InjectAnkiNoteMediaAudioDetails = AnkiNoteBuilder.AudioMediaOptions;
 
+export type InjectAnkiNoteMediaSampleSentenceAudioDetails = {
+    details: InjectAnkiNoteMediaAudioDetails;
+    downloadAudio: boolean;
+}
+
 export type InjectAnkiNoteMediaScreenshotDetails = {
     tabId: number;
     frameId: number;
@@ -188,6 +193,7 @@ type ApiSurface = {
             timestamp: number;
             definitionDetails: InjectAnkiNoteMediaDefinitionDetails;
             audioDetails: InjectAnkiNoteMediaAudioDetails | null;
+            sampleSentenceAudioDetails: InjectAnkiNoteMediaSampleSentenceAudioDetails | null;
             screenshotDetails: InjectAnkiNoteMediaScreenshotDetails | null;
             clipboardDetails: InjectAnkiNoteMediaClipboardDetails | null;
             dictionaryMediaDetails: InjectAnkiNoteMediaDictionaryMediaDetails[];
@@ -197,6 +203,8 @@ type ApiSurface = {
             clipboardImageFileName: string | null;
             clipboardText: string | null;
             audioFileName: string | null;
+            sampleSentenceAudioFileName: string | null;
+            sampleSentenceText: string | null;
             dictionaryMedia: InjectAnkiNoteDictionaryMediaResult[];
             errors: Core.SerializedError[];
         };

--- a/types/ext/audio-downloader.d.ts
+++ b/types/ext/audio-downloader.d.ts
@@ -31,6 +31,7 @@ export type Info1 = {
     type: 'url';
     url: string;
     name?: string;
+    sentence?: string;
 };
 
 export type Info2 = {
@@ -38,11 +39,17 @@ export type Info2 = {
     text: string;
     voice: string;
     name?: undefined;
+    sentence?: undefined;
 };
 
 export type AudioBinaryBase64 = {
     data: string;
     contentType: string | null;
+};
+
+export type SampleSentence = {
+    audio: AudioBinaryBase64 | null;
+    text: string | null;
 };
 
 export type CustomAudioList = {
@@ -53,6 +60,7 @@ export type CustomAudioList = {
 export type CustomAudioListSource = {
     url: string;
     name?: string;
+    sentence?: string;
 };
 
 export type WikimediaCommonsLookupResponse = {

--- a/types/ext/display-audio.d.ts
+++ b/types/ext/display-audio.d.ts
@@ -23,6 +23,7 @@ import type * as Settings from './settings';
 export type CacheItem = {
     sourceMap: Map<number, CachedInfoList>;
     primaryCardAudio: PrimaryCardAudio | null;
+    sentenceCardAudio: PrimaryCardAudio | null;
 };
 
 export type CachedInfoList = {
@@ -77,6 +78,7 @@ export type PlayAudioResult = {
     audio: GenericAudio | null;
     source: AudioSource | null;
     subIndex: number;
+    isSentence: boolean;
     valid: boolean;
 };
 
@@ -84,12 +86,14 @@ export type TermAudio = {
     audio: GenericAudio;
     source: AudioSource;
     subIndex: number;
+    isSentence: boolean;
 };
 
 export type CreateAudioResult = {
     audio: GenericAudio | null;
     index: number;
     cacheUpdated: boolean;
+    isSentence: boolean;
 };
 
 export type GenericAudio = HTMLAudioElement | TextToSpeechAudio;


### PR DESCRIPTION
Allows users to configure a custom audio source with sample sentence audio and corresponding text in addition to regular term audio.

Sample sentence audio is served via a separate JSON audio source. In order to allow for this, the schema has been extended by an optional `sentence` field. One possible implementation for such an audio source can be found here: https://github.com/suuvvy/yomitan-sentence-audio

In the term audio popup, users can select their preferred audio source for sentence audio by clicking the Anki card button while holding Crtl. There are two new markers that can be mapped to Anki fields, `{sample-sentence-audio}` and `{sample-sentence-audio}`. If the user chooses a source without `sentence` property as preferred sentence audio source, neither `{sample-sentence-audio}` nor `{sample-sentence-audio}` are mapped. The `{audio}` marker remains unaffected by this.

After playing audio from an audio source, that source is marked as either preferred (term) audio source or preferred sentence audio source depending on whether the underlying source has a `sentence`  property. This also means the behavior stays the same for all existing audio sources.

A demonstration of the feature can be seen in the video below (remember to unmute):

https://github.com/user-attachments/assets/cb0762a5-14d9-437e-ab76-e80c104c1dba

This is my first time working with the yomitan codebase, so any suggestions to improve code quality are highly appreciated.
