### PR TITLE
Change scanning.scanResolution recommended setting to character for agglutinative languages

### DIFF
--- a/ext/data/recommended-settings.json
+++ b/ext/data/recommended-settings.json
@@ -212,6 +212,14 @@
         {
             "modification": {
                 "action": "set",
+                "path": "scanning.scanResolution",
+                "value": "character"
+            },
+            "description": "Scan text one character at a time."
+        },
+        {
+            "modification": {
+                "action": "set",
                 "path": "parsing.enableScanningParser",
                 "value": false
             },
@@ -244,22 +252,24 @@
             "description": "Turn off Yomitan's internal parser for languages with spaces."
         }
     ],
+    "et": [
+        {
+            "modification": {
+                "action": "set",
+                "path": "scanning.scanResolution",
+                "value": "character"
+            },
+            "description": "Scan text one character at a time."
+        }
+    ],
     "fi": [
         {
             "modification": {
                 "action": "set",
                 "path": "scanning.scanResolution",
-                "value": "word"
+                "value": "character"
             },
-            "description": "Scan text one word at a time (as opposed to one character)."
-        },
-        {
-            "modification": {
-                "action": "set",
-                "path": "translation.searchResolution",
-                "value": "word"
-            },
-            "description": "Lookup whole words in the dictionary."
+            "description": "Scan text one character at a time."
         },
         {
             "modification": {
@@ -368,17 +378,9 @@
             "modification": {
                 "action": "set",
                 "path": "scanning.scanResolution",
-                "value": "word"
+                "value": "character"
             },
-            "description": "Scan text one word at a time (as opposed to one character)."
-        },
-        {
-            "modification": {
-                "action": "set",
-                "path": "translation.searchResolution",
-                "value": "word"
-            },
-            "description": "Lookup whole words in the dictionary."
+            "description": "Scan text one character at a time."
         },
         {
             "modification": {
@@ -394,17 +396,9 @@
             "modification": {
                 "action": "set",
                 "path": "scanning.scanResolution",
-                "value": "word"
+                "value": "character"
             },
-            "description": "Scan text one word at a time (as opposed to one character)."
-        },
-        {
-            "modification": {
-                "action": "set",
-                "path": "translation.searchResolution",
-                "value": "word"
-            },
-            "description": "Lookup whole words in the dictionary."
+            "description": "Scan text one character at a time."
         },
         {
             "modification": {
@@ -459,6 +453,16 @@
             "description": "Lookup words by letter in the dictionary."
         }
     ],
+    "ka": [
+        {
+            "modification": {
+                "action": "set",
+                "path": "scanning.scanResolution",
+                "value": "character"
+            },
+            "description": "Scan text one character at a time."
+        }
+    ],
     "ko": [
         {
             "modification": {
@@ -504,17 +508,9 @@
             "modification": {
                 "action": "set",
                 "path": "scanning.scanResolution",
-                "value": "word"
+                "value": "character"
             },
-            "description": "Scan text one word at a time (as opposed to one character)."
-        },
-        {
-            "modification": {
-                "action": "set",
-                "path": "translation.searchResolution",
-                "value": "word"
-            },
-            "description": "Lookup whole words in the dictionary."
+            "description": "Scan text one character at a time."
         },
         {
             "modification": {
@@ -774,17 +770,9 @@
             "modification": {
                 "action": "set",
                 "path": "scanning.scanResolution",
-                "value": "word"
+                "value": "character"
             },
-            "description": "Scan text one word at a time (as opposed to one character)."
-        },
-        {
-            "modification": {
-                "action": "set",
-                "path": "translation.searchResolution",
-                "value": "word"
-            },
-            "description": "Lookup whole words in the dictionary."
+            "description": "Scan text one character at a time."
         },
         {
             "modification": {


### PR DESCRIPTION
Source is [this](https://en.wikipedia.org/wiki/Category:Agglutinative_languages) Wikipedia category.

Not sure what translation.searchResolution does; removed it completely for agglutinatives.