### PR TITLE
Improve mouse input action prevention

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -479,6 +479,7 @@
                                 "required": [
                                     "inputs",
                                     "preventMiddleMouse",
+                                    "preventBackForward",
                                     "selectText",
                                     "alphanumeric",
                                     "autoHideResults",
@@ -681,6 +682,34 @@
                                         }
                                     },
                                     "preventMiddleMouse": {
+                                        "type": "object",
+                                        "required": [
+                                            "onTextHover",
+                                            "onWebPages",
+                                            "onPopupPages",
+                                            "onSearchPages",
+                                            "onSearchQuery"
+                                        ],
+                                        "properties": {
+                                            "onWebPages": {
+                                                "type": "boolean",
+                                                "default": false
+                                            },
+                                            "onPopupPages": {
+                                                "type": "boolean",
+                                                "default": false
+                                            },
+                                            "onSearchPages": {
+                                                "type": "boolean",
+                                                "default": false
+                                            },
+                                            "onSearchQuery": {
+                                                "type": "boolean",
+                                                "default": false
+                                            }
+                                        }
+                                    },
+                                    "preventBackForward": {
                                         "type": "object",
                                         "required": [
                                             "onTextHover",

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -499,8 +499,10 @@ export class Frontend {
 
         await this._updatePopup();
 
-        const preventMiddleMouseOnPage = this._getPreventMiddleMouseValueForPageType(scanningOptions.preventMiddleMouse);
+        const preventMiddleMouseOnPage = this._getPreventSecondaryMouseValueForPageType(scanningOptions.preventMiddleMouse);
         const preventMiddleMouseOnTextHover = scanningOptions.preventMiddleMouse.onTextHover;
+        const preventBackForwardOnPage = this._getPreventSecondaryMouseValueForPageType(scanningOptions.preventBackForward);
+        const preventBackForwardOnTextHover = scanningOptions.preventBackForward.onTextHover;
         this._textScanner.language = options.general.language;
         this._textScanner.setOptions({
             inputs: scanningOptions.inputs,
@@ -513,6 +515,8 @@ export class Frontend {
             matchTypePrefix: scanningOptions.matchTypePrefix,
             preventMiddleMouseOnPage,
             preventMiddleMouseOnTextHover,
+            preventBackForwardOnPage,
+            preventBackForwardOnTextHover,
             sentenceParsingOptions,
             scanWithoutMousemove: scanningOptions.scanWithoutMousemove,
             scanResolution: scanningOptions.scanResolution,
@@ -902,14 +906,14 @@ export class Frontend {
     }
 
     /**
-     * @param {import('settings').PreventMiddleMouseOptions} preventMiddleMouseOptions
+     * @param {import('settings').PreventSecondaryMouseOptions} preventSecondaryMouseOptions
      * @returns {boolean}
      */
-    _getPreventMiddleMouseValueForPageType(preventMiddleMouseOptions) {
+    _getPreventSecondaryMouseValueForPageType(preventSecondaryMouseOptions) {
         switch (this._pageType) {
-            case 'web': return preventMiddleMouseOptions.onWebPages;
-            case 'popup': return preventMiddleMouseOptions.onPopupPages;
-            case 'search': return preventMiddleMouseOptions.onSearchPages;
+            case 'web': return preventSecondaryMouseOptions.onWebPages;
+            case 'popup': return preventSecondaryMouseOptions.onPopupPages;
+            case 'search': return preventSecondaryMouseOptions.onSearchPages;
         }
     }
 

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -670,6 +670,13 @@ export class OptionsUtil {
                 onSearchPages: false,
                 onSearchQuery: false,
             };
+            profileOptions.scanning.preventBackForward = {
+                onTextHover: false,
+                onWebPages: false,
+                onPopupPages: false,
+                onSearchPages: false,
+                onSearchQuery: false,
+            };
 
             const {modifier, middleMouse} = profileOptions.scanning;
             delete profileOptions.scanning.modifier;

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1062,15 +1062,16 @@ export class Display extends EventDispatcher {
      * @param {MouseEvent} e
      */
     _onDocumentElementClick(e) {
+        const enableBackForwardActions = this._options ? !(this._options.scanning.preventBackForward.onPopupPages) : true;
         switch (e.button) {
             case 3: // Back
-                if (this._history.hasPrevious()) {
+                if (enableBackForwardActions && this._history.hasPrevious()) {
                     e.preventDefault();
                     this._history.back();
                 }
                 break;
             case 4: // Forward
-                if (this._history.hasNext()) {
+                if (enableBackForwardActions && this._history.hasNext()) {
                     e.preventDefault();
                     this._history.forward();
                 }

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -480,6 +480,8 @@ export class Display extends EventDispatcher {
                 layoutAwareScan: scanningOptions.layoutAwareScan,
                 preventMiddleMouseOnPage: scanningOptions.preventMiddleMouse.onSearchQuery,
                 preventMiddleMouseOnTextHover: scanningOptions.preventMiddleMouse.onTextHover,
+                preventBackForwardOnPage: scanningOptions.preventBackForward.onSearchQuery,
+                preventBackForwardOnTextHover: scanningOptions.preventBackForward.onTextHover,
                 matchTypePrefix: false,
                 sentenceParsingOptions,
                 scanWithoutMousemove: scanningOptions.scanWithoutMousemove,
@@ -2088,6 +2090,8 @@ export class Display extends EventDispatcher {
             layoutAwareScan: scanningOptions.layoutAwareScan,
             preventMiddleMouseOnPage: false,
             preventMiddleMouseOnTextHover: false,
+            preventBackForwardOnPage: false,
+            preventBackForwardOnTextHover: false,
             sentenceParsingOptions,
             pageType: this._pageType,
         });

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -114,6 +114,10 @@ export class TextScanner extends EventDispatcher {
         /** @type {boolean} */
         this._preventMiddleMouseOnTextHover = false;
         /** @type {boolean} */
+        this._preventBackForwardOnPage = false;
+        /** @type {boolean} */
+        this._preventBackForwardOnTextHover = false;
+        /** @type {boolean} */
         this._matchTypePrefix = false;
         /** @type {number} */
         this._sentenceScanExtent = 0;
@@ -268,6 +272,8 @@ export class TextScanner extends EventDispatcher {
         layoutAwareScan,
         preventMiddleMouseOnPage,
         preventMiddleMouseOnTextHover,
+        preventBackForwardOnPage,
+        preventBackForwardOnTextHover,
         sentenceParsingOptions,
         matchTypePrefix,
         scanWithoutMousemove,
@@ -300,6 +306,12 @@ export class TextScanner extends EventDispatcher {
         }
         if (typeof preventMiddleMouseOnTextHover === 'boolean') {
             this._preventMiddleMouseOnTextHover = preventMiddleMouseOnTextHover;
+        }
+        if (typeof preventBackForwardOnPage === 'boolean') {
+            this._preventBackForwardOnPage = preventBackForwardOnPage;
+        }
+        if (typeof preventBackForwardOnTextHover === 'boolean') {
+            this._preventBackForwardOnTextHover = preventBackForwardOnTextHover;
         }
         if (typeof matchTypePrefix === 'boolean') {
             this._matchTypePrefix = pageType === 'search' ? matchTypePrefix : false;
@@ -645,6 +657,22 @@ export class TextScanner extends EventDispatcher {
      * @param {PointerEvent} e
      * @returns {boolean|void}
      */
+    _onMouseUp(e) {
+        switch (e.button) {
+            case 3: // Back
+            case 4: // Forward
+                if (this._preventBackForwardOnPage || (this._preventBackForwardOnTextHover && this._isMouseOverText)) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+                break;
+        }
+    }
+
+    /**
+     * @param {PointerEvent} e
+     * @returns {boolean|void}
+     */
     _onMouseDown(e) {
         if (this._preventNextMouseDown) {
             this._preventNextMouseDown = false;
@@ -716,9 +744,20 @@ export class TextScanner extends EventDispatcher {
         void this._searchAt(e.clientX, e.clientY, inputInfo);
     }
 
-    /** */
-    _onAuxClick() {
+    /**
+     * @param {PointerEvent} e
+     * @returns {boolean|void}
+     */
+    _onAuxClick(e) {
         this._preventNextContextMenu = false;
+        switch (e.button) {
+            case 1: // Middle
+                if (this._preventMiddleMouseOnPage || (this._preventMiddleMouseOnTextHover && this._isMouseOverText)) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+                break;
+        }
     }
 
     /**
@@ -1123,6 +1162,7 @@ export class TextScanner extends EventDispatcher {
             [this._node, 'pointerup', this._onPointerUp.bind(this), capture],
             [this._node, 'pointercancel', this._onPointerCancel.bind(this), capture],
             [this._node, 'pointerout', this._onPointerOut.bind(this), capture],
+            [this._node, 'mouseup', this._onMouseUp.bind(this), capture],
             [this._node, 'mousedown', this._onMouseDown.bind(this), capture],
             [this._node, 'touchmove', this._onTouchMove.bind(this), {passive: false, capture}],
             [this._node, 'touchend', this._onTouchEnd.bind(this), capture],

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -811,20 +811,22 @@
         <div class="modal-header"><div class="modal-title">Input Action Prevention</div></div>
         <div class="modal-body">
             <div>
-                Prevent middle mouse button actions on:
+                Prevent secondary mouse button actions on:
                 <a tabindex="0" class="more-toggle more-only" data-parent-distance="2">(?)</a>
             </div>
             <div class="more" hidden>
                 <p>
-                    This option is used to disable the default action of the middle mouse button in different contexts.
-                    This can be useful for preventing the scroll action that the middle mouse button is typically mapped to,
-                    which is otherwise difficult to disable inside extension pages via other means.
+                    This option is used to disable the default action of the secondary mouse buttons in different contexts.
+                    This can be useful for preventing actions that the middle button and buttons 4 and 5 are typically
+                    mapped to (scrolling and back/forward, respectively), which are otherwise difficult to disable inside
+                    extension pages via other means.
                 </p>
                 <p>
                     <a tabindex="0" class="more-toggle" data-parent-distance="3">Less&hellip;</a>
                 </p>
             </div>
             <div class="input-prevention-option-list">
+                Middle mouse button:
                 <label class="input-prevention-option-list-item">
                     <label class="checkbox"><input type="checkbox" data-setting="scanning.preventMiddleMouse.onTextHover"><span class="checkbox-body"><span class="checkbox-fill"></span><span class="checkbox-border"></span><span class="checkbox-check"></span></span></label>
                     <span>Text Hover</span>
@@ -843,6 +845,29 @@
                 </label>
                 <label class="input-prevention-option-list-item">
                     <label class="checkbox"><input type="checkbox" data-setting="scanning.preventMiddleMouse.onSearchQuery"><span class="checkbox-body"><span class="checkbox-fill"></span><span class="checkbox-border"></span><span class="checkbox-check"></span></span></label>
+                    <span>Search query</span>
+                </label>
+            </div>
+            <div class="input-prevention-option-list">
+                Back/forward mouse buttons:
+                <label class="input-prevention-option-list-item">
+                    <label class="checkbox"><input type="checkbox" data-setting="scanning.preventBackForward.onTextHover"><span class="checkbox-body"><span class="checkbox-fill"></span><span class="checkbox-border"></span><span class="checkbox-check"></span></span></label>
+                    <span>Text Hover</span>
+                </label>
+                <label class="input-prevention-option-list-item">
+                    <label class="checkbox"><input type="checkbox" data-setting="scanning.preventBackForward.onWebPages"><span class="checkbox-body"><span class="checkbox-fill"></span><span class="checkbox-border"></span><span class="checkbox-check"></span></span></label>
+                    <span>Webpages</span>
+                </label>
+                <label class="input-prevention-option-list-item">
+                    <label class="checkbox"><input type="checkbox" data-setting="scanning.preventBackForward.onPopupPages"><span class="checkbox-body"><span class="checkbox-fill"></span><span class="checkbox-border"></span><span class="checkbox-check"></span></span></label>
+                    <span>Popups</span>
+                </label>
+                <label class="input-prevention-option-list-item">
+                    <label class="checkbox"><input type="checkbox" data-setting="scanning.preventBackForward.onSearchPages"><span class="checkbox-body"><span class="checkbox-fill"></span><span class="checkbox-border"></span><span class="checkbox-check"></span></span></label>
+                    <span>Search page</span>
+                </label>
+                <label class="input-prevention-option-list-item">
+                    <label class="checkbox"><input type="checkbox" data-setting="scanning.preventBackForward.onSearchQuery"><span class="checkbox-body"><span class="checkbox-fill"></span><span class="checkbox-border"></span><span class="checkbox-check"></span></span></label>
                     <span>Search query</span>
                 </label>
             </div>

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -369,6 +369,13 @@ function createProfileOptionsUpdatedTestData1() {
                 onSearchPages: false,
                 onSearchQuery: false,
             },
+            preventBackForward: {
+                onTextHover: false,
+                onWebPages: false,
+                onPopupPages: false,
+                onSearchPages: false,
+                onSearchQuery: false,
+            },
             scanWithoutMousemove: true,
             scanResolution: 'character',
             inputs: [

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -185,7 +185,8 @@ export type AudioSourceOptions = {
 
 export type ScanningOptions = {
     inputs: ScanningInput[];
-    preventMiddleMouse: ScanningPreventMiddleMouseOptions;
+    preventMiddleMouse: ScanningPreventSecondaryMouseOptions;
+    preventBackForward: ScanningPreventSecondaryMouseOptions;
     selectText: boolean;
     alphanumeric: boolean;
     autoHideResults: boolean;
@@ -238,7 +239,7 @@ export type ScanningInputOptions = {
     minimumTouchTime: number;
 };
 
-export type ScanningPreventMiddleMouseOptions = {
+export type ScanningPreventSecondaryMouseOptions = {
     onTextHover: boolean;
     onWebPages: boolean;
     onPopupPages: boolean;
@@ -376,7 +377,7 @@ export type AccessibilityOptions = {
     forceGoogleDocsHtmlRendering: boolean;
 };
 
-export type PreventMiddleMouseOptions = {
+export type PreventSecondaryMouseOptions = {
     onTextHover: boolean;
     onWebPages: boolean;
     onPopupPages: boolean;

--- a/types/ext/text-scanner.d.ts
+++ b/types/ext/text-scanner.d.ts
@@ -39,6 +39,8 @@ export type Options = {
     layoutAwareScan?: boolean;
     preventMiddleMouseOnPage?: boolean;
     preventMiddleMouseOnTextHover?: boolean;
+    preventBackForwardOnPage?: boolean;
+    preventBackForwardOnTextHover?: boolean;
     matchTypePrefix?: boolean;
     sentenceParsingOptions?: SentenceParsingOptions;
     scanWithoutMousemove?: boolean;


### PR DESCRIPTION
As pointed out in https://github.com/yomidevs/yomitan/issues/2152, currently a middle mouse click still opens links in a new tab, and mouse button 4 and 5 are unusable since they trigger history back/forward. This blocks the new tab action if the appropriate toggles are selected and adds a new set of toggles for button 4/5. I tested all of this on Chrome.