### PR TITLE
Add browser.tabs.captureVisibleTab as a fallback for chrome.tabs.captureVisibleTab

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -2317,6 +2317,7 @@ export class Backend {
         const {windowId} = tab;
 
         let token = null;
+        const errors = [];
         try {
             if (typeof tabId === 'number' && typeof frameId === 'number') {
                 const action = 'frontendSetAllVisibleOverride';
@@ -2336,11 +2337,17 @@ export class Backend {
                     });
                 });
             } catch (e) {
-                log.log(e);
+                errors.push(e);
             }
 
             // Fallback for some Firefox. Usually `chrome.tabs.captureVisibleTab` works but occasionally it doesn't
-            return await browser.tabs.captureVisibleTab(windowId, {format, quality});
+            try {
+                return await browser.tabs.captureVisibleTab(windowId, {format, quality});
+            } catch (e) {
+                errors.push(e);
+            }
+
+            throw new Error('Failed to screenshot, errors: [' + errors.join(', ') + ']');
         } finally {
             if (token !== null) {
                 const action = 'frontendClearAllVisibleOverride';


### PR DESCRIPTION
Fixes #1121

Looking past the AI mistakes in #2327, considering `browser.tabs.captureVisibleTab` is fine. I've added it as a fallback for if `chrome.tabs.captureVisibleTab` fails. I can't replicate `chrome.tabs.captureVisibleTab` failing on Firefox myself but if this fixes anything that's great.

Shouldn't need any permission changes. `browser.tabs.captureVisibleTab` runs without issues with the current manifest permissions.

Also notably, `browser.tabs.captureVisibleTab` does not exist on chromium browsers.