### PR TITLE
Add Scottish Gaelic (gd) support

### DIFF
--- a/ext/js/language/language-descriptors.js
+++ b/ext/js/language/language-descriptors.js
@@ -247,13 +247,13 @@ const languageDescriptors = [
         textPreprocessors: capitalizationPreprocessors,
         languageTransforms: irishTransforms,
     },
-	{
-		iso: 'gd',
-		iso639_3: 'gla',
-		name: 'Scottish Gaelic',
-		exampleText: 'leugh',
-		textPreprocessors: capitalizationPreprocessors,
-	},
+    {
+        iso: 'gd',
+        iso639_3: 'gla',
+        name: 'Scottish Gaelic',
+        exampleText: 'leugh',
+        textPreprocessors: capitalizationPreprocessors,
+    },
     {
         iso: 'grc',
         iso639_3: 'grc',

--- a/types/ext/language-descriptors.d.ts
+++ b/types/ext/language-descriptors.d.ts
@@ -150,9 +150,9 @@ type AllTextProcessors = {
     ga: {
         pre: CapitalizationPreprocessors;
     };
-	gd: {
-		pre: CapitalizationPreprocessors;
-	};
+    gd: {
+        pre: CapitalizationPreprocessors;
+    };
     grc: {
         pre: CapitalizationPreprocessors & AlphabeticDiacriticsProcessor & {
             convertLatinToGreek: TextProcessor;


### PR DESCRIPTION
This change is intended to add basic support for Scottish Gaelic (gd, Gàidhlig) to Yomitan. I tested this on Firefox with the WTY dictionary and it works, properly handling things like lenition and verb conjugations.

If there's anything I need to add or change, please let me know.