### PR TITLE
Fix invokeMulti API key usage with Anki Connect 

### DIFF
--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -517,12 +517,20 @@ export class AnkiConnect {
      * @returns {Promise<unknown[]>}
      */
     async _invokeMulti(actions) {
-        const modifiedActions = actions.map((action) => ({...action, key: this._apiKey}));
-        const result = await this._invoke('multi', {actions: modifiedActions});
-        if (!Array.isArray(result)) {
-            throw this._createUnexpectedResultError('array', result);
+        if (this._apiKey !== null) {
+            const modifiedActions = actions.map((action) => ({...action, key: this._apiKey}));
+            const result = await this._invoke('multi', {actions: modifiedActions});
+            if (!Array.isArray(result)) {
+                throw this._createUnexpectedResultError('array', result);
+            }
+            return result;
+        } else {
+            const result = await this._invoke('multi', {actions: actions});
+            if (!Array.isArray(result)) {
+                throw this._createUnexpectedResultError('array', result);
+            }
+            return result;
         }
-        return result;
     }
 
     /**

--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -517,7 +517,8 @@ export class AnkiConnect {
      * @returns {Promise<unknown[]>}
      */
     async _invokeMulti(actions) {
-        const result = await this._invoke('multi', {actions});
+        const modifiedActions = actions.map(action => ({ ...action, key:this._apiKey}));
+        const result = await this._invoke('multi', {actions: modifiedActions});
         if (!Array.isArray(result)) {
             throw this._createUnexpectedResultError('array', result);
         }

--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -517,20 +517,12 @@ export class AnkiConnect {
      * @returns {Promise<unknown[]>}
      */
     async _invokeMulti(actions) {
-        if (this._apiKey !== null) {
-            const modifiedActions = actions.map((action) => ({...action, key: this._apiKey}));
-            const result = await this._invoke('multi', {actions: modifiedActions});
-            if (!Array.isArray(result)) {
-                throw this._createUnexpectedResultError('array', result);
-            }
-            return result;
-        } else {
-            const result = await this._invoke('multi', {actions: actions});
-            if (!Array.isArray(result)) {
-                throw this._createUnexpectedResultError('array', result);
-            }
-            return result;
+        const modifiedActions = this._apiKey !== null ? actions.map((action) => ({...action, key: this._apiKey})) : actions;
+        const result = await this._invoke('multi', {actions: modifiedActions});
+        if (!Array.isArray(result)) {
+            throw this._createUnexpectedResultError('array', result);
         }
+        return result;
     }
 
     /**

--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -517,7 +517,7 @@ export class AnkiConnect {
      * @returns {Promise<unknown[]>}
      */
     async _invokeMulti(actions) {
-        const modifiedActions = actions.map(action => ({ ...action, key:this._apiKey}));
+        const modifiedActions = actions.map((action) => ({...action, key: this._apiKey}));
         const result = await this._invoke('multi', {actions: modifiedActions});
         if (!Array.isArray(result)) {
             throw this._createUnexpectedResultError('array', result);


### PR DESCRIPTION
Fixes #1864 by appending the API key to every action when using invokeMulti. Works on both Librewolf 150.0.2-1 and Chromium 147.0.7727.137 and `npm test` succeeds. 