### PR TITLE
[fix] Set `wty` dicts link to the /download section

### DIFF
--- a/ext/data/recommended-dictionaries.json
+++ b/ext/data/recommended-dictionaries.json
@@ -8,7 +8,7 @@
             {
                 "name": "wty-afb-en",
                 "description": "Gulf Arabic to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/afb/en/wty-afb-en.zip"
             }
         ]
@@ -21,7 +21,7 @@
             {
                 "name": "wty-aii-en-ipa",
                 "description": "Assyrian Neo-Aramaic IPA dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/aii/en/wty-aii-en-ipa.zip"
             }
         ],
@@ -29,7 +29,7 @@
             {
                 "name": "wty-aii-en",
                 "description": "Assyrian Neo-Aramaic to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/aii/en/wty-aii-en.zip"
             }
         ]
@@ -43,7 +43,7 @@
             {
                 "name": "wty-ajp-en",
                 "description": "South Levantine Arabic to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ajp/en/wty-ajp-en.zip"
             }
         ]
@@ -57,7 +57,7 @@
             {
                 "name": "wty-ang-en",
                 "description": "Old English to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ang/en/wty-ang-en.zip"
             }
         ]
@@ -71,7 +71,7 @@
             {
                 "name": "wty-apc-en",
                 "description": "North Levantine Arabic to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/apc/en/wty-apc-en.zip"
             }
         ]
@@ -84,7 +84,7 @@
             {
                 "name": "wty-ar-en-ipa",
                 "description": "Arabic IPA dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ar/en/wty-ar-en-ipa.zip"
             }
         ],
@@ -92,7 +92,7 @@
             {
                 "name": "wty-ar-en",
                 "description": "Arabic to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ar/en/wty-ar-en.zip"
             }
         ]
@@ -105,7 +105,7 @@
             {
                 "name": "wty-ar-en-ipa",
                 "description": "Arabic IPA dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/yomidevs/wiktionary-to-yomitan/blob/master/downloads.md",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ar/en/wty-ar-en-ipa.zip"
             }
         ],
@@ -113,7 +113,7 @@
             {
                 "name": "wty-ar-en",
                 "description": "Arabic to English dictionary created from Wiktionary data.",
-                "homepage": "https://github.com/yomidevs/wiktionary-to-yomitan/blob/master/downloads.md",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ar/en/wty-ar-en.zip"
             }
         ]
@@ -127,7 +127,7 @@
             {
                 "name": "wty-ast-en",
                 "description": "Asturian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ast/en/wty-ast-en.zip"
             }
         ]
@@ -141,7 +141,7 @@
             {
                 "name": "wty-az-en",
                 "description": "Azerbaijani to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/az/en/wty-az-en.zip"
             }
         ]
@@ -155,7 +155,7 @@
             {
                 "name": "wty-be-en",
                 "description": "Belarusian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/be/en/wty-be-en.zip"
             }
         ]
@@ -169,7 +169,7 @@
             {
                 "name": "wty-bg-en",
                 "description": "Bulgarian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/bg/en/wty-bg-en.zip"
             }
         ]
@@ -183,7 +183,7 @@
             {
                 "name": "wty-bn-en",
                 "description": "Bengali to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/bn/en/wty-bn-en.zip"
             }
         ]
@@ -197,7 +197,7 @@
             {
                 "name": "wty-ca-en",
                 "description": "Catalan to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ca/en/wty-ca-en.zip"
             }
         ]
@@ -211,7 +211,7 @@
             {
                 "name": "wty-ceb-en",
                 "description": "Cebuano to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ceb/en/wty-ceb-en.zip"
             }
         ]
@@ -225,7 +225,7 @@
             {
                 "name": "wty-cs-en",
                 "description": "Czech to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/cs/en/wty-cs-en.zip"
             }
         ]
@@ -239,7 +239,7 @@
             {
                 "name": "wty-cy-en",
                 "description": "Welsh to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/cy/en/wty-cy-en.zip"
             }
         ]
@@ -253,7 +253,7 @@
             {
                 "name": "wty-da-en",
                 "description": "Danish to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/da/en/wty-da-en.zip"
             }
         ]
@@ -267,7 +267,7 @@
             {
                 "name": "wty-de-en",
                 "description": "German to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/de/en/wty-de-en.zip"
             }
         ]
@@ -281,7 +281,7 @@
             {
                 "name": "wty-el-en",
                 "description": "Greek to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/el/en/wty-el-en.zip"
             }
         ]
@@ -295,7 +295,7 @@
             {
                 "name": "wty-en-en",
                 "description": "English to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/en/en/wty-en-en.zip"
             }
         ]
