### PR TITLE
Remove duplicate "search" tag category in docs

### DIFF
--- a/docs/making-yomitan-dictionaries.md
+++ b/docs/making-yomitan-dictionaries.md
@@ -92,7 +92,6 @@ The second item in the array of the tag bank schema determines the tag category,
 - partOfSpeech
 - search
 - pronunciation-dictionary
-- search
 
 You can view the tag colors [here](https://github.com/yomidevs/yomitan/blob/48f1d012ad5045319d4e492dfbefa39da92817b2/ext/css/display.css#L136-L149).
 


### PR DESCRIPTION
Noticed that "search" is listed twice under the tag categories in the docs for making a dictionary. This removes the second entry.