### PR TITLE
[perf] Use 'relaxed' on readwrite transactions

### DIFF
--- a/ext/js/data/database.js
+++ b/ext/js/data/database.js
@@ -92,15 +92,16 @@ export class Database {
      * Returns a new transaction with the given mode ("readonly" or "readwrite") and scope which can be a single object store name or an array of names.
      * @param {string[]} storeNames
      * @param {IDBTransactionMode} mode
+     * @param {IDBTransactionDurability} [durability]
      * @returns {IDBTransaction}
      * @throws {Error}
      */
-    transaction(storeNames, mode) {
+    transaction(storeNames, mode, durability = 'default') {
         if (this._db === null) {
             throw new Error(this._isOpening ? 'Database not ready' : 'Database not open');
         }
         try {
-            return this._db.transaction(storeNames, mode);
+            return this._db.transaction(storeNames, mode, {durability});
         } catch (e) {
             throw new Error(toError(e).message + '\nDatabase transaction error, you may need to Delete All dictionaries to reset the database or manually delete the Indexed DB database.');
         }
@@ -609,7 +610,7 @@ export class Database {
      * @returns {IDBTransaction}
      */
     _readWriteTransaction(storeNames, resolve, reject) {
-        const transaction = this.transaction(storeNames, 'readwrite');
+        const transaction = this.transaction(storeNames, 'readwrite', 'relaxed');
         transaction.onerror = (e) => reject(/** @type {IDBTransaction} */ (e.target).error);
         transaction.onabort = () => reject(new Error('Transaction aborted'));
         transaction.oncomplete = () => resolve();


### PR DESCRIPTION
Use 'relaxed' on readwrite transactions.

Benchmarks (baseline default vs relaxed)
https://share.firefox.dev/3P6xcZk
https://share.firefox.dev/4wd5URB

First is baseline, then with the changes; benchmarked over wty-en-ja ~4.2MB four times.

You filter markers by "dictionary" and you should be able to see dictionaryImport and dictionaryDelete.

For that particular dictionary, it is a 10-15% speed increase. Untested in bigger sizes, in theory it should not affect those by much (see the second reference below)

See
- https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/durability
- https://rxdb.info/slow-indexeddb.html#relaxed-durability

---

As a side note, changing maxTransactionLength in ext/js/dictionary/dictionary-importer.js, is also a trivial way to increase import speed with little to no effort. The drawback is, as far as I can tell, a less accurate progress bar. That should affect all sizes.