### PR TITLE
Show revision on dictionary tag hover

### DIFF
--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -164,7 +164,9 @@ export class DisplayGenerator {
                 const currentDictionaryInfo = dictionaryInfo.find(({title}) => title === dictionary);
                 if (currentDictionaryInfo) {
                     const dictionaryContentArray = [];
+                    // Title and revision are required keys as per the schema.
                     dictionaryContentArray.push(currentDictionaryInfo.title);
+                    dictionaryContentArray.push(`rev.${currentDictionaryInfo.revision}`);
                     if (currentDictionaryInfo.author) {
                         dictionaryContentArray.push('Author: ' + currentDictionaryInfo.author);
                     }

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -165,8 +165,7 @@ export class DisplayGenerator {
                 if (currentDictionaryInfo) {
                     const dictionaryContentArray = [];
                     // Title and revision are required keys as per the schema.
-                    dictionaryContentArray.push(currentDictionaryInfo.title);
-                    dictionaryContentArray.push(`rev.${currentDictionaryInfo.revision}`);
+                    dictionaryContentArray.push(currentDictionaryInfo.title, `rev.${currentDictionaryInfo.revision}`);
                     if (currentDictionaryInfo.author) {
                         dictionaryContentArray.push('Author: ' + currentDictionaryInfo.author);
                     }


### PR DESCRIPTION
A minor QOL improvement. It shows the dictionary revision on dictionary tag hover.

---

<img width="843" height="516" alt="image" src="https://github.com/user-attachments/assets/e6f14cd0-2c55-4532-8d6d-045218fe9dc7" />
