### PR TITLE
Cleanup await-thenable complaints

### DIFF
--- a/ext/js/data/anki-note-builder.js
+++ b/ext/js/data/anki-note-builder.js
@@ -269,6 +269,7 @@ export class AnkiNoteBuilder {
             return str;
         }
         parts.push(str.substring(index));
+        // eslint-disable-next-line @typescript-eslint/await-thenable
         return (await Promise.all(parts)).join('');
     }
 

--- a/ext/js/pages/welcome-main.js
+++ b/ext/js/pages/welcome-main.js
@@ -96,7 +96,7 @@ await Application.main(true, async (application) => {
     preparePromises.push(dictionaryController.prepare());
 
     const dictionaryImportController = new DictionaryImportController(settingsController, modalController, statusFooter);
-    preparePromises.push(dictionaryImportController.prepare());
+    dictionaryImportController.prepare();
 
     const simpleScanningInputController = new ScanInputsSimpleController(settingsController);
     preparePromises.push(simpleScanningInputController.prepare());


### PR DESCRIPTION
eslint doesn't like us doing this anymore

In the `dictionaryImportController` case it's simple enough. But in the `_stringReplaceAsync` case it's quite a pain so I've just set it to ignore. It doesn't break anything to await when you don't need to await in JS so we're fine there.