### PR TITLE
Improve replacements docs within Yomitan

### DIFF
--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -704,6 +704,11 @@
                 The format of the JSON file is described in <a href="/data/schemas/custom-audio-list-schema.json" target="_blank" rel="noopener noreferrer">this schema file</a>.
             </p>
             <p>
+                The replacement tags <code data-select-on-click="">{term}</code> and <code data-select-on-click="">{reading}</code>
+                can be used to specify which term and reading is being looked up.<br>
+                <code data-select-on-click="">{language}</code> is also available for sources that require an iso language string.<br>
+            </p>
+            <p>
                 Example:<br>
                 <a tabindex="0" data-select-on-click="">http://localhost/audio.json?term={term}&amp;reading={reading}</a>
             </p>


### PR DESCRIPTION
How it looks now:
<img width="399" height="243" alt="image" src="https://github.com/user-attachments/assets/ec9e2591-8b61-4ca3-82af-67ce5695f9f7" />
<img width="402" height="282" alt="image" src="https://github.com/user-attachments/assets/190917f2-d289-439d-9994-3dbfbabf7bfe" />

I don't totally love how hidden away these help dialogs feel but better to have it there than not.