### PR TITLE
Make glossary-plain structured gloss to raw string conversion recursive

### DIFF
--- a/ext/js/templates/anki-template-renderer.js
+++ b/ext/js/templates/anki-template-renderer.js
@@ -807,6 +807,32 @@ export class AnkiTemplateRenderer {
     }
 
     /**
+     * @param {import('structured-content.js').Content[]} content
+     * @param {StructuredContentGenerator} structuredContentGenerator
+     * @returns {string[]}
+     */
+    _convertGlossaryStructuredContentRecursive(content, structuredContentGenerator) {
+        /** @type {string[]} */
+        const rawGlossaryContent = [];
+        while (content.length > 0) {
+            const structuredGloss = content.shift();
+            if (typeof structuredGloss === 'string') {
+                rawGlossaryContent.push(structuredGloss);
+            } else if (Array.isArray(structuredGloss)) {
+                rawGlossaryContent.push(...this._convertGlossaryStructuredContentRecursive(structuredGloss, structuredContentGenerator));
+            } else if (typeof structuredGloss === 'object' && structuredGloss.content) {
+                if (structuredGloss.tag === 'ruby') {
+                    const node = structuredContentGenerator.createStructuredContent(structuredGloss.content, '');
+                    rawGlossaryContent.push(node !== null ? this._getStructuredContentText(node) : '');
+                    continue;
+                }
+                rawGlossaryContent.push(...this._convertGlossaryStructuredContentRecursive([structuredGloss.content], structuredContentGenerator));
+            }
+        }
+        return rawGlossaryContent;
+    }
+
+    /**
      * @param {import('dictionary-data').TermGlossaryStructuredContent} content
      * @param {StructuredContentGenerator} structuredContentGenerator
      * @returns {string[]}
@@ -816,23 +842,7 @@ export class AnkiTemplateRenderer {
         const glossaryContentQueue = this._extractGlossaryStructuredContentRecursive([content.content]);
 
         /** @type {string[]} */
-        const rawGlossaryContent = [];
-        while (glossaryContentQueue.length > 0) {
-            const structuredGloss = glossaryContentQueue.shift();
-            if (typeof structuredGloss === 'string') {
-                rawGlossaryContent.push(structuredGloss);
-            } else if (Array.isArray(structuredGloss)) {
-                glossaryContentQueue.push(...structuredGloss);
-            } else if (typeof structuredGloss === 'object' && structuredGloss.content) {
-                if (structuredGloss.tag === 'ruby') {
-                    const node = structuredContentGenerator.createStructuredContent(structuredGloss.content, '');
-                    rawGlossaryContent.push(node !== null ? this._getStructuredContentText(node) : '');
-                    continue;
-                }
-                glossaryContentQueue.push(structuredGloss.content);
-            }
-        }
-        return rawGlossaryContent;
+        return this._convertGlossaryStructuredContentRecursive(glossaryContentQueue, structuredContentGenerator);
     }
 
     /**


### PR DESCRIPTION
Fix another case in #2212 

~~Just one more patch bro it's fixed for real this time bro believe me just one more patch cmon just merge this one patch and we wont have to worry about any more problems with this again for sure real believe me~~

#2240 made the glossary extraction recursive to ensure ordering did not get messed up there. But ordering could still get messed up in the conversion from glossary to raw string. This fixes that by making that part recursive as well.

This could probably be rolled all into a single function rather than two distinct steps but I don't want to worry about testing that at the moment and there's no real problems doing it this way. It's the same amount of compute, just some small extra allocation.
