### PR TITLE
[el] Suggest 24 as the default scanning length for Greek

### DIFF
--- a/ext/data/recommended-settings.json
+++ b/ext/data/recommended-settings.json
@@ -121,6 +121,14 @@
                 "value": false
             },
             "description": "Turn off Yomitan's internal parser for languages with spaces."
+        },
+        {
+            "modification": {
+                "action": "set",
+                "path": "scanning.length",
+                "value": 24
+            },
+            "description": "Increase the default scanning length from 16 to 24 characters."
         }
     ],
     "en": [


### PR DESCRIPTION
Closes #2184

As stated in the issue, the default of 16 is somewhat low for Greek and may end up ignoring long words. We just add a suggestion to up this default to 24 when setting the language to Greek.

The value of 24 is relatively random, and was chosen because of this:

> Looking at kty-el-el, with the help of a simple script, the default of 16 excludes 14266 words of a total of 1085279, for a 1,31% ratio. I think this is high enough to deserve consideration. For comparison, setting the default to 20 ignores only 0.12%, and with 24 it goes down to 0.03%.

I did not want to increase it too much lest performance issues arise.