@@ -309,7 +309,7 @@
             {
                 "name": "wty-enm-en",
                 "description": "Middle English to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/enm/en/wty-enm-en.zip"
             }
         ]
@@ -323,7 +323,7 @@
             {
                 "name": "wty-eo-en",
                 "description": "Esperanto to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/eo/en/wty-eo-en.zip"
             }
         ]
@@ -337,7 +337,7 @@
             {
                 "name": "wty-es-en",
                 "description": "Spanish to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/es/en/wty-es-en.zip"
             }
         ]
@@ -351,7 +351,7 @@
             {
                 "name": "wty-et-en",
                 "description": "Estonian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/et/en/wty-et-en.zip"
             }
         ]
@@ -365,7 +365,7 @@
             {
                 "name": "wty-eu-en",
                 "description": "Basque to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/eu/en/wty-eu-en.zip"
             }
         ]
@@ -379,7 +379,7 @@
             {
                 "name": "wty-fa-en",
                 "description": "Persian  to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/fa/en/wty-fa-en.zip"
             }
         ]
@@ -393,7 +393,7 @@
             {
                 "name": "wty-fi-en",
                 "description": "Finnish to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/fi/en/wty-fi-en.zip"
             }
         ]
@@ -407,7 +407,7 @@
             {
                 "name": "wty-fr-en",
                 "description": "French to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/fr/en/wty-fr-en.zip"
             }
         ]
@@ -421,7 +421,7 @@
             {
                 "name": "wty-ga-en",
                 "description": "Irish to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ga/en/wty-ga-en.zip"
             }
         ]
@@ -435,7 +435,7 @@
             {
                 "name": "wty-gd-en",
                 "description": "Scottish Gaelic to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/gd/en/wty-gd-en.zip"
             }
         ]
@@ -449,7 +449,7 @@
             {
                 "name": "wty-gl-en",
                 "description": "Galician to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/gl/en/wty-gl-en.zip"
             }
         ]
@@ -463,7 +463,7 @@
             {
                 "name": "wty-got-en",
                 "description": "Gothic to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/got/en/wty-got-en.zip"
             }
         ]
@@ -477,7 +477,7 @@
             {
                 "name": "wty-grc-en",
                 "description": "Ancient Greek to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/grc/en/wty-grc-en.zip"
             }
         ]
@@ -517,7 +517,7 @@
             {
                 "name": "wty-he-en",
                 "description": "Hebrew to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/he/en/wty-he-en.zip"
             }
         ]
@@ -531,7 +531,7 @@
             {
                 "name": "wty-hi-en",
                 "description": "Hindi to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/hi/en/wty-hi-en.zip"
             }
         ]
@@ -545,7 +545,7 @@
             {
                 "name": "wty-hu-en",
                 "description": "Hungarian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/hu/en/wty-hu-en.zip"
             }
         ]
@@ -559,7 +559,7 @@
             {
                 "name": "wty-hy-en",
                 "description": "Armenian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/hy/en/wty-hy-en.zip"
             }
         ]
@@ -573,7 +573,7 @@
             {
                 "name": "wty-id-en",
                 "description": "Indonesian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/id/en/wty-id-en.zip"
             }
         ]
@@ -587,7 +587,7 @@
             {
                 "name": "wty-io-en",
                 "description": "Ido to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/io/en/wty-io-en.zip"
             }
         ]
@@ -601,7 +601,7 @@
             {
                 "name": "wty-is-en",
                 "description": "Icelandic to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/is/en/wty-is-en.zip"
             }
         ]
@@ -615,7 +615,7 @@
             {
                 "name": "wty-it-en",
                 "description": "Italian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/it/en/wty-it-en.zip"
             }
         ]
@@ -675,7 +675,7 @@
             {
                 "name": "wty-ka-en",
                 "description": "Georgian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ka/en/wty-ka-en.zip"
             }
         ]
@@ -689,7 +689,7 @@
             {
                 "name": "wty-kk-en",
                 "description": "Kazakh to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/kk/en/wty-kk-en.zip"
             }
         ]
@@ -703,7 +703,7 @@
             {
                 "name": "wty-km-en",
                 "description": "Khmer to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/km/en/wty-km-en.zip"
             }
         ]
@@ -717,7 +717,7 @@
             {
                 "name": "wty-kn-en",
                 "description": "Kannada to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/kn/en/wty-kn-en.zip"
             }
         ]
@@ -731,7 +731,7 @@
             {
                 "name": "wty-ko-en",
                 "description": "Korean to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ko/en/wty-ko-en.zip"
             }
         ]
@@ -745,7 +745,7 @@
             {
                 "name": "wty-ku-en",
                 "description": "Kurdish to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ku/en/wty-ku-en.zip"
             }
         ]
