### PR TITLE
[el] Add processor to support double acute-accented words

### DIFF
--- a/ext/js/language/el/modern-greek-processors.js
+++ b/ext/js/language/el/modern-greek-processors.js
@@ -35,21 +35,12 @@ export function removeDoubleAcuteAccentsImpl(word) {
     const ACUTE_ACCENT = '\u0301'; // Combining acute accent
     const decomposed = word.normalize('NFD');
 
-    // Count accents
-    const accents = [...decomposed].filter((char) => char === ACUTE_ACCENT);
-    if (accents.length < 2) {
-        return word;
-    }
-
     // Remove every acute after the first
-    let removed = false;
-    const updated = [...decomposed].filter((char, i, arr) => {
-        if (char === ACUTE_ACCENT && !removed) {
-            const rest = arr.slice(i + 1);
-            if (!rest.includes(ACUTE_ACCENT)) {
-                removed = true;
-                return false;
-            }
+    let acuteAccents = 0;
+    const updated = [...decomposed].filter((char) => {
+        if (char === ACUTE_ACCENT) {
+            acuteAccents += 1;
+            return acuteAccents === 1;
         }
         return true;
     });

--- a/ext/js/language/el/modern-greek-processors.js
+++ b/ext/js/language/el/modern-greek-processors.js
@@ -32,18 +32,11 @@ export const removeDoubleAcuteAccents = {
  * @returns {string}
  */
 export function removeDoubleAcuteAccentsImpl(word) {
-    const ACUTE_ACCENT = '\u0301'; // Combining acute accent
-    const decomposed = word.normalize('NFD');
+    const ACUTE_ACCENT = '\u0301';
+    const decomposed = [...word.normalize('NFD')];
 
-    // Remove every acute after the first
-    let acuteAccents = 0;
-    const updated = [...decomposed].filter((char) => {
-        if (char === ACUTE_ACCENT) {
-            acuteAccents += 1;
-            return acuteAccents === 1;
-        }
-        return true;
-    });
+    const firstIndex = decomposed.indexOf(ACUTE_ACCENT);
+    const updated = decomposed.filter((char, index) => char !== ACUTE_ACCENT || index === firstIndex);
 
     return updated.join('').normalize('NFC');
 }

--- a/ext/js/language/el/modern-greek-processors.js
+++ b/ext/js/language/el/modern-greek-processors.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {basicTextProcessorOptions} from '../text-processors.js';
+
+/** @type {import('language').TextProcessor<boolean>} */
+export const removeDoubleAcuteAccents = {
+    name: 'Remove double acute accents',
+    description: 'πρόσωπό → πρόσωπο',
+    options: basicTextProcessorOptions,
+    process: (str, setting) => {
+        return setting ? removeDoubleAcuteAccentsImpl(str) : str;
+    },
+};
+
+/**
+ * @param {string} word
+ * @returns {string}
+ */
+export function removeDoubleAcuteAccentsImpl(word) {
+    const ACUTE_ACCENT = '\u0301'; // Combining acute accent
+    const decomposed = word.normalize('NFD');
+
+    // Count accents
+    const accents = [...decomposed].filter((char) => char === ACUTE_ACCENT);
+    if (accents.length < 2) {
+        return word;
+    }
+
+    // Remove every acute after the first
+    let removed = false;
+    const updated = [...decomposed].filter((char, i, arr) => {
+        if (char === ACUTE_ACCENT && !removed) {
+            const rest = arr.slice(i + 1);
+            if (!rest.includes(ACUTE_ACCENT)) {
+                removed = true;
+                return false;
+            }
+        }
+        return true;
+    });
+
+    return updated.join('').normalize('NFC');
+}

--- a/ext/js/language/language-descriptors.js
+++ b/ext/js/language/language-descriptors.js
@@ -29,6 +29,7 @@ import {arabicTransforms} from './ar/arabic-transforms.js';
 import {normalizeRadicalCharacters} from './CJK-util.js';
 import {eszettPreprocessor} from './de/german-text-preprocessors.js';
 import {germanTransforms} from './de/german-transforms.js';
+import {removeDoubleAcuteAccents} from './el/modern-greek-processors.js';
 import {englishTransforms} from './en/english-transforms.js';
 import {esperantoTransforms} from './eo/esperanto-transforms.js';
 import {spanishTransforms} from './es/spanish-transforms.js';
@@ -152,7 +153,10 @@ const languageDescriptors = [
         iso639_3: 'ell',
         name: 'Greek',
         exampleText: 'διαβάζω',
-        textPreprocessors: capitalizationPreprocessors,
+        textPreprocessors: {
+            ...capitalizationPreprocessors,
+            removeDoubleAcuteAccents,
+        },
     },
     {
         iso: 'en',

--- a/test/language/modern-greek-processors.test.js
+++ b/test/language/modern-greek-processors.test.js
@@ -21,9 +21,11 @@ import {removeDoubleAcuteAccentsImpl} from '../../ext/js/language/el/modern-gree
 const testCases = [
     ['πρόσωπό', 'πρόσωπο'],
     ['ναΰδριό', 'ναΰδριο'],
+    ['ό,τί', 'ό,τι'],
     // Does nothing with less than two acute accents
     ['παιδί', 'παιδί'],
     ['το', 'το'],
+    ['ΕΛ.ΑΣ', 'ΕΛ.ΑΣ'],
 ];
 
 describe('diacritics normalization', () => {

--- a/test/language/modern-greek-processors.test.js
+++ b/test/language/modern-greek-processors.test.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {describe, expect, test} from 'vitest';
+import {removeDoubleAcuteAccentsImpl} from '../../ext/js/language/el/modern-greek-processors.js';
+
+const testCases = [
+    ['πρόσωπό', 'πρόσωπο'],
+    ['ναΰδριό', 'ναΰδριο'],
+    // Does nothing with less than two acute accents
+    ['παιδί', 'παιδί'],
+    ['το', 'το'],
+];
+
+describe('diacritics normalization', () => {
+    test.each(testCases)('%s converts to %s', (input, expected) => {
+        expect(removeDoubleAcuteAccentsImpl(input)).toStrictEqual(expected);
+    });
+});

--- a/types/ext/language-descriptors.d.ts
+++ b/types/ext/language-descriptors.d.ts
@@ -112,7 +112,9 @@ type AllTextProcessors = {
         };
     };
     el: {
-        pre: CapitalizationPreprocessors;
+        pre: CapitalizationPreprocessors & {
+            removeDoubleAcuteAccents: TextProcessor<boolean>;
+        };
     };
     en: {
         pre: CapitalizationPreprocessors;


### PR DESCRIPTION
Closes #2007

Adds a processor to convert double acute-accented words to their normalized, single-accented version, in order to properly appear in the dictionary. Without this, words like `πρόσωπό` will not show, no matter the dictionary.

It was [noted](https://github.com/yomidevs/yomitan/issues/2007#issuecomment-2879341866) in the issue above, that the same could be achieved via removing diacritics altogether and modifying the dictionary. I didn't manage to make that approach work.

I still think this is a plain improvement over the current version and can not picture any drawbacks. Let me know if you have any feedback and I will happily iterate over it.