### PR TITLE
Remove redundant connection check

### DIFF
--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -975,9 +975,13 @@ export class DisplayAnki {
         let infos;
         let ankiError = null;
         try {
-            infos = this._checkForDuplicates ?
-                await this._display.application.api.getAnkiNoteInfo(notes, this._isAdditionalInfoEnabled()) :
-                this._getAnkiNoteInfoForceValueIfValid(notes, true);
+            if (this._checkForDuplicates) {
+                infos = await this._display.application.api.getAnkiNoteInfo(notes, this._isAdditionalInfoEnabled());
+            } else {
+                const isAnkiConnected = await this._display.application.api.isAnkiConnected();
+                infos = this._getAnkiNoteInfoForceValueIfValid(notes, isAnkiConnected);
+                ankiError = isAnkiConnected ? null : new Error('Anki not connected');
+            }
         } catch (e) {
             infos = this._getAnkiNoteInfoForceValueIfValid(notes, false);
             ankiError = (e instanceof ExtensionError && e.message.includes('Anki connection failure')) ?


### PR DESCRIPTION
Right now each time we want to get info about the Anki notes we check if the extension is connected to anki.

But getAnkiNotes will throw an error if they are unable to connect so we can just catch that instead.

With this we can avoid redundant calls to getVersion every time we check for duplicates.