### PR TITLE
Treat curly and straight apostrophes as equal when ignoreCase is enabled

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -2672,7 +2672,9 @@ export class Backend {
             for (const {pattern, ignoreCase, replacement} of group) {
                 let patternRegExp;
                 try {
-                    patternRegExp = new RegExp(pattern, ignoreCase ? 'gi' : 'g');
+                    patternRegExp = ignoreCase ?
+                        new RegExp(pattern.replace("'", "['’]"), 'gi') :
+                        new RegExp(pattern, 'g');
                 } catch (e) {
                     // Invalid pattern
                     continue;


### PR DESCRIPTION
Proposed in https://github.com/yomidevs/yomitan/issues/2069

Although I think https://github.com/yomidevs/yomitan/pull/2066 pretty much fixes the issue by handling this case in the recommended settings for French.