### PR TITLE
Fix anki flashcard format errors on deleting too many

### DIFF
--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -350,7 +350,7 @@ export class AnkiController {
         /** @type {HTMLSelectElement} */
         const iconSelect = querySelectorNotNull(this._ankiCardPrimary, '.anki-card-icon');
         iconSelect.dataset.setting = ObjectPropertyAccessor.getPathString(['anki', 'cardFormats', cardFormatIndex, 'icon']);
-        iconSelect.dataset.icon = this._ankiOptions?.cardFormats[cardFormatIndex].icon ?? 'big-circle';
+        iconSelect.dataset.icon = this._ankiOptions?.cardFormats[cardFormatIndex]?.icon ?? 'big-circle';
     }
 
     /**

--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -638,6 +638,9 @@ export class AnkiController {
         if (this._cardFormatIndex > ankiOptions.cardFormats.length) {
             this._cardFormatIndex = ankiOptions.cardFormats.length - 1;
         }
+        if (this._cardFormatIndex < 0) {
+            this._cardFormatIndex = 0;
+        }
 
         for (let i = 0; i < ankiOptions.cardFormats.length; ++i) {
             const cardFormat = ankiOptions.cardFormats[i];

--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -650,6 +650,8 @@ export class AnkiController {
             }
         }
 
+        this._cardFormatDeleteButton.disabled = ankiOptions.cardFormats.length <= 1;
+
         this._setCardFormatIndex(this._cardFormatIndex, 'anki-card-term-field-menu');
     }
 
@@ -724,6 +726,7 @@ export class AnkiController {
      */
     _onCardFormatDeleteClick(e) {
         e.preventDefault();
+        if (this._ankiOptions && this._ankiOptions.cardFormats.length === 1) { return; }
         this.openDeleteCardFormatModal(this._cardFormatIndex);
     }
 


### PR DESCRIPTION
1. Prevents deleting all card formats, the delete button is set to disabled if there are 1 or less formats. The button listener also rejects all events if there are 1 or less formats.
2. If the user already has 0 card formats, prevents erroring in an unrecoverable way. The user will still be able to add back formats and recover without having to reset settings.
3. No longer error when deleting the first card format due to an invalid index. `-1` is not an acceptable index so it is set to `0` if `-1` occurs. 