### PR TITLE
Disable anki add button for 2.5s after click

### DIFF
--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -642,17 +642,18 @@ export class DisplayAnki {
         const button = this._saveButtonFind(dictionaryEntryIndex, cardFormatIndex);
         if (button === null || button.disabled) { return; }
 
+        /** @type {Error[]} */
+        const allErrors = [];
+
         button.disabled = true;
         setTimeout(() => {
-            if (this._duplicateBehavior !== 'prevent') {
+            if (this._duplicateBehavior !== 'prevent' || allErrors.length > 0) {
                 button.disabled = false;
             }
         }, 2500);
 
         this._hideErrorNotification(true);
 
-        /** @type {Error[]} */
-        const allErrors = [];
         const progressIndicatorVisible = this._display.progressIndicatorVisible;
         const overrideToken = progressIndicatorVisible.setOverride(true);
         try {


### PR DESCRIPTION
Stops the user from accidentally double clicking the button or accidentally pressing the add hotkey twice. Button re-enable obv doesn't apply unless dupes/overwrite is allowed.

2.5s seems sane here to me but open to suggestions if this seems too much. If the user scans a word, adds it, scans another. Since the button is re-rendered, the second popup doesn't have any extra delay on adding.

Considered disabling then re-enabling after the card is created. But in some cases this could happen so fast that a user could still accidentally double click and end up adding two cards.