### PR TITLE
Log `_getElementsFromPoint` errors as log not error

### DIFF
--- a/ext/js/dom/text-source-generator.js
+++ b/ext/js/dom/text-source-generator.js
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import {log} from '../core/log.js';
 import {computeZoomScale, isPointInAnyRect} from './document-util.js';
 import {DOMTextScanner} from './dom-text-scanner.js';
 import {TextSourceElement} from './text-source-element.js';
@@ -335,14 +336,19 @@ export class TextSourceGenerator {
      * @returns {Element[]}
      */
     _getElementsFromPoint(x, y, all) {
-        if (all) {
-            // document.elementsFromPoint can return duplicates which must be removed.
-            const elements = document.elementsFromPoint(x, y);
-            return elements.filter((e, i) => elements.indexOf(e) === i);
-        }
+        try {
+            if (all) {
+                // document.elementsFromPoint can return duplicates which must be removed.
+                const elements = document.elementsFromPoint(x, y);
+                return elements.filter((e, i) => elements.indexOf(e) === i);
+            }
 
-        const e = document.elementFromPoint(x, y);
-        return e !== null ? [e] : [];
+            const e = document.elementFromPoint(x, y);
+            return e !== null ? [e] : [];
+        } catch (e) {
+            log.logGenericError(e, 'log');
+            return [];
+        }
     }
 
     /**


### PR DESCRIPTION
Can end up "randomly" throwing when pages do weird stuff. It's an unrecoverable state when this happens (`_getElementsFromPoint` will never find anything) and also useless to tell the user about. This shouldn't be breaking the user's scanning, just a specific placement of the mouse somewhere didn't work.

ex:
```
TypeError: Document.elementFromPoint: Argument 1 is not a finite floating-point value.
_getElementsFromPoint@moz-extension://81ada2fa-2825-4f35-8461-3c0826e9d8e7/js/dom/text-source-generator.js:344:28
_getRangeFromPointInternal@moz-extension://81ada2fa-2825-4f35-8461-3c0826e9d8e7/js/dom/text-source-generator.js:192:31
getRangeFromPoint@moz-extension://81ada2fa-2825-4f35-8461-3c0826e9d8e7/js/dom/text-source-generator.js:42:21
_searchAt@moz-extension://81ada2fa-2825-4f35-8461-3c0826e9d8e7/js/language/text-scanner.js:1341:58
```

Reported on discord. I've been seeing this occasionally too but never bothered to track it down.