### PR TITLE
Added option to adjust position of popup when full-width was enabled

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -88,6 +88,7 @@
                                     "showAdvanced",
                                     "showDebug",
                                     "popupDisplayMode",
+                                    "popupFullWidthPosition",
                                     "popupWidth",
                                     "popupHeight",
                                     "popupHorizontalOffset",
@@ -179,6 +180,11 @@
                                         "type": "string",
                                         "enum": ["default", "full-width"],
                                         "default": "default"
+                                    },
+                                    "popupFullWidthPosition": {
+                                        "type": "string",
+                                        "enum": ["top", "above-cursor", "bottom"],
+                                        "default": "bottom"
                                     },
                                     "popupWidth": {
                                         "type": "number",

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -714,8 +714,10 @@ export class Popup extends EventDispatcher {
             width = viewport.right - viewport.left;
             if (this._fullWidthPosition === 'top') {
                 top = viewport.top;
+                below = false;
             } else if (this._fullWidthPosition !== 'above-cursor') {
                 top = viewport.bottom - height;
+                below = true;
             }
         }
 

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -712,16 +712,10 @@ export class Popup extends EventDispatcher {
         if (this._displayModeIsFullWidth) {
             left = viewport.left;
             width = viewport.right - viewport.left;
-            switch (this._fullWidthPosition) {
-                case 'top':
-                    top = viewport.top;
-                    break;
-                case 'above-cursor':
-                    break;
-                case 'bottom':
-                default:
-                    top = viewport.bottom - height;
-                    break;
+            if (this._fullWidthPosition === 'top') {
+                top = viewport.top;
+            } else if (this._fullWidthPosition !== 'above-cursor') {
+                top = viewport.bottom - height;
             }
         }
 

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -712,12 +712,25 @@ export class Popup extends EventDispatcher {
         if (this._displayModeIsFullWidth) {
             left = viewport.left;
             width = viewport.right - viewport.left;
-            if (this._fullWidthPosition === 'top') {
-                top = viewport.top;
-                below = false;
-            } else if (this._fullWidthPosition !== 'above-cursor') {
-                top = viewport.bottom - height;
-                below = true;
+
+            const sourceRect = this._getBoundingSourceRect(this._convertSourceRectsCoordinateSpace(sourceRects));
+            const overflowAbove = (sourceRect.top - height) < viewport.top;
+            const overflowBelow = (sourceRect.bottom + height) > viewport.bottom;
+
+            switch (this._fullWidthPosition) {
+                case 'top':
+                    // Default to top, unless there is overflow, then set to bottom.
+                    top = overflowAbove ? viewport.bottom - height : viewport.top;
+                    below = overflowAbove;
+                    break;
+                case 'bottom':
+                    // Default to bottom, unless there is overflow below, then move to top.
+                    top = overflowBelow ? viewport.top : viewport.bottom - height;
+                    // If overflowBelow, remove top border, otherwise remove bottom.
+                    below = !overflowBelow;
+                    break;
+                case 'above-cursor':
+                    break;
             }
         }
 

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -93,6 +93,8 @@ export class Popup extends EventDispatcher {
         this._displayMode = 'default';
         /** @type {boolean} */
         this._displayModeIsFullWidth = false;
+        /** @type {import('settings').PopupFullWidthPosition} */
+        this._fullWidthPosition = 'bottom';
         /** @type {boolean} */
         this._scaleRelativeToVisualViewport = true;
         /** @type {boolean} */
@@ -709,8 +711,18 @@ export class Popup extends EventDispatcher {
 
         if (this._displayModeIsFullWidth) {
             left = viewport.left;
-            top = below ? viewport.bottom - height : viewport.top;
             width = viewport.right - viewport.left;
+            switch (this._fullWidthPosition) {
+                case 'top':
+                    top = viewport.top;
+                    break;
+                case 'above-cursor':
+                    break;
+                case 'bottom':
+                default:
+                    top = viewport.bottom - height;
+                    break;
+            }
         }
 
         const frame = this._frame;
@@ -1124,6 +1136,7 @@ export class Popup extends EventDispatcher {
         this._horizontalTextPositionBelow = (general.popupHorizontalTextPosition === 'below');
         this._displayMode = general.popupDisplayMode;
         this._displayModeIsFullWidth = (this._displayMode === 'full-width');
+        this._fullWidthPosition = general.popupFullWidthPosition;
         this._scaleRelativeToVisualViewport = general.popupScaleRelativeToVisualViewport;
         this._useSecureFrameUrl = general.useSecurePopupFrameUrl;
         this._useShadowDom = general.usePopupShadowDom;

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -587,6 +587,7 @@ export class OptionsUtil {
             this._updateVersion73,
             this._updateVersion74,
             this._updateVersion75,
+            this._updateVersion76,
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1838,6 +1839,16 @@ export class OptionsUtil {
      */
     async _updateVersion75(options) {
         await this._applyAnkiFieldTemplatesPatch(options, '/data/templates/anki-field-templates-upgrade-v75.handlebars');
+    }
+
+    /**
+     * - Added general.popupFullWidthPosition.
+     * @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion76(options) {
+        for (const profile of options.profiles) {
+            profile.options.general.popupFullWidthPosition = 'bottom';
+        }
     }
 
     /**

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1268,7 +1268,7 @@
                     <div class="settings-item-right">
                         <select data-setting="general.popupFullWidthPosition">
                             <option value="top">Top</option>
-                            <option value="above-cursor">Above cursor</option>
+                            <option value="above-cursor">Follow Cursor</option>
                             <option value="bottom">Bottom</option>
                         </select>
                     </div>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1237,7 +1237,13 @@
                     </div>
                 </div>
                 <div class="settings-item-right">
-                    <select data-setting="general.popupDisplayMode">
+                    <select data-setting="general.popupDisplayMode"
+                        data-transform='{
+                            "type": "setVisibility",
+                            "selector": "#full-width-position-options",
+                            "condition": {"op": "===", "value": "full-width"}
+                        }'
+                    >
                         <option value="default">Default</option>
                         <option value="full-width">Full width</option>
                     </select>
@@ -1252,6 +1258,20 @@
                 <p>
                     <a tabindex="0" class="more-toggle" data-parent-distance="3">Less&hellip;</a>
                 </p>
+            </div>
+            <div class="settings-item-children settings-item-children-group" id="full-width-position-options" hidden>
+                <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
+                    <div class="settings-item-left">
+                        <div class="settings-item-label">Popup position</div>
+                    </div>
+                    <div class="settings-item-right">
+                        <select data-setting="general.popupFullWidthPosition">
+                            <option value="top">Top</option>
+                            <option value="above-cursor">Above cursor</option>
+                            <option value="bottom">Bottom</option>
+                        </select>
+                    </div>
+                </div></div>
             </div>
         </div>
         <div class="settings-item">

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -43,6 +43,7 @@ function createProfileOptionsTestData1() {
             maxResults: 32,
             showAdvanced: false,
             popupDisplayMode: 'default',
+            popupFullWidthPosition: 'bottom',
             popupWidth: 400,
             popupHeight: 250,
             popupHorizontalOffset: 0,
@@ -275,6 +276,7 @@ function createProfileOptionsUpdatedTestData1() {
             showAdvanced: false,
             showDebug: false,
             popupDisplayMode: 'default',
+            popupFullWidthPosition: 'bottom',
             popupWidth: 400,
             popupHeight: 250,
             popupHorizontalOffset: 0,
@@ -705,7 +707,7 @@ function createOptionsUpdatedTestData1() {
             },
         ],
         profileCurrent: 0,
-        version: 75,
+        version: 76,
         global: {
             database: {
                 prefixWildcardsSupported: false,

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -416,7 +416,7 @@ export type PopupActionBarVisibility = 'auto' | 'always';
 
 export type PopupActionBarLocation = 'left' | 'right' | 'top' | 'bottom';
 
-export type FrequencyDisplayMode = 'tags' | 'tags-grouped' | 'split-tags' | 'split-tags-grouped' | 'inline-list' | 'list';
+export type FrequencyDisplayMode = 'tags' | 'tags-grouped' | 'split-tags' | 'split-tags-grouped' | 'inline-list' | 'list' | 'bordered-list';
 
 export type TermDisplayMode = 'ruby' | 'ruby-and-reading' | 'term-and-reading' | 'term-only';
 

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -115,6 +115,7 @@ export type GeneralOptions = {
     fontSize: number;
     lineHeight: string;
     popupDisplayMode: PopupDisplayMode;
+    popupFullWidthPosition: PopupFullWidthPosition;
     popupWidth: number;
     popupHeight: number;
     popupHorizontalOffset: number;
@@ -396,6 +397,8 @@ export type PreventSecondaryMouseOptions = {
 export type ResultOutputMode = 'group' | 'merge' | 'split' | 'term';
 
 export type PopupDisplayMode = 'default' | 'full-width';
+
+export type PopupFullWidthPosition = 'top' | 'above-cursor' | 'bottom';
 
 export type PopupHorizontalTextPosition = 'below' | 'above';
 


### PR DESCRIPTION
I didn't really like that when you chose full-width option for the popup, you cannot adjust where it appears. It default to the bottom, but I wanted it to be above the cursor. So I added the option and also added 'Top' too in case a user wishes to have it appear at the top of the screen.