### PR TITLE
Fix Chrome 146+ detection (fixes https://github.com/yomidevs/yomitan/…

### DIFF
--- a/ext/js/extension/environment.js
+++ b/ext/js/extension/environment.js
@@ -101,10 +101,14 @@ export class Environment {
             if (this._isSafari()) {
                 return 'safari';
             }
-            if (os === 'android') {
-                return 'firefox-mobile';
+            if (navigator.userAgent.includes('Firefox')) {
+                if (os === 'android') {
+                    return 'firefox-mobile';
+                }
+                return 'firefox';
             }
-            return 'firefox';
+            // Chrome 146+ now supports the browser namespace
+            return 'chrome';
         } else {
             return 'chrome';
         }


### PR DESCRIPTION
Starting with Chrome 146, Chrome supports the "browser" namespace on top of the "chrome" one. This broke the yomitan browser detection causing Chrome to be detected as Firefox, in turn also breaking the clipboard monitor and possibly more side effects we haven't noticed.