@@ -759,7 +759,7 @@
             {
                 "name": "wty-la-en",
                 "description": "Latin to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/la/en/wty-la-en.zip"
             }
         ]
@@ -773,7 +773,7 @@
             {
                 "name": "wty-lo-en",
                 "description": "Lao to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/lo/en/wty-lo-en.zip"
             }
         ]
@@ -787,7 +787,7 @@
             {
                 "name": "wty-lt-en",
                 "description": "Lithuanian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/lt/en/wty-lt-en.zip"
             }
         ]
@@ -801,7 +801,7 @@
             {
                 "name": "wty-lv-en",
                 "description": "Latvian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/lv/en/wty-lv-en.zip"
             }
         ]
@@ -815,7 +815,7 @@
             {
                 "name": "wty-mk-en",
                 "description": "Macedonian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/mk/en/wty-mk-en.zip"
             }
         ]
@@ -829,7 +829,7 @@
             {
                 "name": "wty-ml-en",
                 "description": "Malayalam to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ml/en/wty-ml-en.zip"
             }
         ]
@@ -843,7 +843,7 @@
             {
                 "name": "wty-mn-en",
                 "description": "Mongolian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/mn/en/wty-mn-en.zip"
             }
         ]
@@ -857,7 +857,7 @@
             {
                 "name": "wty-mr-en",
                 "description": "Marathi to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/mr/en/wty-mr-en.zip"
             }
         ]
@@ -871,7 +871,7 @@
             {
                 "name": "wty-ms-en",
                 "description": "Malay to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ms/en/wty-ms-en.zip"
             }
         ]
@@ -884,7 +884,7 @@
             {
                 "name": "wty-mt-en-ipa",
                 "description": "Maltese IPA dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/mt/en/wty-mt-en-ipa.zip"
             }
         ],
@@ -892,7 +892,7 @@
             {
                 "name": "wty-mt-en",
                 "description": "Maltese to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/mt/en/wty-mt-en.zip"
             }
         ]
@@ -906,7 +906,7 @@
             {
                 "name": "wty-my-en",
                 "description": "Burmese to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/my/en/wty-my-en.zip"
             }
         ]
@@ -920,7 +920,7 @@
             {
                 "name": "wty-nb-en",
                 "description": "Norwegian Bokmål to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/nb/en/wty-nb-en.zip"
             }
         ]
@@ -934,7 +934,7 @@
             {
                 "name": "wty-nl-en",
                 "description": "Dutch to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/nl/en/wty-nl-en.zip"
             }
         ]
@@ -948,7 +948,7 @@
             {
                 "name": "wty-nn-en",
                 "description": "Norwegian Nynorsk to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/nn/en/wty-nn-en.zip"
             }
         ]
@@ -962,13 +962,13 @@
             {
                 "name": "wty-nb-en",
                 "description": "Norwegian Bokmål to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/nb/en/wty-nb-en.zip"
             },
             {
                 "name": "wty-nn-en",
                 "description": "Norwegian Nynorsk to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/nn/en/wty-nn-en.zip"
             }
         ]
@@ -982,7 +982,7 @@
             {
                 "name": "wty-non-en",
                 "description": "Old Norse to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/non/en/wty-non-en.zip"
             }
         ]
@@ -996,7 +996,7 @@
             {
                 "name": "wty-nv-en",
                 "description": "Navajo to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/nv/en/wty-nv-en.zip"
             }
         ]
@@ -1010,7 +1010,7 @@
             {
                 "name": "wty-ota-en",
                 "description": "Ottoman Turkish to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ota/en/wty-ota-en.zip"
             }
         ]
@@ -1024,7 +1024,7 @@
             {
                 "name": "wty-pa-en",
                 "description": "Punjabi to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/pa/en/wty-pa-en.zip"
             }
         ]
@@ -1038,7 +1038,7 @@
             {
                 "name": "wty-pi-en",
                 "description": "Pali to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/pi/en/wty-pi-en.zip"
             }
         ]
@@ -1052,7 +1052,7 @@
             {
                 "name": "wty-pl-en",
                 "description": "Polish to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/pl/en/wty-pl-en.zip"
             }
         ]
@@ -1066,7 +1066,7 @@
             {
                 "name": "wty-pt-en",
                 "description": "Portuguese to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/pt/en/wty-pt-en.zip"
             }
         ]
@@ -1080,7 +1080,7 @@
             {
                 "name": "wty-ro-en",
                 "description": "Romanian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ro/en/wty-ro-en.zip"
             }
         ]
@@ -1094,7 +1094,7 @@
             {
                 "name": "wty-ru-en",
                 "description": "Russian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ru/en/wty-ru-en.zip"
             },
             {
@@ -1114,7 +1114,7 @@
             {
                 "name": "wty-sa-en",
                 "description": "Sanskrit to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/sa/en/wty-sa-en.zip"
             }
         ]
