### PR TITLE
Scan delay for middle mouse click

### DIFF
--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -651,7 +651,6 @@ export class TextScanner extends EventDispatcher {
      * @returns {boolean|void}
      */
     _onMouseUp(e) {
-        this._scanTimerClear();
         switch (e.button) {
             case 3: // Back
             case 4: // Forward


### PR DESCRIPTION
Prevents instant popup when opening new browser tabs if set to something like 150+ ms. Maybe this is a hacky solution since iirc the original Yomichan already had this behavior, but I couldn't find what exactly changed years ago or why.