### PR TITLE
Add "Reduced motion scrolling" option

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -496,7 +496,9 @@
                                     "matchTypePrefix",
                                     "hidePopupOnCursorExit",
                                     "hidePopupOnCursorExitDelay",
-                                    "paginatedScrolling",
+                                    "reducedMotionScrolling",
+                                    "reducedMotionScrollingScale",
+                                    "reducedMotionScrollingSwipeThreshold",
                                     "normalizeCssZoom",
                                     "scanWithoutMousemove",
                                     "scanResolution"
@@ -807,9 +809,18 @@
                                         "minimum": 0,
                                         "default": 0
                                     },
-                                    "paginatedScrolling": {
+                                    "reducedMotionScrolling": {
                                         "type": "boolean",
                                         "default": false
+                                    },
+                                    "reducedMotionScrollingScale": {
+                                        "type": "number",
+                                        "default": 1
+                                    },
+                                    "reducedMotionScrollingSwipeThreshold": {
+                                        "type": "number",
+                                        "minimum": 0,
+                                        "default": 40
                                     },
                                     "normalizeCssZoom": {
                                         "type": "boolean",

--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -496,6 +496,7 @@
                                     "matchTypePrefix",
                                     "hidePopupOnCursorExit",
                                     "hidePopupOnCursorExitDelay",
+                                    "paginatedScrolling",
                                     "normalizeCssZoom",
                                     "scanWithoutMousemove",
                                     "scanResolution"
@@ -805,6 +806,10 @@
                                         "type": "number",
                                         "minimum": 0,
                                         "default": 0
+                                    },
+                                    "paginatedScrolling": {
+                                        "type": "boolean",
+                                        "default": false
                                     },
                                     "normalizeCssZoom": {
                                         "type": "boolean",

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1764,7 +1764,7 @@ export class Display extends EventDispatcher {
         const popupHeight = this._contentScrollElement.clientHeight;
         const contentBottom = this._contentScrollElement.scrollHeight - popupHeight;
         const overlap = 10;
-        const scrollAmount = ((popupHeight - overlap) * direction);
+        const scrollAmount = (popupHeight - overlap) * direction;
         const target = Math.min(this._windowScroll.y + scrollAmount, contentBottom);
 
         this._windowScroll.stop();

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1764,11 +1764,11 @@ export class Display extends EventDispatcher {
         const popupHeight = this._contentScrollElement.clientHeight;
         const contentBottom = this._contentScrollElement.scrollHeight - popupHeight;
         const overlap = 10;
-        const scrollAmount = Math.min(this._windowScroll.y + ((popupHeight - overlap) * direction), contentBottom);
-        const target = Math.max(0, scrollAmount);
+        const scrollAmount = ((popupHeight - overlap) * direction);
+        const target = Math.min(this._windowScroll.y + scrollAmount, contentBottom);
 
         this._windowScroll.stop();
-        this._windowScroll.toY(target);
+        this._windowScroll.toY(Math.max(0, target));
     }
 
     /**

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -680,6 +680,15 @@
         </div>
         <div class="settings-item advanced-only"><div class="settings-item-inner">
             <div class="settings-item-left">
+                <div class="settings-item-label">Paginate scrolling in popup</div>
+                <div class="settings-item-description">Scroll by popup's current height</div>
+            </div>
+            <div class="settings-item-right">
+                <label class="toggle"><input type="checkbox" data-setting="scanning.paginatedScrolling"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+            </div>
+        </div></div>
+        <div class="settings-item advanced-only"><div class="settings-item-inner">
+            <div class="settings-item-left">
                 <div class="settings-item-label">Search terms when clicking text from the results list</div>
             </div>
             <div class="settings-item-right">

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -678,15 +678,57 @@
                 </div></div>
             </div>
         </div>
-        <div class="settings-item advanced-only"><div class="settings-item-inner">
-            <div class="settings-item-left">
-                <div class="settings-item-label">Paginate scrolling in popup</div>
-                <div class="settings-item-description">Scroll by popup's current height</div>
+        <div class="settings-item advanced-only">
+            <div class="settings-item-inner">
+                <div class="settings-item-left">
+                    <div class="settings-item-label">Reduced motion scrolling</div>
+                    <div class="settings-item-description">Scrolls by a configurable height (similar to pagination), reducing animations. Useful on e-readers and e-ink screens.</div>
+                </div>
+                <div class="settings-item-right">
+                    <label class="toggle"><input type="checkbox"
+                        data-setting="scanning.reducedMotionScrolling"
+                        data-transform='{
+                            "type": "setVisibility",
+                            "selector": "#reduced-motion-scrolling-options",
+                            "condition": {"op": "===", "value": true}
+                        }'
+                    ><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                </div>
             </div>
-            <div class="settings-item-right">
-                <label class="toggle"><input type="checkbox" data-setting="scanning.paginatedScrolling"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+            <div class="settings-item-children settings-item-children-group" id="reduced-motion-scrolling-options" hidden>
+                <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
+                    <div class="settings-item-left">
+                        <div class="settings-item-label">Scale</div>
+                        <div class="settings-item-description">Percentage of the popup's height scrolled per step.</div>
+                    </div>
+                    <div class="settings-item-right">
+                        <select data-setting="scanning.reducedMotionScrollingScale"
+                            data-transform='[
+                                {"type": "toNumber", "step": "pre", "constraints": {"min": 0.4}},
+                                {"type": "toString", "step": "post"}
+                            ]'
+                        >
+                            <option value="0.4">40%</option>
+                            <option value="0.5">50%</option>
+                            <option value="0.6">60%</option>
+                            <option value="0.7">70%</option>
+                            <option value="0.8">80%</option>
+                            <option value="0.9">90%</option>
+                            <option value="1">100%</option>
+                        </select>
+                    </div>
+                </div></div>
+                <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
+                    <div class="settings-item-left">
+                        <div class="settings-item-label">Swipe Threshold <span class="light">(in pixels)</span></div>
+                        <div class="settings-item-description">Minimum distance on touch devices for a swipe to be recognized as scrolling. Lower values can feel more responsive but increase the chance for misinputs.</div>
+                    </div>
+                    <div class="settings-item-right">
+                        <input type="number" data-setting="scanning.reducedMotionScrollingSwipeThreshold" min="0">
+                    </div>
+                </div></div>
             </div>
-        </div></div>
+        </div>
         <div class="settings-item advanced-only"><div class="settings-item-inner">
             <div class="settings-item-left">
                 <div class="settings-item-label">Search terms when clicking text from the results list</div>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -720,11 +720,16 @@
                 </div></div>
                 <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
                     <div class="settings-item-left">
-                        <div class="settings-item-label">Swipe Threshold <span class="light">(in pixels)</span></div>
+                        <div class="settings-item-label">Swipe Threshold</div>
                         <div class="settings-item-description">Minimum distance on touch devices for a swipe to be recognized as scrolling. Lower values can feel more responsive but increase the chance for misinputs.</div>
                     </div>
                     <div class="settings-item-right">
-                        <input type="number" data-setting="scanning.reducedMotionScrollingSwipeThreshold" min="0">
+                        <div class="settings-item-group">
+                            <div class="settings-item-group-item">
+                                <div class="settings-item-group-item-label">px</div>
+                                <input type="number" class="short-width short-height" data-setting="scanning.reducedMotionScrollingSwipeThreshold" min="0">
+                            </div>
+                        </div>
                     </div>
                 </div></div>
             </div>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -720,7 +720,7 @@
                 </div></div>
                 <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
                     <div class="settings-item-left">
-                        <div class="settings-item-label">Swipe Threshold</div>
+                        <div class="settings-item-label">Swipe threshold</div>
                         <div class="settings-item-description">Minimum distance on touch devices for a swipe to be recognized as scrolling. Lower values can feel more responsive but increase the chance for misinputs.</div>
                     </div>
                     <div class="settings-item-right">

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -361,6 +361,7 @@ function createProfileOptionsUpdatedTestData1() {
             matchTypePrefix: false,
             hidePopupOnCursorExit: false,
             hidePopupOnCursorExitDelay: 0,
+            paginatedScrolling: false,
             normalizeCssZoom: true,
             preventMiddleMouse: {
                 onTextHover: false,

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -361,7 +361,9 @@ function createProfileOptionsUpdatedTestData1() {
             matchTypePrefix: false,
             hidePopupOnCursorExit: false,
             hidePopupOnCursorExitDelay: 0,
-            paginatedScrolling: false,
+            reducedMotionScrolling: false,
+            reducedMotionScrollingScale: 1,
+            reducedMotionScrollingSwipeThreshold: 40,
             normalizeCssZoom: true,
             preventMiddleMouse: {
                 onTextHover: false,

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -203,6 +203,7 @@ export type ScanningOptions = {
     matchTypePrefix: boolean;
     hidePopupOnCursorExit: boolean;
     hidePopupOnCursorExitDelay: number;
+    paginatedScrolling: boolean;
     normalizeCssZoom: boolean;
     scanWithoutMousemove: boolean;
     scanResolution: string;

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -203,7 +203,9 @@ export type ScanningOptions = {
     matchTypePrefix: boolean;
     hidePopupOnCursorExit: boolean;
     hidePopupOnCursorExitDelay: number;
-    paginatedScrolling: boolean;
+    reducedMotionScrolling: boolean;
+    reducedMotionScrollingScale: number;
+    reducedMotionScrollingSwipeThreshold: number;
     normalizeCssZoom: boolean;
     scanWithoutMousemove: boolean;
     scanResolution: string;


### PR DESCRIPTION
This was suggested on Discord and I thought it'd be pretty cool. Especially useful on ereaders and would make scrolling through definitions on higher quality modes feel a lot better.

It doesn't exactly scroll by popup height, there is a small overlap to kind of help with orientation.

I wasn't sure where to place the checkbox, so it's currently under "Popup Behaviour" as an advanced option.

https://github.com/user-attachments/assets/92bf0d4f-fd18-4729-855d-5307a7df0f4d