@@ -1128,7 +1128,7 @@
             {
                 "name": "wty-scn-en",
                 "description": "Sicillian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/scn/en/wty-scn-en.zip"
             }
         ]
@@ -1142,7 +1142,7 @@
             {
                 "name": "wty-sga-en",
                 "description": "Old Irish to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/sga/en/wty-sga-en.zip"
             }
         ]
@@ -1156,7 +1156,7 @@
             {
                 "name": "wty-sh-en",
                 "description": "Serbo-Croatian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/sh/en/wty-sh-en.zip"
             }
         ]
@@ -1170,7 +1170,7 @@
             {
                 "name": "wty-sk-en",
                 "description": "Slovak to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/sk/en/wty-sk-en.zip"
             }
         ]
@@ -1184,7 +1184,7 @@
             {
                 "name": "wty-sl-en",
                 "description": "Slovene to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/sl/en/wty-sl-en.zip"
             }
         ]
@@ -1198,7 +1198,7 @@
             {
                 "name": "wty-sq-en",
                 "description": "Albanian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/sq/en/wty-sq-en.zip"
             }
         ]
@@ -1212,7 +1212,7 @@
             {
                 "name": "wty-sv-en",
                 "description": "Swedish to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/sv/en/wty-sv-en.zip"
             }
         ]
@@ -1226,7 +1226,7 @@
             {
                 "name": "wty-sw-en",
                 "description": "Swahili to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/sw/en/wty-sw-en.zip"
             }
         ]
@@ -1240,7 +1240,7 @@
             {
                 "name": "wty-ta-en",
                 "description": "Tamil to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ta/en/wty-ta-en.zip"
             }
         ]
@@ -1254,7 +1254,7 @@
             {
                 "name": "wty-te-en",
                 "description": "Telugu to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/te/en/wty-te-en.zip"
             }
         ]
@@ -1268,7 +1268,7 @@
             {
                 "name": "wty-th-en",
                 "description": "Thai to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/th/en/wty-th-en.zip"
             }
         ]
@@ -1282,7 +1282,7 @@
             {
                 "name": "wty-tl-en",
                 "description": "Tagalog to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/tl/en/wty-tl-en.zip"
             }
         ]
@@ -1394,7 +1394,7 @@
             {
                 "name": "wty-tr-en",
                 "description": "Turkish to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/tr/en/wty-tr-en.zip"
             }
         ]
@@ -1408,7 +1408,7 @@
             {
                 "name": "wty-uk-en",
                 "description": "Ukranian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/uk/en/wty-uk-en.zip"
             }
         ]
@@ -1422,7 +1422,7 @@
             {
                 "name": "wty-ur-en",
                 "description": "Urdu to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ur/en/wty-ur-en.zip"
             }
         ]
@@ -1436,7 +1436,7 @@
             {
                 "name": "wty-vi-en",
                 "description": "Vietnamese to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/vi/en/wty-vi-en.zip"
             }
         ]
@@ -1450,7 +1450,7 @@
             {
                 "name": "wty-xcl-en",
                 "description": "Old Armenian to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/xcl/en/wty-xcl-en.zip"
             }
         ]
@@ -1464,7 +1464,7 @@
             {
                 "name": "wty-yi-en",
                 "description": "Yiddish to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/yi/en/wty-yi-en.zip"
             }
         ]
@@ -1537,7 +1537,7 @@
             {
                 "name": "wty-zh-en",
                 "description": "Chinese to English dictionary created from Wiktionary data.",
-                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/",
+                "homepage": "https://yomidevs.github.io/wiktionary-to-yomitan/download/",
                 "downloadUrl": "https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/zh/en/wty-zh-en.zip"
             }
         ]

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -302,7 +302,7 @@
         <div class="modal-body">
             <p>
                 For non-English dictionaries, please refer to the list of available
-                <a href="https://yomidevs.github.io/wiktionary-to-yomitan/" target="_blank"> Wiktionary dictionaries</a>.
+                <a href="https://yomidevs.github.io/wiktionary-to-yomitan/download/" target="_blank"> Wiktionary dictionaries</a>.
             </p>
             <div id="recommended-term-dictionaries" hidden>
                 <h1 class="modal-title">Term Dictionaries</h1>


### PR DESCRIPTION
Title.

The download section makes more sense in this context. The main page is (was?, still WIP) intended for people reaching the repo before knowing what yomitan is (if there are such people), and for people wanting a general overview of the project.

https://yomidevs.github.io/wiktionary-to-yomitan/
https://yomidevs.github.io/wiktionary-to-yomitan/download/