### PR TITLE
Add back furigana handlebars for all languages

### DIFF
--- a/ext/js/data/anki-template-util.js
+++ b/ext/js/data/anki-template-util.js
@@ -42,6 +42,8 @@ export function getStandardFieldMarkers(type, language = 'ja') {
                 'frequency-harmonic-occurrence',
                 'frequency-average-rank',
                 'frequency-average-occurrence',
+                'furigana',
+                'furigana-plain',
                 'glossary',
                 'glossary-brief',
                 'glossary-no-dictionary',
@@ -65,8 +67,6 @@ export function getStandardFieldMarkers(type, language = 'ja') {
             if (language === 'ja') {
                 markers.push(
                     'cloze-body-kana',
-                    'furigana',
-                    'furigana-plain',
                     'pitch-accents',
                     'pitch-accent-graphs',
                     'pitch-accent-graphs-jj',


### PR DESCRIPTION
Although "furigana" isn't a great name for this in other languages, Japanese isn't the only language with users who want readings displayed overtop words.

Same thing as #2135. These handlebars can already be used in all languages but are hidden from the dropdown if the language is not Japanese.