### PR TITLE
fix: prevent popup close from exiting fullscreen

### DIFF
--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -764,6 +764,10 @@ export class Popup extends EventDispatcher {
             if (contentWindow !== null) {
                 contentWindow.focus();
             }
+        } else if (getFullscreenElement() !== null) {
+            // In fullscreen, only blur the frame to let focus return implicitly.
+            // Calling window.focus() causes Chrome to exit fullscreen asynchronously.
+            this._frame.blur();
         } else {
             // Firefox doesn't like focusing window without first blurring the iframe.
             // this._frame.contentWindow.blur() doesn't work on Firefox for some reason.


### PR DESCRIPTION
Fixes #2192

When dismissing the Yomitan popup in fullscreen, Chrome exits fullscreen even if the close hotkey isn't Escape. The cause is `_focusParent()` calling `window.focus()` after blurring the popup iframe. Chromium intentionally exits fullscreen when `window.focus()` is called, as a security measure to prevent pages from obscuring the fullscreen UI ([chromestatus](https://chromestatus.com/feature/5732193850621952), [crbug.com/800056](https://crbug.com/800056)).

The fix skips `window.focus()` when in fullscreen. Just blurring the frame is sufficient to return focus. Host page keyboard shortcuts (e.g. `k` for pause/play on YouTube) continue to work. The fullscreen state check now also goes through the existing `getFullscreenElement()` helper for consistency with the rest of the file.

Automated testing note: I tried reproducing this in headed Playwright using both Brave and Playwright Chromium 131.0.6778.33, but fullscreen remained active in those Playwright runs, so I could not turn the original bug into a reliable Playwright regression test.

Tested on:
- Brave 1.87.192 (Chromium 145.0.7632.160) — bug reproduced manually and fix confirmed
- Firefox 149.0 — not affected (Firefox does not exit fullscreen on `window.focus()`)
