### PR TITLE
Add `frequencyMode` and `prefixWildcardsSupported` to dictionary details

### DIFF
--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -356,6 +356,8 @@ class DictionaryEntry {
             kanjiMeta: 'Kanji Meta Count',
             tagMeta: 'Tag Count',
             media: 'Media Count',
+            frequencyMode: 'Frequency Mode',
+            prefixWildcardsSupported: 'Prefix Wildcards Enabled',
             importSuccess: 'Import Success',
         };
 


### PR DESCRIPTION
Rather silly to not have these here. And `frequencyMode` will be especially relevant with #2373 getting pulled in.

These only display on dicts that actually set them. How it looks:

<img width="586" height="396" alt="image" src="https://github.com/user-attachments/assets/bd4a2b73-798f-476d-bc31-bb1c8b609f8d" />
