### PR TITLE
Use ctrl+u to clear text in the search page

### DIFF
--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -302,7 +302,7 @@ export class SearchDisplayController {
     }
 
     /**
-     * @param {MouseEvent} e
+     * @param {Event} e
      */
     _onClear(e) {
         e.preventDefault();


### PR DESCRIPTION
Ctrl+u is a common shortcut for clearing text on input fields and has been in my muscle memory, but the current behavior prevents that and will instead view the page source which is not my intention.

Thanks.