### PR TITLE
Disable audio help button when not available instead of hiding

### DIFF
--- a/ext/js/pages/settings/audio-controller.js
+++ b/ext/js/pages/settings/audio-controller.js
@@ -471,10 +471,10 @@ class AudioSourceEntry {
                 break;
         }
 
-        /** @type {?HTMLElement} */
+        /** @type {?HTMLButtonElement} */
         const helpNode = menu.bodyNode.querySelector('.popup-menu-item[data-menu-action=help]');
         if (helpNode !== null) {
-            helpNode.hidden = !hasHelp;
+            helpNode.disabled = !hasHelp;
         }
     }
 


### PR DESCRIPTION
To help a tiny bit with the discoverability concerns of the audio source help menu mentioned in #2196.

The help button not existing for most of the sources will put off users even looking for it after they see it doesn't exist on the kebab menu. Showing it disabled at least gives an indication that it must exist *sometimes*.

Before:
<img width="112" height="82" alt="image" src="https://github.com/user-attachments/assets/e86d2907-ed84-4cb6-abf2-91b7a5df253e" />

After:
<img width="122" height="118" alt="image" src="https://github.com/user-attachments/assets/a2028f38-46a7-4e3a-bc69-f97d4bd6c2ab" />
