### PR TITLE
Remove wildcard handling from text-scanner entirely

### DIFF
--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -560,7 +560,6 @@ export class Frontend {
             delay: scanningOptions.delay,
             scanLength: scanningOptions.length,
             layoutAwareScan: scanningOptions.layoutAwareScan,
-            matchTypePrefix: scanningOptions.matchTypePrefix,
             preventMiddleMouseOnPage,
             preventMiddleMouseOnTextHover,
             preventBackForwardOnPage,
@@ -568,7 +567,6 @@ export class Frontend {
             sentenceParsingOptions,
             scanWithoutMousemove: scanningOptions.scanWithoutMousemove,
             scanResolution: scanningOptions.scanResolution,
-            pageType: this._pageType,
         });
         this._updateTextScannerEnabled();
 

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -117,8 +117,6 @@ export class TextScanner extends EventDispatcher {
         this._preventBackForwardOnPage = false;
         /** @type {boolean} */
         this._preventBackForwardOnTextHover = false;
-        /** @type {boolean} */
-        this._matchTypePrefix = false;
         /** @type {number} */
         this._sentenceScanExtent = 0;
         /** @type {boolean} */
@@ -275,10 +273,8 @@ export class TextScanner extends EventDispatcher {
         preventBackForwardOnPage,
         preventBackForwardOnTextHover,
         sentenceParsingOptions,
-        matchTypePrefix,
         scanWithoutMousemove,
         scanResolution,
-        pageType,
     }) {
         if (Array.isArray(inputs)) {
             this._inputs = inputs.map((input) => this._convertInput(input));
@@ -312,9 +308,6 @@ export class TextScanner extends EventDispatcher {
         }
         if (typeof preventBackForwardOnTextHover === 'boolean') {
             this._preventBackForwardOnTextHover = preventBackForwardOnTextHover;
-        }
-        if (typeof matchTypePrefix === 'boolean') {
-            this._matchTypePrefix = pageType === 'search' ? matchTypePrefix : false;
         }
         if (typeof scanWithoutMousemove === 'boolean') {
             this._scanWithoutMousemove = scanWithoutMousemove;
@@ -1268,7 +1261,6 @@ export class TextScanner extends EventDispatcher {
 
         /** @type {import('api').FindTermsDetails} */
         const details = {};
-        if (this._matchTypePrefix) { details.matchType = 'prefix'; }
         const {dictionaryEntries, originalTextLength} = await this._api.termsFind(searchText, details, optionsContext);
         if (dictionaryEntries.length === 0) { return null; }
 


### PR DESCRIPTION
Somewhat of a followup to #2145

#2145 fixes wildcard scanning making lookups super laggy on normal webpages. But they can still be messed up when using the popup to hover words on the search page.

The search page does not even use this setting to determine whether or not to search using wildcards. In theory it may have been possible to scan `*わ` for example on a webpage and have that be a wildcard search. But this is silly and nobody complained when I removed this behavior in #2145 so it makes sense to just remove this entirely.

I'm not removing the wildcard setting itself since it probably should control the function on the search page (currently it does nothing). I'll leave that to a future pr.

This does not change any behavior with how the search page handles wildcards.