### PR TITLE
Attach source for firefox dev build

### DIFF
--- a/.github/workflows/publish-firefox-development.yml
+++ b/.github/workflows/publish-firefox-development.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Sign Firefox xpi for offline distribution
         id: ffSignXpi
         continue-on-error: true
-        uses: cardinalby/webext-buildtools-firefox-sign-xpi-action@b5c3dd6962ca3114057a5e9a31f5381d8ebd9b8f # signing_test branch
+        uses: cardinalby/webext-buildtools-firefox-sign-xpi-action@0953ef0b8a488a791f17c14fa5b800b131632d34
         with:
           approvalTimeoutMs: 1200000
           validationTimeoutMs: 3600000


### PR DESCRIPTION
Kinda works, kinda doesnt. Attaching the source code goes fine without issue but mozilla takes forever to approve it for us. Possibly because Yomitan is a recommended extension. This issue first started popping up quite soon after Yomitan got the recommended badge.

Probably need to go a bit further with this action to fetch a build reliably (something like scheduling an action run a few days later). But by the time these get approved it's so close to already getting pushed to stable there's probably not much point.

Related: https://github.com/cardinalby/webext-buildtools-firefox-sign-xpi-action/issues/10