### PR TITLE
Disconnect cross frame api on BFCache page restore

### DIFF
--- a/ext/js/comm/cross-frame-api.js
+++ b/ext/js/comm/cross-frame-api.js
@@ -69,6 +69,7 @@ export class CrossFrameAPIPort extends EventDispatcher {
         if (this._port === null) { throw new Error('Invalid state'); }
         this._eventListeners.addListener(this._port.onDisconnect, this._onDisconnect.bind(this));
         this._eventListeners.addListener(this._port.onMessage, this._onMessage.bind(this));
+        this._eventListeners.addEventListener(window, 'pageshow', this._onPageShow.bind(this));
     }
 
     /**
@@ -122,6 +123,16 @@ export class CrossFrameAPIPort extends EventDispatcher {
     }
 
     // Private
+
+    /**
+     * @param {PageTransitionEvent} e
+     */
+    _onPageShow(e) {
+        // Page restored from BFCache
+        if (e.persisted) {
+            this._onDisconnect();
+        }
+    }
 
     /** */
     _onDisconnect() {


### PR DESCRIPTION
Fixes #2189

Chrome BFCache changes now break the port connections forcefully and Yomitan ends up unaware of this thinking the connection is just timing out and not disconnected. https://developer.chrome.com/blog/bfcache-extension-messaging-changes

Very similar implementation to the example from the chrome dev blog. Persisted must be checked for to only disconnect when the page is pulled from cache and avoid unnecessary disconnects.

Tested on Firefox as well. Appears to not cause any issues.