### PR TITLE
Update GitHub raw URLs for JSON schemas

### DIFF
--- a/docs/making-yomitan-dictionaries.md
+++ b/docs/making-yomitan-dictionaries.md
@@ -47,31 +47,35 @@ A dictionary can contain various types of information within the zip file. After
 
 To validate schemas, configure [VSCode](https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings) to validate schemas or use a website such as [jsonschemavalidator](https://www.jsonschemavalidator.net/).
 
-For VSCode validation, use the following settings JSON:
+For VSCode validation, add the following to your User or Workspace `settings.json`:
 
 ```json
-  "json.schemas": [
+"json.schemas": [
     {
-      "fileMatch": ["kanji_bank_*.json"],
-      "url": "https://github.com/yomidevs/yomitan/raw/master/ext/data/schemas/dictionary-kanji-bank-v3-schema.json"
+        "fileMatch": ["index.json"],
+        "url": "https://raw.githubusercontent.com/yomidevs/yomitan/refs/heads/master/ext/data/schemas/dictionary-index-schema.json"
     },
     {
-      "fileMatch": ["kanji_meta_bank_*.json"],
-      "url": "https://github.com/yomidevs/yomitan/raw/master/ext/data/schemas/dictionary-kanji-meta-bank-v3-schema.json"
+        "fileMatch": ["kanji_bank_*.json"],
+        "url": "https://raw.githubusercontent.com/yomidevs/yomitan/refs/heads/master/ext/data/schemas/dictionary-kanji-bank-v3-schema.json"
     },
     {
-      "fileMatch": ["tag_bank_*.json"],
-      "url": "https://github.com/yomidevs/yomitan/raw/master/ext/data/schemas/dictionary-tag-bank-v3-schema.json"
+        "fileMatch": ["kanji_meta_bank_*.json"],
+        "url": "https://raw.githubusercontent.com/yomidevs/yomitan/refs/heads/master/ext/data/schemas/dictionary-kanji-meta-bank-v3-schema.json"
     },
     {
-      "fileMatch": ["term_bank_*.json"],
-      "url": "https://github.com/yomidevs/yomitan/raw/master/ext/data/schemas/dictionary-term-bank-v3-schema.json"
+        "fileMatch": ["tag_bank_*.json"],
+        "url": "https://raw.githubusercontent.com/yomidevs/yomitan/refs/heads/master/ext/data/schemas/dictionary-tag-bank-v3-schema.json"
     },
     {
-      "fileMatch": ["term_meta_bank_*.json"],
-      "url": "https://github.com/yomidevs/yomitan/raw/master/ext/data/schemas/dictionary-term-meta-bank-v3-schema.json"
+        "fileMatch": ["term_bank_*.json"],
+        "url": "https://raw.githubusercontent.com/yomidevs/yomitan/refs/heads/master/ext/data/schemas/dictionary-term-bank-v3-schema.json"
+    },
+    {
+        "fileMatch": ["term_meta_bank_*.json"],
+        "url": "https://raw.githubusercontent.com/yomidevs/yomitan/refs/heads/master/ext/data/schemas/dictionary-term-meta-bank-v3-schema.json"
     }
-  ],
+]
 ```
 
 ## Conjugation


### PR DESCRIPTION
## Main Changes

This updates the raw URLs recommended for JSON schema reference in VSCode settings, as the URLs accepted as trusted domains by default in VSCode only contain the following:

<img width="871" height="241" alt="image" src="https://github.com/user-attachments/assets/411780f4-8854-4613-bbdc-e5415c25a877" />

Now users copying these settings don't need to add an additional trusted domain to their settings to get the schemas working (what I ran into trying to copy the current settings initially).

Note that these URLs are what the existing ones resolve to if you navigate to them (they redirect to the `raw.githubusercontent` domain).

## Other Minor Changes

- Slightly rephrase where to put these settings to specify the VSCode scope / file they go in to make it clearer either location is fine and that it's in addition to any existing settings you have
- Include the `index.json` schema URL so it's covered by the validation too
- Un-indent the code by one level
- Remove the trailing comma

For the last two, on save the editor will add indentation and a trailing comma but I made those edits just to match the examples in the linked VSCode documentation (I have no preference either way though).

However, to maintain current space-saving I didn't update `"fileMatch"` to match the the linked documentation of being multi-line like:

```json
        {
            "fileMatch": [
                "kanji_bank_*.json"
            ],
            "url": "https://raw.githubusercontent.com/yomidevs/yomitan/refs/heads/master/ext/data/schemas/dictionary-kanji-bank-v3-schema.json"
        },
```

## Screenshot

<img width="1137" height="775" alt="image" src="https://github.com/user-attachments/assets/33b0be05-a71a-4e5c-876a-576dbcd8cb6c" />
