### PR TITLE
fix: escape angle brackets in glossary Anki output

### DIFF
--- a/ext/js/templates/anki-template-renderer.js
+++ b/ext/js/templates/anki-template-renderer.js
@@ -149,11 +149,22 @@ export class AnkiTemplateRenderer {
     }
 
     /**
+     * Bypasses Handlebars HTML escaping. Use with care.
      * @param {string} text
      * @returns {string}
      */
     _safeString(text) {
         return new Handlebars.SafeString(text);
+    }
+
+    /**
+     * Escape angle brackets so raw HTML doesn't leak into Anki cards.
+     * Must run before _safeString since SafeString bypasses Handlebars escaping.
+     * @param {string} text
+     * @returns {string}
+     */
+    _escapeExpression(text) {
+        return text.replaceAll('<', '&lt;').replaceAll('>', '&gt;');
     }
 
     // Template helpers
@@ -721,12 +732,12 @@ export class AnkiTemplateRenderer {
     _formatGlossary(args, _context, options) {
         const [dictionary, content] = /** @type {[dictionary: string, content: import('dictionary-data').TermGlossaryContent]} */ (args);
         const data = this._getNoteDataFromOptions(options);
-        if (typeof content === 'string') { return this._safeString(this._stringToMultiLineHtml(content)); }
+        if (typeof content === 'string') { return this._safeString(this._stringToMultiLineHtml(this._escapeExpression(content))); }
         if (!(typeof content === 'object' && content !== null)) { return ''; }
         switch (content.type) {
             case 'image': return this._formatGlossaryImage(content, dictionary, data);
             case 'structured-content': return this._formatStructuredContent(content, dictionary, data);
-            case 'text': return this._safeString(this._stringToMultiLineHtml(content.text));
+            case 'text': return this._safeString(this._stringToMultiLineHtml(this._escapeExpression(content.text)));
         }
         return '';
     }
@@ -761,7 +772,7 @@ export class AnkiTemplateRenderer {
     _formatGlossaryPlain(args, _context, options) {
         const [dictionary, content] = /** @type {[dictionary: string, content: import('dictionary-data').TermGlossaryContent]} */ (args);
         const data = this._getNoteDataFromOptions(options);
-        if (typeof content === 'string') { return this._safeString(content); }
+        if (typeof content === 'string') { return this._safeString(this._escapeExpression(content)); }
         if (!(typeof content === 'object' && content !== null)) { return ''; }
         const structuredContentGenerator = this._createStructuredContentGenerator(data);
         switch (content.type) {
@@ -775,7 +786,7 @@ export class AnkiTemplateRenderer {
                     return node !== null ? this._getStructuredContentText(node) : '';
                 }
             }
-            case 'text': return this._safeString(content.text);
+            case 'text': return this._safeString(this._escapeExpression(content.text));
         }
         return '';
     }


### PR DESCRIPTION
The angle brackets in the dictionary glossary were leaking onto the Anki cards as unescaped (raw) HTML,
  which broke rendering.

  - Added _escapeExpression() to convert "<" to "&lt;" and ">" to "&gt;" before the renderer marks the text
  as safe through the Handlebars.SafeString
  - https://handlebarsjs.com/api-reference/utilities.html#handlebars-safestring-string

  Fixes #1906
  Fixes #2350
  Closes #2394