### PR TITLE
Don't allow `content` to get mutated when creating glossary-plain

### DIFF
--- a/ext/js/templates/anki-template-renderer.js
+++ b/ext/js/templates/anki-template-renderer.js
@@ -787,8 +787,8 @@ export class AnkiTemplateRenderer {
     _extractGlossaryStructuredContentRecursive(content) {
         /** @type {import('structured-content.js').Content[]} */
         const extractedContent = [];
-        while (content.length > 0) {
-            const structuredContent = content.shift();
+        for (let i = 0; i < content.length; i++) {
+            const structuredContent = content[i];
             if (Array.isArray(structuredContent)) {
                 extractedContent.push(...this._extractGlossaryStructuredContentRecursive(structuredContent));
             } else if (typeof structuredContent === 'object' && structuredContent) {


### PR DESCRIPTION
Fixes #2270

#2261 was fixing the wrong problem. Reverting that change in 928325547395954d82223bcfe61ad610cbc63918.

The real problem was this part failing to do anything due to content getting cleared out: https://github.com/Kuuuube/yomitan/blob/fa28f9a5163e39c9054eac1bd3e13fba3e4d643e/ext/js/templates/anki-template-renderer.js#L773-L776.

I don't really understand how the original code did not have this same issue (tell me how this doesn't mutate `content` ???):

```js
/**
 * @param {import('structured-content.js').Content[]} content
 * @returns {import('structured-content.js').Content[]}
 */
_extractGlossaryDataOld(content) {
    /** @type {import('structured-content.js').Content[]} */
    const glossaryContentQueue = [];
    const structuredContentQueue = content;
    while (structuredContentQueue.length > 0) {
        const structuredContent = structuredContentQueue.shift();
        if (Array.isArray(structuredContent)) {
            structuredContentQueue.push(...structuredContent);
        } else if (typeof structuredContent === 'object' && structuredContent.content) {
            // @ts-expect-error - Checking if `data` exists
            if (structuredContent.data?.content === 'glossary') {
                glossaryContentQueue.push(structuredContent);
                continue;
            }
            structuredContentQueue.push(structuredContent.content);
        }
    }

    return glossaryContentQueue;
}
```

But for whatever reason this works and now with the recursive version it doesn't. Both use `shift` just the same and assigning `content` to another variable beforehand in the current version does nothing (as is expected since it's setting a reference). Only thing I can think is JS breaks the ref if it gets too deep into the recursion.

Regardless, this doesn't actually need a shift anymore since the recursive version never pushes anything back into the original array.