### PR TITLE
Remove shift to prevent mutating content when running _convertGlossaryStructuredContentRecursive

### DIFF
--- a/ext/js/templates/anki-template-renderer.js
+++ b/ext/js/templates/anki-template-renderer.js
@@ -814,8 +814,8 @@ export class AnkiTemplateRenderer {
     _convertGlossaryStructuredContentRecursive(content, structuredContentGenerator) {
         /** @type {string[]} */
         const rawGlossaryContent = [];
-        while (content.length > 0) {
-            const structuredGloss = content.shift();
+        for (let i = 0; i < content.length; i++) {
+            const structuredGloss = content[i];
             if (typeof structuredGloss === 'string') {
                 rawGlossaryContent.push(structuredGloss);
             } else if (Array.isArray(structuredGloss)) {


### PR DESCRIPTION
Same change as #2274 but in the other function now. Nothing gets pushed back to `content` anymore so the shift is unnecessary.

Fixes #2286

Bug only happens if a glossary plain handlebars is rendered before other glossary handlebars.