### PR TITLE
Fixing the logic in isNonNounVerbOrAdjective

### DIFF
--- a/ext/js/dictionary/dictionary-data-util.js
+++ b/ext/js/dictionary/dictionary-data-util.js
@@ -333,7 +333,7 @@ export function isNonNounVerbOrAdjective(wordClasses) {
             case 'vs':
                 isVerbOrAdjective = true;
                 isSuruVerb = true;
-                // Falls through
+		break;
             case 'n':
                 isNoun = true;
                 break;

--- a/ext/js/dictionary/dictionary-data-util.js
+++ b/ext/js/dictionary/dictionary-data-util.js
@@ -333,7 +333,7 @@ export function isNonNounVerbOrAdjective(wordClasses) {
             case 'vs':
                 isVerbOrAdjective = true;
                 isSuruVerb = true;
-		break;
+                break;
             case 'n':
                 isNoun = true;
                 break;


### PR DESCRIPTION
As discussed on discord, this merge request fixes the logic in the isNonNounVerbOrAdjective function, so that it doesn't treat every suru verb as a noun.

I have chosen to leave the 'n' logic in place. If a dictionary doesn't make use of the 'n' tag (such as Jitendex), then this function will simply return true if the word inflects, which appears to be the intended behavior.

If there are dictionaries that do make use of the 'n' tag, then this function will return false if the word can be treated as a noun. For instance, if a dictionary marks the word 勉強 as both a noun 'n' and a suru verb 'vs', then it should return false, which is also the intended behavior. (Jitendex also returns false for 勉強, since it doesn't provide any tag).