### PR TITLE
Handle resume event and log BFCache pageshow event

### DIFF
--- a/ext/js/comm/cross-frame-api.js
+++ b/ext/js/comm/cross-frame-api.js
@@ -70,6 +70,7 @@ export class CrossFrameAPIPort extends EventDispatcher {
         this._eventListeners.addListener(this._port.onDisconnect, this._onDisconnect.bind(this));
         this._eventListeners.addListener(this._port.onMessage, this._onMessage.bind(this));
         this._eventListeners.addEventListener(window, 'pageshow', this._onPageShow.bind(this));
+        this._eventListeners.addEventListener(document, 'resume', this._onResume.bind(this));
     }
 
     /**
@@ -125,11 +126,21 @@ export class CrossFrameAPIPort extends EventDispatcher {
     // Private
 
     /**
+     * @param {Event} e
+     */
+    _onResume(e) {
+        // Page Resumed after being frozen
+        log.log('Yomitan cross frame reset. Resuming after page frozen.', e);
+        this._onDisconnect();
+    }
+
+    /**
      * @param {PageTransitionEvent} e
      */
     _onPageShow(e) {
         // Page restored from BFCache
         if (e.persisted) {
+            log.log('Yomitan cross frame reset. Page restored from BFCache.', e);
             this._onDisconnect();
         }
     }


### PR DESCRIPTION
Part 2 of #2216 to fix the frozen popup issue

Pages can be set in a "frozen" state. When pages are "resumed", it is very similar to when a page is restored from the BFCache.

To test for a frozen page:
1. Open `chrome://discards/` and whichever page you want to freeze
2. Click `[Freeze]` on the page to freeze
    Do not have any dev tools open (such as console logs) while waiting for the page to freeze. It will prevent the page from freezing.
4. Wait a minute and do not open the page in this time

https://developer.chrome.com/blog/freezing-on-energy-saver
https://developer.chrome.com/docs/web-platform/page-lifecycle-api#event-resume

This does not exist on Firefox. But I have tested that attempting to put a listener on this event in Firefox does not cause any issue.

Also added logging for when this happens as well as the BFCache pageshow event.

`resume` and `pageshow` may be called together in some cases. Potentially spamming `_onDisconnect` should not cause any issues here.