### PR TITLE
Hash media names instead of using date when sending to Anki

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -27,8 +27,8 @@ import {fetchText} from '../core/fetch-utilities.js';
 import {logErrorLevelToNumber} from '../core/log-utilities.js';
 import {log} from '../core/log.js';
 import {isObjectNotArray} from '../core/object-utilities.js';
-import {clone, deferPromise, promiseTimeout, unsafeArrayBufferDigest} from '../core/utilities.js';
-import {generateAnkiNoteMediaFileName, INVALID_NOTE_ID, isNoteDataValid} from '../data/anki-util.js';
+import {clone, deferPromise, promiseTimeout} from '../core/utilities.js';
+import {generateAnkiNoteMediaFileName, INVALID_NOTE_ID, isNoteDataValid, mediaFileNameHashOrTimestamp} from '../data/anki-util.js';
 import {arrayBufferToBase64} from '../data/array-buffer-util.js';
 import {OptionsUtil} from '../data/options-util.js';
 import {getAllPermissions, hasPermissions, hasRequiredPermissionsForOptions} from '../data/permissions-util.js';
@@ -2564,23 +2564,7 @@ export class Backend {
             if (media !== null) {
                 const {content, mediaType} = media;
                 const extension = getFileExtensionFromImageMediaType(mediaType);
-                try {
-                    // @ts-expect-error - typescript-eslint does not recognize `Uint8Array.fromBase64` yet despite it already being available on all major browsers for over 6 months
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    const contentHash = await unsafeArrayBufferDigest('SHA-1', Uint8Array.fromBase64(content));
-                    fileName = generateAnkiNoteMediaFileName(
-                        'yomitan_dictionary_media_',
-                        extension !== null ? extension : '',
-                        contentHash,
-                    );
-                } catch {
-                    // fallback on using timestamp for older browser versions
-                    fileName = generateAnkiNoteMediaFileName(
-                        `yomitan_dictionary_media_${i + 1}`,
-                        extension !== null ? extension : '',
-                        timestamp,
-                    );
-                }
+                fileName = await mediaFileNameHashOrTimestamp(content, extension, i, timestamp);
                 try {
                     fileName = await ankiConnect.storeMediaFile(fileName, content);
                 } catch (e) {

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -27,7 +27,7 @@ import {fetchText} from '../core/fetch-utilities.js';
 import {logErrorLevelToNumber} from '../core/log-utilities.js';
 import {log} from '../core/log.js';
 import {isObjectNotArray} from '../core/object-utilities.js';
-import {clone, deferPromise, promiseTimeout} from '../core/utilities.js';
+import {clone, deferPromise, promiseTimeout, unsafeArrayBufferDigest} from '../core/utilities.js';
 import {generateAnkiNoteMediaFileName, INVALID_NOTE_ID, isNoteDataValid} from '../data/anki-util.js';
 import {arrayBufferToBase64} from '../data/array-buffer-util.js';
 import {OptionsUtil} from '../data/options-util.js';
@@ -2564,11 +2564,23 @@ export class Backend {
             if (media !== null) {
                 const {content, mediaType} = media;
                 const extension = getFileExtensionFromImageMediaType(mediaType);
-                fileName = generateAnkiNoteMediaFileName(
-                    `yomitan_dictionary_media_${i + 1}`,
-                    extension !== null ? extension : '',
-                    timestamp,
-                );
+                try {
+                    // @ts-expect-error - typescript-eslint does not recognize `Uint8Array.fromBase64` yet despite it already being available on all major browsers for over 6 months
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                    const contentHash = await unsafeArrayBufferDigest('SHA-1', Uint8Array.fromBase64(content));
+                    fileName = generateAnkiNoteMediaFileName(
+                        'yomitan_dictionary_media_',
+                        extension !== null ? extension : '',
+                        contentHash,
+                    );
+                } catch {
+                    // fallback on using timestamp for older browser versions
+                    fileName = generateAnkiNoteMediaFileName(
+                        `yomitan_dictionary_media_${i + 1}`,
+                        extension !== null ? extension : '',
+                        timestamp,
+                    );
+                }
                 try {
                     fileName = await ankiConnect.storeMediaFile(fileName, content);
                 } catch (e) {

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -2564,7 +2564,7 @@ export class Backend {
             if (media !== null) {
                 const {content, mediaType} = media;
                 const extension = getFileExtensionFromImageMediaType(mediaType);
-                fileName = await mediaFileNameHashOrTimestamp(content, extension, i, timestamp);
+                fileName = await mediaFileNameHashOrTimestamp('yomitan_dictionary_media', content, extension, i, timestamp);
                 try {
                     fileName = await ankiConnect.storeMediaFile(fileName, content);
                 } catch (e) {

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -2470,7 +2470,7 @@ export class Backend {
 
         let extension = contentType !== null ? getFileExtensionFromAudioMediaType(contentType) : null;
         if (extension === null) { extension = '.mp3'; }
-        let fileName = generateAnkiNoteMediaFileName('yomitan_audio', extension, timestamp);
+        let fileName = await mediaFileNameHashOrTimestamp('yomitan_audio', data, extension, null, timestamp);
         fileName = fileName.replace(/\]/g, '');
         return await ankiConnect.storeMediaFile(fileName, data);
     }

--- a/ext/js/comm/yomitan-api.js
+++ b/ext/js/comm/yomitan-api.js
@@ -26,7 +26,7 @@ import {log} from '../core/log.js';
 import {toError} from '../core/to-error.js';
 import {createFuriganaHtml, createFuriganaPlain} from '../data/anki-note-builder.js';
 import {getDynamicTemplates} from '../data/anki-template-util.js';
-import {generateAnkiNoteMediaFileName} from '../data/anki-util.js';
+import {mediaFileNameHashOrTimestamp} from '../data/anki-util.js';
 import {getLanguageSummaries} from '../language/languages.js';
 import {AudioDownloader} from '../media/audio-downloader.js';
 import {getFileExtensionFromAudioMediaType, getFileExtensionFromImageMediaType} from '../media/media-util.js';
@@ -335,7 +335,7 @@ export class YomitanApi {
             for (const mediaFileData of mediaFilesData) {
                 if (media.some((x) => x.dictionary === mediaFileData.dictionary && x.path === mediaFileData.path)) { continue; }
                 const timestamp = Date.now();
-                const ankiFilename = generateAnkiNoteMediaFileName(`yomitan_dictionary_media_${mediaCount}`, getFileExtensionFromImageMediaType(mediaFileData.mediaType) ?? '', timestamp);
+                const ankiFilename = await mediaFileNameHashOrTimestamp('yomitan_dictionary_media', mediaFileData.content, getFileExtensionFromImageMediaType(mediaFileData.mediaType) ?? '', mediaCount, timestamp);
                 media.push({
                     dictionary: mediaFileData.dictionary,
                     path: mediaFileData.path,
@@ -371,7 +371,7 @@ export class YomitanApi {
                 const mediaType = audioData.contentType ?? '';
                 let extension = mediaType !== null ? getFileExtensionFromAudioMediaType(mediaType) : null;
                 if (extension === null) { extension = '.mp3'; }
-                const ankiFilename = generateAnkiNoteMediaFileName('yomitan_audio', extension, timestamp);
+                const ankiFilename = await mediaFileNameHashOrTimestamp('yomitan_audio', audioData.data, extension, null, timestamp);
                 audioDatas.push({
                     term: headword.term,
                     reading: headword.reading,

--- a/ext/js/core/utilities.js
+++ b/ext/js/core/utilities.js
@@ -320,3 +320,27 @@ export function addScopeToCssLegacy(css, scopeSelector) {
         return addScopeToCss(css, scopeSelector);
     }
 }
+
+/**
+ * @param {'SHA-256'|'SHA-384'|'SHA-512'} algorithm
+ * @param {ArrayBuffer} arrayBuffer
+ * @returns {Promise<string>}
+ */
+export async function arrayBufferDigest(algorithm, arrayBuffer) {
+    const hash = new Uint8Array(await crypto.subtle.digest(algorithm, new Uint8Array(arrayBuffer)));
+    let digest = '';
+    for (const byte of hash) {
+        digest += byte.toString(16).padStart(2, '0');
+    }
+    return digest;
+}
+
+/**
+ * @param {'SHA-1'|'SHA-256'|'SHA-384'|'SHA-512'} algorithm
+ * @param {ArrayBuffer} arrayBuffer
+ * @returns {Promise<string>}
+ */
+export async function unsafeArrayBufferDigest(algorithm, arrayBuffer) {
+    // @ts-expect-error - Allow SHA-1 here
+    return arrayBufferDigest(algorithm, arrayBuffer);
+}

--- a/ext/js/data/anki-util.js
+++ b/ext/js/data/anki-util.js
@@ -17,6 +17,7 @@
  */
 
 import {isObjectNotArray} from '../core/object-utilities.js';
+import {unsafeArrayBufferDigest} from '../core/utilities.js';
 
 /** @type {RegExp} @readonly */
 const markerPattern = /\{([\p{Letter}\p{Number}_-]+)\}/gu;
@@ -101,6 +102,34 @@ export function generateAnkiNoteMediaFileName(prefix, extension, suffix) {
     fileName = replaceInvalidFileNameCharacters(fileName);
 
     return fileName;
+}
+
+/**
+ * @param {string} content
+ * @param {string?} extension
+ * @param {number} mediaCount
+ * @param {number} timestamp
+ * @returns {Promise<string>}
+ */
+export async function mediaFileNameHashOrTimestamp(content, extension, mediaCount, timestamp) {
+    try {
+        /** @type {string} */
+        // @ts-expect-error - typescript-eslint does not recognize `Uint8Array.fromBase64` yet despite it already being available on all major browsers for over 6 months
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        const contentHash = await unsafeArrayBufferDigest('SHA-1', Uint8Array.fromBase64(content));
+        return generateAnkiNoteMediaFileName(
+            'yomitan_dictionary_media_',
+                            extension !== null ? extension : '',
+                            contentHash,
+        );
+    } catch {
+        // fallback on using timestamp for older browser versions
+        return generateAnkiNoteMediaFileName(
+            `yomitan_dictionary_media_${mediaCount + 1}`,
+                            extension !== null ? extension : '',
+                            timestamp,
+        );
+    }
 }
 
 /**

--- a/ext/js/data/anki-util.js
+++ b/ext/js/data/anki-util.js
@@ -89,13 +89,13 @@ export const INVALID_NOTE_ID = -1;
 /**
  * @param {string} prefix
  * @param {string} extension
- * @param {number} timestamp
+ * @param {number|string} suffix
  * @returns {string}
  */
-export function generateAnkiNoteMediaFileName(prefix, extension, timestamp) {
+export function generateAnkiNoteMediaFileName(prefix, extension, suffix) {
     let fileName = prefix;
 
-    fileName += `_${ankNoteDateToString(new Date(timestamp))}`;
+    fileName += typeof suffix === 'string' ? suffix : `_${ankNoteDateToString(new Date(suffix))}`;
     fileName += extension;
 
     fileName = replaceInvalidFileNameCharacters(fileName);

--- a/ext/js/data/anki-util.js
+++ b/ext/js/data/anki-util.js
@@ -105,30 +105,24 @@ export function generateAnkiNoteMediaFileName(prefix, extension, suffix) {
 }
 
 /**
+ * @param {string} prefix
  * @param {string} content
  * @param {string?} extension
- * @param {number} mediaCount
+ * @param {number?} mediaCount
  * @param {number} timestamp
  * @returns {Promise<string>}
  */
-export async function mediaFileNameHashOrTimestamp(content, extension, mediaCount, timestamp) {
+export async function mediaFileNameHashOrTimestamp(prefix, content, extension, mediaCount, timestamp) {
     try {
         /** @type {string} */
         // @ts-expect-error - typescript-eslint does not recognize `Uint8Array.fromBase64` yet despite it already being available on all major browsers for over 6 months
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         const contentHash = await unsafeArrayBufferDigest('SHA-1', Uint8Array.fromBase64(content));
-        return generateAnkiNoteMediaFileName(
-            'yomitan_dictionary_media_',
-                            extension !== null ? extension : '',
-                            contentHash,
-        );
+        return generateAnkiNoteMediaFileName(`${prefix}_`, extension !== null ? extension : '', contentHash);
     } catch {
+        const mediaCountInfix = mediaCount ? mediaCount + 1 : '';
         // fallback on using timestamp for older browser versions
-        return generateAnkiNoteMediaFileName(
-            `yomitan_dictionary_media_${mediaCount + 1}`,
-                            extension !== null ? extension : '',
-                            timestamp,
-        );
+        return generateAnkiNoteMediaFileName(`${prefix}_${mediaCountInfix}`, extension !== null ? extension : '', timestamp);
     }
 }
 

--- a/ext/js/media/audio-downloader.js
+++ b/ext/js/media/audio-downloader.js
@@ -19,6 +19,7 @@
 import {RequestBuilder} from '../background/request-builder.js';
 import {ExtensionError} from '../core/extension-error.js';
 import {readResponseJson} from '../core/json.js';
+import {arrayBufferDigest} from '../core/utilities.js';
 import {arrayBufferToBase64} from '../data/array-buffer-util.js';
 import {JsonSchema} from '../data/json-schema.js';
 import {NativeSimpleDOMParser} from '../dom/native-simple-dom-parser.js';
@@ -559,7 +560,7 @@ export class AudioDownloader {
         switch (sourceType) {
             case 'jpod101':
             {
-                const digest = await this._arrayBufferDigest(arrayBuffer);
+                const digest = await arrayBufferDigest('SHA-256', arrayBuffer);
                 switch (digest) {
                     case 'ae6398b5a27bc8c0a771df6c907ade794be15518174773c58c7c7ddd17098906': // Invalid audio
                         return false;
@@ -570,19 +571,6 @@ export class AudioDownloader {
             default:
                 return true;
         }
-    }
-
-    /**
-     * @param {ArrayBuffer} arrayBuffer
-     * @returns {Promise<string>}
-     */
-    async _arrayBufferDigest(arrayBuffer) {
-        const hash = new Uint8Array(await crypto.subtle.digest('SHA-256', new Uint8Array(arrayBuffer)));
-        let digest = '';
-        for (const byte of hash) {
-            digest += byte.toString(16).padStart(2, '0');
-        }
-        return digest;
     }
 
     /**


### PR DESCRIPTION
Using sha1 here because it's a lot faster than sha256 and there's no need to worry about sha1 having a collision in this case. Though sha1 is technically broken, the chance of a collision is `1/2*n^2/2^160` where n is the number of unique things youre hashing. Collisions only become somewhat likely once you hash about 1,000,000,000,000,000,000,000,000 things.

Fallback only because theres a 100% chance someone is going to complain about this breaking on some ancient version of kiwi or that one dude using firefox esr on debian that hasnt updated in ages.

Leaving the clipboard and screenshot media to not use a hash. There's no point in having those use this.

Brought up in discord, this is kindof a mess for dicts with repetitive content: 
<img width="988" height="1172" alt="image" src="https://github.com/user-attachments/assets/2e53b1df-f97f-4a71-8b7b-3c08e04167c7" />
