### PR TITLE
feat(theming): add theme mode system (Classic, Minimal, E-Ink)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Yomitan provides powerful features not available in other browser-based dictiona
 - Anki Integration
   - 🔧 [Anki handlebar templates](./docs/templates.md)
 - Advanced Features
+  - 🎨 [Creating themes](./docs/theming.md)
 - Troubleshooting
   - 🕷️ [Known browser bugs](./docs/browser-bugs.md)
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -109,7 +109,7 @@ Add your theme ID to the `popupThemeMode` enum in [`ext/data/schemas/options-sch
 "popupThemeMode": {
     "type": "string",
     "enum": ["classic", "minimal", "eink", "your-theme-id"],
-    "default": "classic"
+    "default": "minimal"
 }
 ```
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,220 @@
+# Theming
+
+## Overview
+
+Yomitan supports multiple visual themes ("modes") that change the appearance of popups and the search page. Themes are additive CSS overrides — the base "Classic" theme is always present, and other themes layer on top by overriding CSS variables and adding rules.
+
+The active theme is controlled by the `data-theme-mode` attribute on the `<html>` element (set by JavaScript based on user preference). Theme CSS files use attribute selectors like `:root[data-theme-mode='minimal']` to apply only when active.
+
+## How it works
+
+### Additive architecture
+
+- Classic is the base theme ([`display.css`](../ext/css/display.css), [`material.css`](../ext/css/material.css), etc.)
+- All other themes are CSS _overrides_ loaded on top
+- Only the active theme's selectors match, so unused themes have zero visual effect
+- CSS files are loaded statically via `<link>` tags in HTML (no dynamic injection)
+
+### Activation mechanism
+
+- [`theme-controller.js`](../ext/js/app/theme-controller.js) sets `data-theme-mode` on the root element
+- CSS selectors like `:root[data-theme-mode='eink']` activate automatically
+- No JavaScript logic needed per-theme
+
+## Creating a theme
+
+### Step 1: Create the CSS file
+
+Create `ext/css/theme-<your-theme-id>.css`. Use this template:
+
+```css
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* ===== YOUR THEME NAME ===== */
+
+/* Light mode overrides */
+:root[data-theme-mode="your-theme-id"][data-theme="light"] {
+  --text-color: #000000;
+  --background-color: #ffffff;
+  /* override other variables as needed */
+}
+
+/* Dark mode overrides */
+:root[data-theme-mode="your-theme-id"][data-theme="dark"] {
+  --text-color: #ffffff;
+  --background-color: #000000;
+  /* override other variables as needed */
+}
+
+/* Component overrides (works for both light and dark) */
+:root[data-theme-mode="your-theme-id"] .tag {
+  border-radius: 0;
+}
+```
+
+### Step 2: Register the theme
+
+Add your theme to [`ext/js/data/theme-registry.js`](../ext/js/data/theme-registry.js):
+
+```js
+export const themes = [
+  {
+    id: "classic",
+    label: "Classic",
+  },
+  // ... existing themes ...
+  {
+    id: "your-theme-id",
+    label: "Your Theme Name",
+  },
+];
+```
+
+### Step 3: Add CSS links to HTML
+
+Add a `<link>` tag to each HTML file that displays popup content:
+
+**[`ext/popup.html`](../ext/popup.html)** — inside `<head>`, with other theme links:
+
+```html
+<link rel="stylesheet" type="text/css" href="/css/theme-your-theme-id.css" />
+```
+
+**[`ext/search.html`](../ext/search.html)** — same location.
+
+**[`ext/popup-preview.html`](../ext/popup-preview.html)** — same location.
+
+### Step 4: Add to settings schema
+
+Add your theme ID to the `popupThemeMode` enum in [`ext/data/schemas/options-schema.json`](../ext/data/schemas/options-schema.json):
+
+```json
+"popupThemeMode": {
+    "type": "string",
+    "enum": ["classic", "minimal", "eink", "your-theme-id"],
+    "default": "classic"
+}
+```
+
+### Step 5: Add TypeScript type
+
+Add your theme ID to the union type in [`types/ext/settings.d.ts`](../types/ext/settings.d.ts):
+
+```typescript
+export type PopupThemeMode = "classic" | "minimal" | "eink" | "your-theme-id";
+```
+
+## CSS patterns
+
+### Variable overrides
+
+The easiest way to theme is overriding CSS custom properties. Key variables:
+
+| Variable                                 | Purpose                            |
+| ---------------------------------------- | ---------------------------------- |
+| `--text-color`                           | Primary text                       |
+| `--text-color-light1` through `--light4` | Muted text (progressively lighter) |
+| `--background-color`                     | Main background                    |
+| `--background-color-light`               | Lighter background variant         |
+| `--background-color-dark1`               | Darker background variant          |
+| `--accent-color`                         | Primary accent                     |
+| `--link-color`                           | Link text                          |
+| `--tag-*-background-color`               | Tag type backgrounds               |
+| `--sidebar-background-color`             | Sidebar background                 |
+| `--light-border-color`                   | Subtle borders                     |
+| `--medium-border-color`                  | Standard borders                   |
+| `--dark-border-color`                    | Strong borders                     |
+
+### Component targeting
+
+Target specific components with attribute-qualified selectors:
+
+```css
+/* All tags in your theme */
+:root[data-theme-mode="your-theme-id"] .tag {
+  border-radius: 4px;
+}
+
+/* Only in light mode */
+:root[data-theme-mode="your-theme-id"][data-theme="light"] .entry {
+  border-bottom: 1px solid #eeeeee;
+}
+```
+
+### Outer chrome styling
+
+For popup iframe styling (borders, shadows, radius), target the iframe:
+
+```css
+iframe.yomitan-popup[data-theme-mode="your-theme-id"] {
+  --popup-border-radius: 8px;
+  --popup-border-width: 1px;
+  --popup-border-color: #cccccc;
+  --popup-box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  --popup-background-color: #ffffff;
+}
+```
+
+## Best practices
+
+### Do
+
+- Use CSS variables for colors — easy to override per mode
+- Use `currentColor` for borders to inherit text color
+- Target specific selectors (`.tag`, `.entry`) rather than universal `*`
+- Test both light and dark modes
+- Run `npm run test:css` to validate syntax
+
+### Don't
+
+- Use `!important` (stylelint will reject it)
+- Use universal `*` selectors (performance issue)
+- Modify HTML structure — themes are CSS-only
+- Load fonts or external resources (extension CSP restrictions)
+
+## Testing
+
+After creating your theme:
+
+1. **Lint**: `npm run test:css`
+2. **Fast tests**: `npm run test:fast`
+3. **Visual**: Reload the extension and switch modes in Settings → Appearance
+4. **Search page**: Open the search page and verify styling there too
+
+## Example: Minimal theme
+
+The Minimal theme ([`ext/css/theme-minimal.css`](../ext/css/theme-minimal.css)) demonstrates:
+
+- Light/dark palette overrides
+- Tag restyling (rounded pills → subtle backgrounds)
+- Dictionary label conversion (colored badges → text labels)
+- Inflection chain simplification (icons hidden, compact layout)
+- Frequency tag accent colors
+
+## Files reference
+
+| File                                                                              | Purpose                    |
+| --------------------------------------------------------------------------------- | -------------------------- |
+| [`ext/css/theme-*.css`](../ext/css/)                                              | Theme stylesheets          |
+| [`ext/js/data/theme-registry.js`](../ext/js/data/theme-registry.js)               | Theme registry             |
+| [`ext/data/schemas/options-schema.json`](../ext/data/schemas/options-schema.json) | Settings schema            |
+| [`types/ext/settings.d.ts`](../types/ext/settings.d.ts)                           | TypeScript types           |
+| [`ext/popup.html`](../ext/popup.html)                                             | Popup page HTML            |
+| [`ext/search.html`](../ext/search.html)                                           | Search page HTML           |
+| [`ext/popup-preview.html`](../ext/popup-preview.html)                             | Settings preview HTML      |
+| [`ext/js/app/theme-controller.js`](../ext/js/app/theme-controller.js)             | Theme attribute controller |

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -189,12 +189,12 @@ iframe.yomitan-popup[data-theme-mode="your-theme-id"] {
 - Test both light and dark modes
 - Run `npm run test:css` to validate syntax
 
-### Don't
+### Caution
 
-- Use `!important` (stylelint will reject it)
-- Use universal `*` selectors (performance issue)
-- Modify HTML structure — themes are CSS-only
-- Load fonts or external resources (extension CSP restrictions)
+- **`!important`** — Hard to override and fights the cascade. Use higher-specificity selectors instead. If you must (e.g. killing animations), disable the lint rule with `/* stylelint-disable-next-line declaration-no-important */`.
+- **Universal `*`** — Slows rendering on large popups. Target specific classes.
+- **HTML structure** — Themes are CSS-only; markup changes require core changes.
+- **External fonts/resources** — Blocked by extension CSP. Use system fonts only.
 
 ## Testing
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -76,11 +76,13 @@ export const themes = [
   {
     id: "classic",
     label: "Classic",
+    css: null /* base CSS is classic; no override file needed */,
   },
   // ... existing themes ...
   {
     id: "your-theme-id",
     label: "Your Theme Name",
+    css: "/css/theme-your-theme-id.css",
   },
 ];
 ```
@@ -158,7 +160,14 @@ Target specific components with attribute-qualified selectors:
 
 ### Outer chrome styling
 
-For popup iframe styling (borders, shadows, radius), target the iframe:
+Theme CSS files are loaded in **both** contexts:
+
+1. **Inner** — via static `<link>` in `popup.html` / `search.html` / `popup-preview.html`
+2. **Outer** — via dynamic injection by `popup.js` into the parent page's shadow DOM
+
+This means a single theme file contains both inner selectors (`:root[data-theme-mode='...']`) and outer selectors (`iframe.yomitan-popup[data-theme-mode='...']`). Selectors that don't match their current context are harmless no-ops.
+
+For popup iframe styling (borders, shadows, radius), add outer selectors at the **end** of your theme file:
 
 ```css
 iframe.yomitan-popup[data-theme-mode="your-theme-id"] {
@@ -218,3 +227,4 @@ The Minimal theme ([`ext/css/theme-minimal.css`](../ext/css/theme-minimal.css)) 
 | [`ext/search.html`](../ext/search.html)                                           | Search page HTML           |
 | [`ext/popup-preview.html`](../ext/popup-preview.html)                             | Settings preview HTML      |
 | [`ext/js/app/theme-controller.js`](../ext/js/app/theme-controller.js)             | Theme attribute controller |
+| [`ext/js/app/popup.js`](../ext/js/app/popup.js)                                   | Outer theme injection      |

--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -151,6 +151,9 @@
     --tag-search-background-color: #8a8a91;
     --tag-pronunciation-dictionary-background-color: #6640be;
 
+    --tag-muted-background-color: #8a8a91;
+    --tag-accent-background-color: #b6327a;
+
     --sidebar-background-color: #f8f9fa;
 
     --sidebar-button-background-color: transparent;
@@ -218,6 +221,9 @@
     --tag-part-of-speech-background-color: #565656;
     --tag-search-background-color: #69696e;
     --tag-pronunciation-dictionary-background-color: #6640be;
+
+    --tag-muted-background-color: #69696e;
+    --tag-accent-background-color: #992a67;
 
     --sidebar-background-color: #282828;
 
@@ -792,7 +798,7 @@ button.action-button:active:not(:disabled) {
 
 /* Tags */
 .tag {
-    --tag-color: var(--tag-default-background-color);
+    --tag-color: var(--tag-muted-background-color);
 
     display: inline-flex;
     flex-flow: row nowrap;
@@ -855,7 +861,7 @@ button.action-button:active:not(:disabled) {
     border-bottom-right-radius: 0;
 }
 .tag[data-category=name] {
-    --tag-color: var(--tag-name-background-color);
+    --tag-color: var(--tag-accent-background-color);
 }
 .tag[data-category=expression] {
     --tag-color: var(--tag-expression-background-color);
@@ -879,7 +885,7 @@ button.action-button:active:not(:disabled) {
     --tag-color: var(--tag-part-of-speech-background-color);
 }
 .tag[data-category=search] {
-    --tag-color: var(--tag-search-background-color);
+    --tag-color: var(--tag-muted-background-color);
 }
 .tag[data-category=pronunciation-dictionary] {
     --tag-color: var(--tag-pronunciation-dictionary-background-color);

--- a/ext/css/popup-outer.css
+++ b/ext/css/popup-outer.css
@@ -19,9 +19,10 @@
 iframe.yomitan-popup {
     all: initial;
     font-size: 1px;
-    background-color: #ffffff;
-    border: 1em solid #999999;
-    box-shadow: 0 0 10em rgba(0, 0, 0, 0.5);
+    background-color: var(--popup-background-color, #ffffff);
+    border: var(--popup-border-width, 1em) solid var(--popup-border-color, #999999);
+    box-shadow: var(--popup-box-shadow, 0 0 10em rgba(0, 0, 0, 0.5));
+    border-radius: var(--popup-border-radius, 0);
     position: fixed;
     resize: none;
     visibility: hidden;
@@ -29,8 +30,8 @@ iframe.yomitan-popup {
     box-sizing: border-box;
 }
 iframe.yomitan-popup[data-theme=dark] {
-    background-color: #1e1e1e;
-    border-color: #666666;
+    background-color: var(--popup-background-color, #1e1e1e);
+    border-color: var(--popup-border-color, #666666);
 }
 iframe.yomitan-popup[data-outer-theme=dark] {
     box-shadow: 0 0 10em rgba(255, 255, 255, 0.5);

--- a/ext/css/popup-outer.css
+++ b/ext/css/popup-outer.css
@@ -34,7 +34,7 @@ iframe.yomitan-popup[data-theme=dark] {
     border-color: var(--popup-border-color, #666666);
 }
 iframe.yomitan-popup[data-outer-theme=dark] {
-    box-shadow: 0 0 10em rgba(255, 255, 255, 0.5);
+    box-shadow: var(--popup-box-shadow, 0 0 10em rgba(255, 255, 255, 0.5));
 }
 iframe.yomitan-popup[data-outer-theme=none] {
     box-shadow: none;

--- a/ext/css/theme-eink.css
+++ b/ext/css/theme-eink.css
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ * Copyright (C) 2016-2022  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* ===== E-INK THEME: STRIP ALL MOTION AND DEPTH ===== */
+/* Targeted selectors — NOT universal * */
+:root[data-theme-mode="eink"] .entry,
+:root[data-theme-mode="eink"] .tag,
+:root[data-theme-mode="eink"] button,
+:root[data-theme-mode="eink"] .popup-menu,
+:root[data-theme-mode="eink"] .sidebar-button,
+:root[data-theme-mode="eink"] .action-button {
+    transition: none;
+    box-shadow: none;
+    text-shadow: none;
+}
+
+/* Only animation properties keep !important if absolutely needed */
+:root[data-theme-mode="eink"] .entry,
+:root[data-theme-mode="eink"] .tag,
+:root[data-theme-mode="eink"] button,
+:root[data-theme-mode="eink"] .popup-menu,
+:root[data-theme-mode="eink"] .sidebar-button,
+:root[data-theme-mode="eink"] .action-button {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+}
+
+/* ===== E-INK THEME: INNER CONTENT (Light) ===== */
+/* NOTE: E-ink is the ONLY theme that overrides palette colors */
+:root[data-theme-mode="eink"][data-theme="light"] {
+    --text-color: #000000;
+    --text-color-light1: #000000;
+    --text-color-light2: #000000;
+    --text-color-light3: #000000;
+    --text-color-light4: #000000;
+    --background-color: #ffffff;
+    --background-color-light: #ffffff;
+    --background-color-dark1: #ffffff;
+    --accent-color: #000000;
+    --link-color: #000000;
+    --sidebar-background-color: #ffffff;
+    --light-border-color: #000000;
+    --medium-border-color: #000000;
+    --dark-border-color: #000000;
+    --tag-text-color: #000000;
+    --tag-border-color: #000000;
+
+    /* Popup chrome */
+    --popup-border-radius: 0;
+    --popup-border-width: 1px;
+    --popup-border-color: #000000;
+    --popup-box-shadow: none;
+    --popup-background-color: #ffffff;
+}
+
+/* ===== E-INK THEME: INNER CONTENT (Dark) ===== */
+:root[data-theme-mode="eink"][data-theme="dark"] {
+    --text-color: #ffffff;
+    --text-color-light1: #ffffff;
+    --text-color-light2: #ffffff;
+    --text-color-light3: #ffffff;
+    --text-color-light4: #ffffff;
+    --background-color: #000000;
+    --background-color-light: #000000;
+    --background-color-dark1: #000000;
+    --accent-color: #ffffff;
+    --link-color: #ffffff;
+    --sidebar-background-color: #000000;
+    --light-border-color: #ffffff;
+    --medium-border-color: #ffffff;
+    --dark-border-color: #ffffff;
+    --tag-text-color: #ffffff;
+    --tag-border-color: #ffffff;
+
+    /* Popup chrome */
+    --popup-border-radius: 0;
+    --popup-border-width: 1px;
+    --popup-border-color: #ffffff;
+    --popup-box-shadow: none;
+    --popup-background-color: #000000;
+}
+
+/* ===== E-INK THEME: TAGS AS OUTLINED BOXES ===== */
+/* High specificity, no !important needed */
+:root[data-theme-mode="eink"] .tag {
+    --tag-color: transparent;
+    background-color: transparent;
+    border: 1px solid currentColor;
+    border-radius: 0;
+}
+:root[data-theme-mode="eink"] .tag-label {
+    background-color: transparent;
+    color: inherit;
+}
+:root[data-theme-mode="eink"] .tag-body::before {
+    display: none;
+}
+
+/* ===== E-INK THEME: REMOVE ALL ROUNDING ===== */
+:root[data-theme-mode="eink"] .entry,
+:root[data-theme-mode="eink"] .tag,
+:root[data-theme-mode="eink"] button,
+:root[data-theme-mode="eink"] input,
+:root[data-theme-mode="eink"] .menu {
+    border-radius: 0;
+}
+
+/* ===== E-INK THEME: ENTRY SEPARATION ===== */
+:root[data-theme-mode="eink"] .entry + .entry {
+    border-top: 1px solid currentColor;
+}
+
+/* ===== E-INK THEME: IMAGE FILTERS ===== */
+:root[data-theme-mode="eink"] .gloss-image {
+    filter: none;
+}
+
+/* ===== E-INK THEME: SCROLLBAR ===== */
+:root[data-theme-mode="eink"] ::-webkit-scrollbar-thumb {
+    background-color: currentColor;
+}
+:root[data-theme-mode="eink"] ::-webkit-scrollbar-track {
+    background-color: transparent;
+}

--- a/ext/css/theme-eink.css
+++ b/ext/css/theme-eink.css
@@ -28,16 +28,6 @@
     transition: none;
     box-shadow: none;
     text-shadow: none;
-}
-
-/* Only animation properties keep !important if absolutely needed */
-:root[data-theme-mode='eink'] .entry,
-:root[data-theme-mode='eink'] .tag,
-:root[data-theme-mode='eink'] button,
-:root[data-theme-mode='eink'] .popup-menu,
-:root[data-theme-mode='eink'] .sidebar-button,
-:root[data-theme-mode='eink'] .action-button,
-:root[data-theme-mode='eink'] .progress-bar-indeterminant {
     /* stylelint-disable-next-line declaration-no-important */
     animation-duration: 0s !important;
     /* stylelint-disable-next-line declaration-no-important */

--- a/ext/css/theme-eink.css
+++ b/ext/css/theme-eink.css
@@ -99,6 +99,12 @@
     display: none;
 }
 
+/* Remove borders from tag inner elements to prevent double-bordering */
+:root[data-theme-mode='eink'] .tag-label,
+:root[data-theme-mode='eink'] .tag-body {
+    border: none;
+}
+
 /* ===== E-INK THEME: REMOVE ALL ROUNDING ===== */
 :root[data-theme-mode='eink'] .entry,
 :root[data-theme-mode='eink'] .tag,

--- a/ext/css/theme-eink.css
+++ b/ext/css/theme-eink.css
@@ -18,31 +18,33 @@
 
 /* ===== E-INK THEME: STRIP ALL MOTION AND DEPTH ===== */
 /* Targeted selectors — NOT universal * */
-:root[data-theme-mode="eink"] .entry,
-:root[data-theme-mode="eink"] .tag,
-:root[data-theme-mode="eink"] button,
-:root[data-theme-mode="eink"] .popup-menu,
-:root[data-theme-mode="eink"] .sidebar-button,
-:root[data-theme-mode="eink"] .action-button {
+:root[data-theme-mode='eink'] .entry,
+:root[data-theme-mode='eink'] .tag,
+:root[data-theme-mode='eink'] button,
+:root[data-theme-mode='eink'] .popup-menu,
+:root[data-theme-mode='eink'] .sidebar-button,
+:root[data-theme-mode='eink'] .action-button {
     transition: none;
     box-shadow: none;
     text-shadow: none;
 }
 
 /* Only animation properties keep !important if absolutely needed */
-:root[data-theme-mode="eink"] .entry,
-:root[data-theme-mode="eink"] .tag,
-:root[data-theme-mode="eink"] button,
-:root[data-theme-mode="eink"] .popup-menu,
-:root[data-theme-mode="eink"] .sidebar-button,
-:root[data-theme-mode="eink"] .action-button {
+:root[data-theme-mode='eink'] .entry,
+:root[data-theme-mode='eink'] .tag,
+:root[data-theme-mode='eink'] button,
+:root[data-theme-mode='eink'] .popup-menu,
+:root[data-theme-mode='eink'] .sidebar-button,
+:root[data-theme-mode='eink'] .action-button {
+    /* stylelint-disable-next-line declaration-no-important */
     animation-duration: 0s !important;
+    /* stylelint-disable-next-line declaration-no-important */
     animation-delay: 0s !important;
 }
 
 /* ===== E-INK THEME: INNER CONTENT (Light) ===== */
 /* NOTE: E-ink is the ONLY theme that overrides palette colors */
-:root[data-theme-mode="eink"][data-theme="light"] {
+:root[data-theme-mode='eink'][data-theme='light'] {
     --text-color: #000000;
     --text-color-light1: #000000;
     --text-color-light2: #000000;
@@ -59,17 +61,10 @@
     --dark-border-color: #000000;
     --tag-text-color: #000000;
     --tag-border-color: #000000;
-
-    /* Popup chrome */
-    --popup-border-radius: 0;
-    --popup-border-width: 1px;
-    --popup-border-color: #000000;
-    --popup-box-shadow: none;
-    --popup-background-color: #ffffff;
 }
 
 /* ===== E-INK THEME: INNER CONTENT (Dark) ===== */
-:root[data-theme-mode="eink"][data-theme="dark"] {
+:root[data-theme-mode='eink'][data-theme='dark'] {
     --text-color: #ffffff;
     --text-color-light1: #ffffff;
     --text-color-light2: #ffffff;
@@ -86,54 +81,61 @@
     --dark-border-color: #ffffff;
     --tag-text-color: #ffffff;
     --tag-border-color: #ffffff;
-
-    /* Popup chrome */
-    --popup-border-radius: 0;
-    --popup-border-width: 1px;
-    --popup-border-color: #ffffff;
-    --popup-box-shadow: none;
-    --popup-background-color: #000000;
 }
 
 /* ===== E-INK THEME: TAGS AS OUTLINED BOXES ===== */
 /* High specificity, no !important needed */
-:root[data-theme-mode="eink"] .tag {
+:root[data-theme-mode='eink'] .tag {
     --tag-color: transparent;
     background-color: transparent;
     border: 1px solid currentColor;
     border-radius: 0;
 }
-:root[data-theme-mode="eink"] .tag-label {
+:root[data-theme-mode='eink'] .tag-label {
     background-color: transparent;
     color: inherit;
 }
-:root[data-theme-mode="eink"] .tag-body::before {
+:root[data-theme-mode='eink'] .tag-body::before {
     display: none;
 }
 
 /* ===== E-INK THEME: REMOVE ALL ROUNDING ===== */
-:root[data-theme-mode="eink"] .entry,
-:root[data-theme-mode="eink"] .tag,
-:root[data-theme-mode="eink"] button,
-:root[data-theme-mode="eink"] input,
-:root[data-theme-mode="eink"] .menu {
+:root[data-theme-mode='eink'] .entry,
+:root[data-theme-mode='eink'] .tag,
+:root[data-theme-mode='eink'] button,
+:root[data-theme-mode='eink'] input,
+:root[data-theme-mode='eink'] .menu {
     border-radius: 0;
 }
 
 /* ===== E-INK THEME: ENTRY SEPARATION ===== */
-:root[data-theme-mode="eink"] .entry + .entry {
+:root[data-theme-mode='eink'] .entry+.entry {
     border-top: 1px solid currentColor;
 }
 
 /* ===== E-INK THEME: IMAGE FILTERS ===== */
-:root[data-theme-mode="eink"] .gloss-image {
+:root[data-theme-mode='eink'] .gloss-image {
     filter: none;
 }
 
 /* ===== E-INK THEME: SCROLLBAR ===== */
-:root[data-theme-mode="eink"] ::-webkit-scrollbar-thumb {
+:root[data-theme-mode='eink'] ::-webkit-scrollbar-thumb {
     background-color: currentColor;
 }
-:root[data-theme-mode="eink"] ::-webkit-scrollbar-track {
+:root[data-theme-mode='eink'] ::-webkit-scrollbar-track {
     background-color: transparent;
+}
+
+/* ===== E-INK THEME: OUTER CHROME ===== */
+iframe.yomitan-popup[data-theme-mode='eink'] {
+    --popup-border-radius: 0;
+    --popup-border-width: 1px;
+    --popup-border-color: #000000;
+    --popup-box-shadow: none;
+    --popup-background-color: #ffffff;
+}
+
+iframe.yomitan-popup[data-theme-mode='eink'][data-theme='dark'] {
+    --popup-border-color: #ffffff;
+    --popup-background-color: #000000;
 }

--- a/ext/css/theme-eink.css
+++ b/ext/css/theme-eink.css
@@ -45,7 +45,6 @@
 }
 
 /* ===== E-INK THEME: INNER CONTENT (Light) ===== */
-/* NOTE: E-ink is the ONLY theme that overrides palette colors */
 :root[data-theme-mode='eink'][data-theme='light'] {
     --text-color: #000000;
     --text-color-light1: #000000;

--- a/ext/css/theme-eink.css
+++ b/ext/css/theme-eink.css
@@ -23,7 +23,8 @@
 :root[data-theme-mode='eink'] button,
 :root[data-theme-mode='eink'] .popup-menu,
 :root[data-theme-mode='eink'] .sidebar-button,
-:root[data-theme-mode='eink'] .action-button {
+:root[data-theme-mode='eink'] .action-button,
+:root[data-theme-mode='eink'] .progress-bar-indeterminant {
     transition: none;
     box-shadow: none;
     text-shadow: none;
@@ -35,7 +36,8 @@
 :root[data-theme-mode='eink'] button,
 :root[data-theme-mode='eink'] .popup-menu,
 :root[data-theme-mode='eink'] .sidebar-button,
-:root[data-theme-mode='eink'] .action-button {
+:root[data-theme-mode='eink'] .action-button,
+:root[data-theme-mode='eink'] .progress-bar-indeterminant {
     /* stylelint-disable-next-line declaration-no-important */
     animation-duration: 0s !important;
     /* stylelint-disable-next-line declaration-no-important */
@@ -115,7 +117,7 @@
 :root[data-theme-mode='eink'] .tag,
 :root[data-theme-mode='eink'] button,
 :root[data-theme-mode='eink'] input,
-:root[data-theme-mode='eink'] .menu {
+:root[data-theme-mode='eink'] .popup-menu {
     border-radius: 0;
 }
 

--- a/ext/css/theme-eink.css
+++ b/ext/css/theme-eink.css
@@ -105,6 +105,11 @@
     border: none;
 }
 
+/* Remove border from nested frequency tags to prevent double-bordering in grouped modes */
+:root[data-theme-mode='eink'] .frequency-group-tag .frequency-tag {
+    border: none;
+}
+
 /* ===== E-INK THEME: REMOVE ALL ROUNDING ===== */
 :root[data-theme-mode='eink'] .entry,
 :root[data-theme-mode='eink'] .tag,

--- a/ext/css/theme-minimal.css
+++ b/ext/css/theme-minimal.css
@@ -142,3 +142,32 @@ iframe.yomitan-popup[data-theme-mode='minimal'][data-theme='dark'] {
     margin-bottom: 0.6em;
     letter-spacing: 0.02em;
 }
+
+/* ===== MINIMAL THEME: COMPACT INFLECTION DISPLAY ===== */
+
+/* Hide source icons (📖, 🧩) — too noisy in minimal mode */
+:root[data-theme-mode='minimal'] .inflection-source-icon {
+    display: none;
+}
+
+/* Hide « separators between inflections */
+:root[data-theme-mode='minimal'] .inflection-rule-chain>.inflection+.inflection-separator+.inflection::before,
+:root[data-theme-mode='minimal'] .inflection-separator {
+    display: none;
+}
+
+/* Style inflections as small inline pills */
+:root[data-theme-mode='minimal'] .inflection {
+    display: inline-block;
+    font-size: calc(1em * 11 / 14);
+    padding: 0.15em 0.4em;
+    margin-right: 0.3em;
+    border-radius: 4px;
+    background-color: var(--tag-default-background-color);
+    color: var(--tag-text-color);
+}
+
+/* Compact the inflection rule chain container */
+:root[data-theme-mode='minimal'] .inflection-rule-chain {
+    margin: 0.25em 0;
+}

--- a/ext/css/theme-minimal.css
+++ b/ext/css/theme-minimal.css
@@ -138,8 +138,8 @@ iframe.yomitan-popup[data-theme-mode='minimal'][data-theme='dark'] {
     font-size: calc(1em * 10 / 14);
     font-weight: 500;
     color: var(--text-color-light2);
-    margin-top: 0.35em;
-    margin-bottom: 0.6em;
+    margin-top: 0.2em;
+    margin-bottom: 0.3em;
     letter-spacing: 0.02em;
 }
 
@@ -164,8 +164,8 @@ iframe.yomitan-popup[data-theme-mode='minimal'][data-theme='dark'] {
 :root[data-theme-mode='minimal'] .inflection {
     display: inline-block;
     font-size: calc(1em * 11 / 14);
-    padding: 0.15em 0.4em;
-    margin-right: 0.5em;
+    padding: 0.1em 0.25em;
+    margin-right: 0.25em;
     border-radius: 4px;
     background-color: var(--tag-default-background-color);
     color: var(--tag-text-color);
@@ -173,5 +173,5 @@ iframe.yomitan-popup[data-theme-mode='minimal'][data-theme='dark'] {
 
 /* Compact the inflection rule chain container */
 :root[data-theme-mode='minimal'] .inflection-rule-chain {
-    margin: 0.25em 0;
+    margin: 0.15em 0;
 }

--- a/ext/css/theme-minimal.css
+++ b/ext/css/theme-minimal.css
@@ -150,8 +150,12 @@ iframe.yomitan-popup[data-theme-mode='minimal'][data-theme='dark'] {
     display: none;
 }
 
-/* Hide « separators between inflections */
-:root[data-theme-mode='minimal'] .inflection-rule-chain>.inflection+.inflection-separator+.inflection::before,
+/* No arrow separator — use spacing instead for consistency across platforms */
+:root[data-theme-mode='minimal'] .inflection-rule-chain>.inflection+.inflection-separator+.inflection::before {
+    display: none;
+}
+
+/* Keep the .inflection-separator itself hidden (the ::before handles it) */
 :root[data-theme-mode='minimal'] .inflection-separator {
     display: none;
 }
@@ -161,7 +165,7 @@ iframe.yomitan-popup[data-theme-mode='minimal'][data-theme='dark'] {
     display: inline-block;
     font-size: calc(1em * 11 / 14);
     padding: 0.15em 0.4em;
-    margin-right: 0.3em;
+    margin-right: 0.5em;
     border-radius: 4px;
     background-color: var(--tag-default-background-color);
     color: var(--tag-text-color);

--- a/ext/css/theme-minimal.css
+++ b/ext/css/theme-minimal.css
@@ -123,3 +123,21 @@ iframe.yomitan-popup[data-theme-mode='minimal'][data-theme='dark'] {
     --popup-border-color: #3a3a3c;
     background-color: #000000;
 }
+
+/* ===== MINIMAL THEME: DICTIONARY NAME LABELS ===== */
+
+/* Hide dictionary tag pills - they're too visually noisy */
+:root[data-theme-mode='minimal'] .tag[data-category='dictionary'] {
+    display: none;
+}
+
+/* Show dictionary name as subtle text label above each definition */
+:root[data-theme-mode='minimal'] .definition-item::before {
+    content: attr(data-dictionary);
+    display: block;
+    font-size: calc(1em * 10 / 14);
+    font-weight: 500;
+    color: var(--text-color-light2);
+    margin-bottom: 0.35em;
+    letter-spacing: 0.02em;
+}

--- a/ext/css/theme-minimal.css
+++ b/ext/css/theme-minimal.css
@@ -19,7 +19,7 @@
 /* ===== MINIMAL THEME: FULL HOSHI READER REPRODUCTION ===== */
 
 /* Light mode — pure white bg, black text, muted grays */
-:root[data-theme-mode="minimal"][data-theme="light"] {
+:root[data-theme-mode='minimal'][data-theme='light'] {
     --text-color: #000000;
     --text-color-light1: #555555;
     --text-color-light2: #666666;
@@ -58,7 +58,7 @@
 }
 
 /* Dark mode — pure black bg, white text */
-:root[data-theme-mode="minimal"][data-theme="dark"] {
+:root[data-theme-mode='minimal'][data-theme='dark'] {
     --text-color: #ffffff;
     --text-color-light1: #aaaaaa;
     --text-color-light2: #999999;
@@ -97,29 +97,29 @@
 }
 
 /* Structural overrides (same for light and dark) */
-:root[data-theme-mode="minimal"] .entry + .entry {
+:root[data-theme-mode='minimal'] .entry+.entry {
     border-top: none;
 }
 
-:root[data-theme-mode="minimal"] button.action-button {
+:root[data-theme-mode='minimal'] button.action-button {
     background: transparent;
     border: none;
     opacity: 0.6;
     transition: opacity 0.1s ease;
 }
-:root[data-theme-mode="minimal"] button.action-button:hover {
+:root[data-theme-mode='minimal'] button.action-button:hover {
     opacity: 1;
 }
 
 /* ===== MINIMAL THEME: OUTER CHROME ===== */
-iframe.yomitan-popup[data-theme-mode="minimal"] {
+iframe.yomitan-popup[data-theme-mode='minimal'] {
     --popup-border-radius: 8em;
     --popup-border-color: #d1d1d6;
     --popup-box-shadow: none;
     background-color: #ffffff;
 }
 
-iframe.yomitan-popup[data-theme-mode="minimal"][data-theme="dark"] {
+iframe.yomitan-popup[data-theme-mode='minimal'][data-theme='dark'] {
     --popup-border-color: #3a3a3c;
     background-color: #000000;
 }

--- a/ext/css/theme-minimal.css
+++ b/ext/css/theme-minimal.css
@@ -36,8 +36,8 @@
     --shadow-color-light: rgba(0, 0, 0, 0);
 
     --tag-text-color: #000000;
-    --tag-default-background-color: rgba(128, 128, 128, 0.2);
-    --tag-name-background-color: rgba(128, 128, 128, 0.2);
+    --tag-muted-background-color: rgba(128, 128, 128, 0.2);
+    --tag-accent-background-color: rgba(128, 128, 128, 0.2);
     --tag-expression-background-color: rgba(120, 140, 160, 0.22);
     --tag-popular-background-color: rgba(120, 140, 160, 0.22);
     --tag-frequent-background-color: rgba(128, 128, 128, 0.2);
@@ -45,7 +45,6 @@
     --tag-dictionary-background-color: rgba(128, 128, 128, 0.2);
     --tag-frequency-background-color: rgba(119, 170, 235, 0.25);
     --tag-part-of-speech-background-color: rgba(128, 128, 128, 0.2);
-    --tag-search-background-color: rgba(128, 128, 128, 0.2);
     --tag-pronunciation-dictionary-background-color: rgba(148, 166, 235, 0.25);
 
     --sidebar-background-color: var(--background-color);
@@ -75,8 +74,8 @@
     --shadow-color-light: rgba(0, 0, 0, 0);
 
     --tag-text-color: #ffffff;
-    --tag-default-background-color: rgba(128, 128, 128, 0.25);
-    --tag-name-background-color: rgba(128, 128, 128, 0.25);
+    --tag-muted-background-color: rgba(128, 128, 128, 0.25);
+    --tag-accent-background-color: rgba(128, 128, 128, 0.25);
     --tag-expression-background-color: rgba(120, 140, 160, 0.3);
     --tag-popular-background-color: rgba(120, 140, 160, 0.3);
     --tag-frequent-background-color: rgba(128, 128, 128, 0.25);
@@ -84,7 +83,6 @@
     --tag-dictionary-background-color: rgba(128, 128, 128, 0.25);
     --tag-frequency-background-color: rgba(119, 170, 235, 0.3);
     --tag-part-of-speech-background-color: rgba(128, 128, 128, 0.25);
-    --tag-search-background-color: rgba(128, 128, 128, 0.25);
     --tag-pronunciation-dictionary-background-color: rgba(148, 166, 235, 0.3);
 
     --sidebar-background-color: var(--background-color);
@@ -154,7 +152,7 @@
     padding: 0.1em 0.25em;
     margin-right: 0.25em;
     border-radius: 4px;
-    background-color: var(--tag-default-background-color);
+    background-color: var(--tag-muted-background-color);
     color: var(--tag-text-color);
 }
 

--- a/ext/css/theme-minimal.css
+++ b/ext/css/theme-minimal.css
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ * Copyright (C) 2016-2022  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* ===== MINIMAL THEME: FULL HOSHI READER REPRODUCTION ===== */
+
+/* Light mode — pure white bg, black text, muted grays */
+:root[data-theme-mode="minimal"][data-theme="light"] {
+    --text-color: #000000;
+    --text-color-light1: #555555;
+    --text-color-light2: #666666;
+    --text-color-light3: #777777;
+    --text-color-light4: #888888;
+    --background-color: #ffffff;
+    --background-color-light: #ffffff;
+    --background-color-dark1: #eeeeee;
+
+    --accent-color: #426cf5;
+    --link-color: #426cf5;
+
+    --shadow-color: rgba(0, 0, 0, 0);
+    --shadow-color-light: rgba(0, 0, 0, 0);
+
+    --tag-text-color: #000000;
+    --tag-default-background-color: rgba(128, 128, 128, 0.2);
+    --tag-name-background-color: rgba(128, 128, 128, 0.2);
+    --tag-expression-background-color: rgba(120, 140, 160, 0.22);
+    --tag-popular-background-color: rgba(120, 140, 160, 0.22);
+    --tag-frequent-background-color: rgba(128, 128, 128, 0.2);
+    --tag-archaism-background-color: rgba(128, 128, 128, 0.2);
+    --tag-dictionary-background-color: rgba(128, 128, 128, 0.2);
+    --tag-frequency-background-color: rgba(128, 128, 128, 0.2);
+    --tag-part-of-speech-background-color: rgba(128, 128, 128, 0.2);
+    --tag-search-background-color: rgba(128, 128, 128, 0.2);
+    --tag-pronunciation-dictionary-background-color: rgba(128, 128, 128, 0.2);
+
+    --sidebar-background-color: var(--background-color);
+    --sidebar-button-background-color-hover: var(--background-color-dark1);
+    --sidebar-button-background-color-active: var(--background-color-dark1);
+
+    --entry-current-indicator-color: transparent;
+    --action-button-hover-color: transparent;
+    --action-button-active-color: transparent;
+}
+
+/* Dark mode — pure black bg, white text */
+:root[data-theme-mode="minimal"][data-theme="dark"] {
+    --text-color: #ffffff;
+    --text-color-light1: #aaaaaa;
+    --text-color-light2: #999999;
+    --text-color-light3: #888888;
+    --text-color-light4: #777777;
+    --background-color: #000000;
+    --background-color-light: #000000;
+    --background-color-dark1: #333333;
+
+    --accent-color: #426cf5;
+    --link-color: #426cf5;
+
+    --shadow-color: rgba(0, 0, 0, 0);
+    --shadow-color-light: rgba(0, 0, 0, 0);
+
+    --tag-text-color: #ffffff;
+    --tag-default-background-color: rgba(128, 128, 128, 0.25);
+    --tag-name-background-color: rgba(128, 128, 128, 0.25);
+    --tag-expression-background-color: rgba(120, 140, 160, 0.3);
+    --tag-popular-background-color: rgba(120, 140, 160, 0.3);
+    --tag-frequent-background-color: rgba(128, 128, 128, 0.25);
+    --tag-archaism-background-color: rgba(128, 128, 128, 0.25);
+    --tag-dictionary-background-color: rgba(128, 128, 128, 0.25);
+    --tag-frequency-background-color: rgba(128, 128, 128, 0.25);
+    --tag-part-of-speech-background-color: rgba(128, 128, 128, 0.25);
+    --tag-search-background-color: rgba(128, 128, 128, 0.25);
+    --tag-pronunciation-dictionary-background-color: rgba(128, 128, 128, 0.25);
+
+    --sidebar-background-color: var(--background-color);
+    --sidebar-button-background-color-hover: var(--background-color-dark1);
+    --sidebar-button-background-color-active: var(--background-color-dark1);
+
+    --entry-current-indicator-color: transparent;
+    --action-button-hover-color: transparent;
+    --action-button-active-color: transparent;
+}
+
+/* Structural overrides (same for light and dark) */
+:root[data-theme-mode="minimal"] .entry + .entry {
+    border-top: none;
+}
+
+:root[data-theme-mode="minimal"] button.action-button {
+    background: transparent;
+    border: none;
+    opacity: 0.6;
+    transition: opacity 0.1s ease;
+}
+:root[data-theme-mode="minimal"] button.action-button:hover {
+    opacity: 1;
+}
+
+/* ===== MINIMAL THEME: OUTER CHROME ===== */
+iframe.yomitan-popup[data-theme-mode="minimal"] {
+    --popup-border-radius: 8em;
+    --popup-border-color: #d1d1d6;
+    --popup-box-shadow: none;
+    background-color: #ffffff;
+}
+
+iframe.yomitan-popup[data-theme-mode="minimal"][data-theme="dark"] {
+    --popup-border-color: #3a3a3c;
+    background-color: #000000;
+}

--- a/ext/css/theme-minimal.css
+++ b/ext/css/theme-minimal.css
@@ -111,19 +111,6 @@
     opacity: 1;
 }
 
-/* ===== MINIMAL THEME: OUTER CHROME ===== */
-iframe.yomitan-popup[data-theme-mode='minimal'] {
-    --popup-border-radius: 8em;
-    --popup-border-color: #d1d1d6;
-    --popup-box-shadow: none;
-    background-color: #ffffff;
-}
-
-iframe.yomitan-popup[data-theme-mode='minimal'][data-theme='dark'] {
-    --popup-border-color: #3a3a3c;
-    background-color: #000000;
-}
-
 /* ===== MINIMAL THEME: DICTIONARY NAME LABELS ===== */
 
 /* Hide dictionary tag pills - they're too visually noisy */
@@ -174,4 +161,17 @@ iframe.yomitan-popup[data-theme-mode='minimal'][data-theme='dark'] {
 /* Compact the inflection rule chain container */
 :root[data-theme-mode='minimal'] .inflection-rule-chain {
     margin: 0.15em 0;
+}
+
+/* ===== MINIMAL THEME: OUTER CHROME ===== */
+iframe.yomitan-popup[data-theme-mode='minimal'] {
+    --popup-border-radius: 8em;
+    --popup-border-color: #d1d1d6;
+    --popup-box-shadow: none;
+    background-color: #ffffff;
+}
+
+iframe.yomitan-popup[data-theme-mode='minimal'][data-theme='dark'] {
+    --popup-border-color: #3a3a3c;
+    background-color: #000000;
 }

--- a/ext/css/theme-minimal.css
+++ b/ext/css/theme-minimal.css
@@ -51,9 +51,9 @@
     --sidebar-button-background-color-hover: var(--background-color-dark1);
     --sidebar-button-background-color-active: var(--background-color-dark1);
 
-    --entry-current-indicator-color: transparent;
-    --action-button-hover-color: transparent;
-    --action-button-active-color: transparent;
+    --entry-current-indicator-color: rgba(128, 128, 128, 0.15);
+    --action-button-hover-color: rgba(128, 128, 128, 0.12);
+    --action-button-active-color: rgba(128, 128, 128, 0.12);
 }
 
 /* Dark mode — pure black bg, white text */
@@ -89,9 +89,9 @@
     --sidebar-button-background-color-hover: var(--background-color-dark1);
     --sidebar-button-background-color-active: var(--background-color-dark1);
 
-    --entry-current-indicator-color: transparent;
-    --action-button-hover-color: transparent;
-    --action-button-active-color: transparent;
+    --entry-current-indicator-color: rgba(255, 255, 255, 0.15);
+    --action-button-hover-color: rgba(255, 255, 255, 0.12);
+    --action-button-active-color: rgba(255, 255, 255, 0.12);
 }
 
 /* Structural overrides (same for light and dark) */

--- a/ext/css/theme-minimal.css
+++ b/ext/css/theme-minimal.css
@@ -43,10 +43,10 @@
     --tag-frequent-background-color: rgba(128, 128, 128, 0.2);
     --tag-archaism-background-color: rgba(128, 128, 128, 0.2);
     --tag-dictionary-background-color: rgba(128, 128, 128, 0.2);
-    --tag-frequency-background-color: rgba(128, 128, 128, 0.2);
+    --tag-frequency-background-color: rgba(119, 170, 235, 0.25);
     --tag-part-of-speech-background-color: rgba(128, 128, 128, 0.2);
     --tag-search-background-color: rgba(128, 128, 128, 0.2);
-    --tag-pronunciation-dictionary-background-color: rgba(128, 128, 128, 0.2);
+    --tag-pronunciation-dictionary-background-color: rgba(148, 166, 235, 0.25);
 
     --sidebar-background-color: var(--background-color);
     --sidebar-button-background-color-hover: var(--background-color-dark1);
@@ -82,10 +82,10 @@
     --tag-frequent-background-color: rgba(128, 128, 128, 0.25);
     --tag-archaism-background-color: rgba(128, 128, 128, 0.25);
     --tag-dictionary-background-color: rgba(128, 128, 128, 0.25);
-    --tag-frequency-background-color: rgba(128, 128, 128, 0.25);
+    --tag-frequency-background-color: rgba(119, 170, 235, 0.3);
     --tag-part-of-speech-background-color: rgba(128, 128, 128, 0.25);
     --tag-search-background-color: rgba(128, 128, 128, 0.25);
-    --tag-pronunciation-dictionary-background-color: rgba(128, 128, 128, 0.25);
+    --tag-pronunciation-dictionary-background-color: rgba(148, 166, 235, 0.3);
 
     --sidebar-background-color: var(--background-color);
     --sidebar-button-background-color-hover: var(--background-color-dark1);

--- a/ext/css/theme-minimal.css
+++ b/ext/css/theme-minimal.css
@@ -138,6 +138,7 @@ iframe.yomitan-popup[data-theme-mode='minimal'][data-theme='dark'] {
     font-size: calc(1em * 10 / 14);
     font-weight: 500;
     color: var(--text-color-light2);
-    margin-bottom: 0.35em;
+    margin-top: 0.35em;
+    margin-bottom: 0.6em;
     letter-spacing: 0.02em;
 }

--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -108,6 +108,7 @@
                                     "mainDictionary",
                                     "popupTheme",
                                     "popupOuterTheme",
+                                    "popupThemeMode",
                                     "customPopupCss",
                                     "customPopupOuterCss",
                                     "enableWanakana",
@@ -267,6 +268,11 @@
                                         "type": "string",
                                         "enum": ["light", "dark", "browser", "site", "none"],
                                         "default": "site"
+                                    },
+                                    "popupThemeMode": {
+                                        "type": "string",
+                                        "enum": ["minimal", "classic", "eink"],
+                                        "default": "minimal"
                                     },
                                     "customPopupCss": {
                                         "type": "string",

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -676,42 +676,41 @@ export class Popup extends EventDispatcher {
      * Injects the active theme's CSS into the outer chrome (parent page/shadow DOM).
      * Theme CSS files contain both inner and outer selectors; outer selectors
      * (iframe.yomitan-popup) match here, inner selectors are harmless no-ops.
+     * Uses manual DOM manipulation to avoid loadStyle's WebExtension API tracking
+     * which throws on repeated injection with the same ID.
      * @param {string} themeMode
      */
-    async _injectThemeStylesheet(themeMode) {
+    _injectThemeStylesheet(themeMode) {
         const theme = getThemeById(themeMode);
-        if (!theme || !theme.css) {
-            // Remove any previously injected theme stylesheet
-            if (this._shadow !== null) {
-                const existing = this._shadow.querySelector('#yomitan-popup-theme-outer-stylesheet');
-                if (existing) { existing.remove(); }
-            }
-            return;
-        }
 
-        /** @type {'code'|'file'|'file-content'} */
-        let fileType = 'file';
-        let useWebExtensionApi = true;
-        let parentNode = null;
+        // Remove any previously injected theme stylesheet
+        const existingId = 'yomitan-popup-theme-outer-stylesheet';
         if (this._shadow !== null) {
-            fileType = 'file-content';
-            useWebExtensionApi = false;
-            parentNode = this._shadow;
-        }
-
-        if (parentNode !== null) {
-            const existing = parentNode.querySelector('#yomitan-popup-theme-outer-stylesheet');
+            const existing = this._shadow.querySelector(`#${existingId}`);
+            if (existing) { existing.remove(); }
+        } else {
+            const existing = document.querySelector(`#${existingId}`);
             if (existing) { existing.remove(); }
         }
 
-        await loadStyle(
-            this._application,
-            'yomitan-popup-theme-outer-stylesheet',
-            fileType,
-            theme.css,
-            useWebExtensionApi,
-            parentNode,
-        );
+        if (!theme || !theme.css) {
+            return;
+        }
+
+        const link = document.createElement('link');
+        link.id = existingId;
+        link.rel = 'stylesheet';
+        link.type = 'text/css';
+        link.href = theme.css;
+
+        if (this._shadow !== null) {
+            this._shadow.appendChild(link);
+        } else {
+            const head = document.head;
+            if (head !== null) {
+                head.appendChild(link);
+            }
+        }
     }
 
     /**
@@ -1179,7 +1178,7 @@ export class Popup extends EventDispatcher {
             this._themeController.outerTheme = this._themeController.theme;
         }
         this._themeController.themeMode = general.popupThemeMode;
-        await this._injectThemeStylesheet(general.popupThemeMode);
+        this._injectThemeStylesheet(general.popupThemeMode);
         this._initialWidth = general.popupWidth;
         this._initialHeight = general.popupHeight;
         this._horizontalOffset = general.popupHorizontalOffset;

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -687,10 +687,11 @@ export class Popup extends EventDispatcher {
             useWebExtensionApi = false;
             parentNode = this._shadow;
         }
-        if (parentNode === null) { return; }
-        const existing = parentNode.querySelector('#yomitan-popup-theme-outer-stylesheet');
-        if (existing) {
-            existing.remove();
+        if (parentNode !== null) {
+            const existing = parentNode.querySelector('#yomitan-popup-theme-outer-stylesheet');
+            if (existing) {
+                existing.remove();
+            }
         }
         if (theme && theme.css) {
             await loadStyle(

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -24,7 +24,6 @@ import {ExtensionError} from '../core/extension-error.js';
 import {safePerformance} from '../core/safe-performance.js';
 import {deepEqual} from '../core/utilities.js';
 import {addFullscreenChangeEventListener, computeZoomScale, convertRectZoomCoordinates, getFullscreenElement} from '../dom/document-util.js';
-import {getThemeById} from '../data/theme-registry.js';
 import {loadStyle} from '../dom/style-util.js';
 import {checkPopupPreviewURL} from '../pages/settings/popup-preview-controller.js';
 import {ThemeController} from './theme-controller.js';
@@ -673,39 +672,6 @@ export class Popup extends EventDispatcher {
     }
 
     /**
-     * Injects the active theme's CSS into the outer chrome.
-     * @param {string} themeMode
-     */
-    async _injectThemeStylesheet(themeMode) {
-        const theme = getThemeById(themeMode);
-        /** @type {'code'|'file'|'file-content'} */
-        let fileType = 'file';
-        let useWebExtensionApi = true;
-        let parentNode = null;
-        if (this._shadow !== null) {
-            fileType = 'file-content';
-            useWebExtensionApi = false;
-            parentNode = this._shadow;
-        }
-        if (parentNode !== null) {
-            const existing = parentNode.querySelector('#yomitan-popup-theme-outer-stylesheet');
-            if (existing) {
-                existing.remove();
-            }
-        }
-        if (theme && theme.css) {
-            await loadStyle(
-                this._application,
-                'yomitan-popup-theme-outer-stylesheet',
-                fileType,
-                theme.css,
-                useWebExtensionApi,
-                parentNode,
-            );
-        }
-    }
-
-    /**
      * @param {boolean} observe
      */
     _observeFullscreen(observe) {
@@ -1169,7 +1135,6 @@ export class Popup extends EventDispatcher {
         if (this._themeController.outerTheme === 'site' && this._themeController.siteOverride && ['dark', 'light'].includes(this._themeController.theme)) {
             this._themeController.outerTheme = this._themeController.theme;
         }
-        await this._injectThemeStylesheet(general.popupThemeMode);
         this._themeController.themeMode = general.popupThemeMode;
         this._initialWidth = general.popupWidth;
         this._initialHeight = general.popupHeight;

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -676,11 +676,10 @@ export class Popup extends EventDispatcher {
      * Injects the active theme's CSS into the outer chrome (parent page/shadow DOM).
      * Theme CSS files contain both inner and outer selectors; outer selectors
      * (iframe.yomitan-popup) match here, inner selectors are harmless no-ops.
-     * Uses manual DOM manipulation to avoid loadStyle's WebExtension API tracking
-     * which throws on repeated injection with the same ID.
      * @param {string} themeMode
+     * @returns {Promise<void>}
      */
-    _injectThemeStylesheet(themeMode) {
+    async _injectThemeStylesheet(themeMode) {
         const theme = getThemeById(themeMode);
 
         // Remove any previously injected theme stylesheet
@@ -697,19 +696,10 @@ export class Popup extends EventDispatcher {
             return;
         }
 
-        const link = document.createElement('link');
-        link.id = existingId;
-        link.rel = 'stylesheet';
-        link.type = 'text/css';
-        link.href = theme.css;
-
-        if (this._shadow !== null) {
-            this._shadow.appendChild(link);
-        } else {
-            const head = document.head;
-            if (head !== null) {
-                head.appendChild(link);
-            }
+        const parentNode = this._shadow !== null ? this._shadow : null;
+        const styleNode = await loadStyle(this._application, existingId, 'file-content', theme.css, false, parentNode);
+        if (styleNode) {
+            styleNode.id = existingId;
         }
     }
 
@@ -1178,7 +1168,7 @@ export class Popup extends EventDispatcher {
             this._themeController.outerTheme = this._themeController.theme;
         }
         this._themeController.themeMode = general.popupThemeMode;
-        this._injectThemeStylesheet(general.popupThemeMode);
+        await this._injectThemeStylesheet(general.popupThemeMode);
         this._initialWidth = general.popupWidth;
         this._initialHeight = general.popupHeight;
         this._horizontalOffset = general.popupHorizontalOffset;

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -687,22 +687,15 @@ export class Popup extends EventDispatcher {
      */
     async _injectThemeStylesheet(themeMode) {
         const theme = getThemeById(themeMode);
-
-        // Remove any previously injected theme stylesheet
         const existingId = 'yomitan-popup-theme-outer-stylesheet';
-        if (this._shadow !== null) {
-            const existing = this._shadow.querySelector(`#${existingId}`);
-            if (existing) { existing.remove(); }
-        } else {
-            const existing = document.querySelector(`#${existingId}`);
-            if (existing) { existing.remove(); }
-        }
+        const parentNode = this._shadow !== null ? this._shadow : null;
 
         if (!theme || !theme.css) {
+            const existing = (this._shadow !== null ? this._shadow : document).querySelector(`#${existingId}`);
+            if (existing) { existing.remove(); }
             return;
         }
 
-        const parentNode = this._shadow !== null ? this._shadow : null;
         const styleNode = await loadStyle(this._application, existingId, 'file-content', theme.css, false, parentNode);
         if (styleNode) {
             styleNode.id = existingId;
@@ -1174,7 +1167,12 @@ export class Popup extends EventDispatcher {
             this._themeController.outerTheme = this._themeController.theme;
         }
         this._themeController.themeMode = general.popupThemeMode;
-        await this._injectThemeStylesheet(general.popupThemeMode);
+        if (general.popupThemeMode === 'eink') {
+            this._themeController.outerTheme = 'none';
+        }
+        if (this._injectPromiseComplete) {
+            await this._injectThemeStylesheet(general.popupThemeMode);
+        }
         this._initialWidth = general.popupWidth;
         this._initialHeight = general.popupHeight;
         this._horizontalOffset = general.popupHorizontalOffset;

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -650,6 +650,12 @@ export class Popup extends EventDispatcher {
         }
 
         try {
+            await this._injectThemeStylesheet(this._themeController.themeMode);
+        } catch (e) {
+            // NOP
+        }
+
+        try {
             await this.setCustomOuterCss(this._customOuterCss, true);
         } catch (e) {
             // NOP

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -24,6 +24,7 @@ import {ExtensionError} from '../core/extension-error.js';
 import {safePerformance} from '../core/safe-performance.js';
 import {deepEqual} from '../core/utilities.js';
 import {addFullscreenChangeEventListener, computeZoomScale, convertRectZoomCoordinates, getFullscreenElement} from '../dom/document-util.js';
+import {getThemeById} from '../data/theme-registry.js';
 import {loadStyle} from '../dom/style-util.js';
 import {checkPopupPreviewURL} from '../pages/settings/popup-preview-controller.js';
 import {ThemeController} from './theme-controller.js';
@@ -672,6 +673,38 @@ export class Popup extends EventDispatcher {
     }
 
     /**
+     * Injects the active theme's CSS into the outer chrome.
+     * @param {string} themeMode
+     */
+    async _injectThemeStylesheet(themeMode) {
+        const theme = getThemeById(themeMode);
+        /** @type {'code'|'file'|'file-content'} */
+        let fileType = 'file';
+        let useWebExtensionApi = true;
+        let parentNode = null;
+        if (this._shadow !== null) {
+            fileType = 'file-content';
+            useWebExtensionApi = false;
+            parentNode = this._shadow;
+        }
+        if (parentNode === null) { return; }
+        const existing = parentNode.querySelector('#yomitan-popup-theme-outer-stylesheet');
+        if (existing) {
+            existing.remove();
+        }
+        if (theme && theme.css) {
+            await loadStyle(
+                this._application,
+                'yomitan-popup-theme-outer-stylesheet',
+                fileType,
+                theme.css,
+                useWebExtensionApi,
+                parentNode,
+            );
+        }
+    }
+
+    /**
      * @param {boolean} observe
      */
     _observeFullscreen(observe) {
@@ -1135,6 +1168,8 @@ export class Popup extends EventDispatcher {
         if (this._themeController.outerTheme === 'site' && this._themeController.siteOverride && ['dark', 'light'].includes(this._themeController.theme)) {
             this._themeController.outerTheme = this._themeController.theme;
         }
+        await this._injectThemeStylesheet(general.popupThemeMode);
+        this._themeController.themeMode = general.popupThemeMode;
         this._initialWidth = general.popupWidth;
         this._initialHeight = general.popupHeight;
         this._horizontalOffset = general.popupHorizontalOffset;

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -27,6 +27,7 @@ import {addFullscreenChangeEventListener, computeZoomScale, convertRectZoomCoord
 import {loadStyle} from '../dom/style-util.js';
 import {checkPopupPreviewURL} from '../pages/settings/popup-preview-controller.js';
 import {ThemeController} from './theme-controller.js';
+import {getThemeById} from '../data/theme-registry.js';
 
 /**
  * This class is the container which hosts the display of search results.
@@ -672,6 +673,48 @@ export class Popup extends EventDispatcher {
     }
 
     /**
+     * Injects the active theme's CSS into the outer chrome (parent page/shadow DOM).
+     * Theme CSS files contain both inner and outer selectors; outer selectors
+     * (iframe.yomitan-popup) match here, inner selectors are harmless no-ops.
+     * @param {string} themeMode
+     */
+    async _injectThemeStylesheet(themeMode) {
+        const theme = getThemeById(themeMode);
+        if (!theme || !theme.css) {
+            // Remove any previously injected theme stylesheet
+            if (this._shadow !== null) {
+                const existing = this._shadow.querySelector('#yomitan-popup-theme-outer-stylesheet');
+                if (existing) { existing.remove(); }
+            }
+            return;
+        }
+
+        /** @type {'code'|'file'|'file-content'} */
+        let fileType = 'file';
+        let useWebExtensionApi = true;
+        let parentNode = null;
+        if (this._shadow !== null) {
+            fileType = 'file-content';
+            useWebExtensionApi = false;
+            parentNode = this._shadow;
+        }
+
+        if (parentNode !== null) {
+            const existing = parentNode.querySelector('#yomitan-popup-theme-outer-stylesheet');
+            if (existing) { existing.remove(); }
+        }
+
+        await loadStyle(
+            this._application,
+            'yomitan-popup-theme-outer-stylesheet',
+            fileType,
+            theme.css,
+            useWebExtensionApi,
+            parentNode,
+        );
+    }
+
+    /**
      * @param {boolean} observe
      */
     _observeFullscreen(observe) {
@@ -1136,6 +1179,7 @@ export class Popup extends EventDispatcher {
             this._themeController.outerTheme = this._themeController.theme;
         }
         this._themeController.themeMode = general.popupThemeMode;
+        await this._injectThemeStylesheet(general.popupThemeMode);
         this._initialWidth = general.popupWidth;
         this._initialHeight = general.popupHeight;
         this._horizontalOffset = general.popupHorizontalOffset;

--- a/ext/js/app/theme-controller.js
+++ b/ext/js/app/theme-controller.js
@@ -31,6 +31,8 @@ export class ThemeController {
         this._theme = 'site';
         /** @type {import("settings.js").PopupOuterTheme} */
         this._outerTheme = 'site';
+        /** @type {import("settings.js").PopupThemeMode} */
+        this._themeMode = 'minimal';
         /** @type {?('dark'|'light')} */
         this._siteTheme = null;
         /** @type {'dark'|'light'} */
@@ -88,6 +90,22 @@ export class ThemeController {
     }
 
     /**
+     * Gets the theme mode.
+     * @type {import("settings.js").PopupThemeMode}
+     */
+    get themeMode() {
+        return this._themeMode;
+    }
+
+    /**
+     * Sets the theme mode.
+     * @param {import("settings.js").PopupThemeMode} value The theme mode to assign.
+     */
+    set themeMode(value) {
+        this._themeMode = value;
+    }
+
+    /**
      * Gets the override value for the site theme.
      * If this value is `null`, the computed value will be used.
      * @type {?('dark'|'light')}
@@ -137,6 +155,7 @@ export class ThemeController {
         data.browserTheme = this._browserTheme;
         data.themeRaw = this._theme;
         data.outerThemeRaw = this._outerTheme;
+        data.themeMode = this._themeMode;
     }
 
     /**

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -588,6 +588,7 @@ export class OptionsUtil {
             this._updateVersion74,
             this._updateVersion75,
             this._updateVersion76,
+            this._updateVersion77,
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1848,6 +1849,19 @@ export class OptionsUtil {
     async _updateVersion76(options) {
         for (const profile of options.profiles) {
             profile.options.general.popupFullWidthPosition = 'bottom';
+        }
+    }
+
+    /**
+     * - Added general.popupThemeMode.
+     * - Existing users default to 'classic' to preserve current appearance.
+     * @type {import('options-util').UpdateFunction}
+     */
+    _updateVersion77(options) {
+        for (const profile of options.profiles) {
+            if (profile.options?.general && !('popupThemeMode' in profile.options.general)) {
+                profile.options.general.popupThemeMode = 'classic';
+            }
         }
     }
 

--- a/ext/js/data/theme-registry.js
+++ b/ext/js/data/theme-registry.js
@@ -23,20 +23,23 @@ export const themes = [
     {
         id: 'classic',
         label: 'Classic',
+        css: null, /* base CSS is classic; no override file needed */
     },
     {
         id: 'minimal',
         label: 'Minimal',
+        css: '/css/theme-minimal.css',
     },
     {
         id: 'eink',
         label: 'E-Ink',
+        css: '/css/theme-eink.css',
     },
 ];
 
 /**
  * @param {string} themeId
- * @returns {{id: string, label: string} | undefined}
+ * @returns {{id: string, label: string, css: string | null} | undefined}
  */
 export function getThemeById(themeId) {
     return themes.find((t) => t.id === themeId);

--- a/ext/js/data/theme-registry.js
+++ b/ext/js/data/theme-registry.js
@@ -34,13 +34,31 @@ export const themes = [
         id: 'eink',
         label: 'E-Ink',
         css: '/css/theme-eink.css',
+        constraints: {
+            disableShadow: true,
+        },
     },
 ];
 
 /**
  * @param {string} themeId
- * @returns {{id: string, label: string, css: string | null} | undefined}
+ * @returns {{id: string, label: string, css: string | null, constraints?: {disableShadow?: boolean}} | undefined}
  */
 export function getThemeById(themeId) {
     return themes.find((t) => t.id === themeId);
+}
+
+/**
+ * Populates a <select> element with theme options from the registry.
+ * @param {HTMLSelectElement|null} select
+ */
+export function populateThemeModeSelect(select) {
+    if (!select) { return; }
+    select.innerHTML = '';
+    for (const theme of themes) {
+        const option = document.createElement('option');
+        option.value = theme.id;
+        option.textContent = theme.label;
+        select.appendChild(option);
+    }
 }

--- a/ext/js/data/theme-registry.js
+++ b/ext/js/data/theme-registry.js
@@ -23,23 +23,20 @@ export const themes = [
     {
         id: 'classic',
         label: 'Classic',
-        css: null, /* base CSS is classic; no override file needed */
     },
     {
         id: 'minimal',
         label: 'Minimal',
-        css: '/css/theme-minimal.css',
     },
     {
         id: 'eink',
         label: 'E-Ink',
-        css: '/css/theme-eink.css',
     },
 ];
 
 /**
  * @param {string} themeId
- * @returns {{id: string, label: string, css: string | null} | undefined}
+ * @returns {{id: string, label: string} | undefined}
  */
 export function getThemeById(themeId) {
     return themes.find((t) => t.id === themeId);

--- a/ext/js/data/theme-registry.js
+++ b/ext/js/data/theme-registry.js
@@ -1,0 +1,29 @@
+/**
+ * Theme registry — single source of truth for available theme modes.
+ * Adding a theme: add entry here, create CSS file, add to settings enum.
+ */
+export const themes = [
+    {
+        id: 'classic',
+        label: 'Classic',
+        css: null, /* base CSS is classic; no override file needed */
+    },
+    {
+        id: 'minimal',
+        label: 'Minimal',
+        css: '/css/theme-minimal.css',
+    },
+    {
+        id: 'eink',
+        label: 'E-Ink',
+        css: '/css/theme-eink.css',
+    },
+];
+
+/**
+ * @param {string} themeId
+ * @returns {{id: string, label: string, css: string | null} | undefined}
+ */
+export function getThemeById(themeId) {
+    return themes.find((t) => t.id === themeId);
+}

--- a/ext/js/data/theme-registry.js
+++ b/ext/js/data/theme-registry.js
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2024-2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  * Theme registry — single source of truth for available theme modes.
  * Adding a theme: add entry here, create CSS file, add to settings enum.

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -17,7 +17,6 @@
  */
 
 import {ThemeController} from '../app/theme-controller.js';
-import {getThemeById} from '../data/theme-registry.js';
 import {FrameEndpoint} from '../comm/frame-endpoint.js';
 import {extendApiMap, invokeApiMapHandler} from '../core/api-map.js';
 import {DynamicProperty} from '../core/dynamic-property.js';
@@ -1296,7 +1295,6 @@ export class Display extends EventDispatcher {
         } catch (e) {
             log.error(e);
         }
-        await this._loadThemeStylesheet(popupThemeMode);
         this._themeController.theme = popupTheme;
         this._themeController.outerTheme = popupOuterTheme;
         this._themeController.themeMode = popupThemeMode;
@@ -1305,31 +1303,6 @@ export class Display extends EventDispatcher {
         const customCss = this._getCustomCss(options);
         this.setCustomCss(customCss);
         this.setFontOptions(fontFamily, fontSize, lineHeight);
-    }
-
-    /**
-     * Dynamically loads the active theme's CSS file.
-     * @param {string} themeMode
-     */
-    async _loadThemeStylesheet(themeMode) {
-        const theme = getThemeById(themeMode);
-        const existing = document.getElementById('yomitan-theme-stylesheet');
-        if (existing) {
-            existing.remove();
-        }
-        if (theme && theme.css) {
-            const link = document.createElement('link');
-            link.id = 'yomitan-theme-stylesheet';
-            link.rel = 'stylesheet';
-            link.type = 'text/css';
-            link.href = theme.css;
-            document.head.appendChild(link);
-            await new Promise((resolve) => {
-                link.onload = resolve;
-                link.onerror = resolve;
-                setTimeout(resolve, 500);
-            });
-        }
     }
 
     /**

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -534,7 +534,7 @@ export class Display extends EventDispatcher {
         }
 
         if (this._options) {
-            void this._setTheme(this._options);
+            this._setTheme(this._options);
         }
     }
 

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -459,7 +459,7 @@ export class Display extends EventDispatcher {
 
         this._updateHotkeys(options);
         this._updateDocumentOptions(options);
-        await this._setTheme(options);
+        this._setTheme(options);
         this._setStickyHeader(options);
         this._hotkeyHelpController.setOptions(options);
         this._displayGenerator.updateHotkeys();
@@ -1277,7 +1277,7 @@ export class Display extends EventDispatcher {
     /**
      * @param {import('settings').ProfileOptions} options
      */
-    async _setTheme(options) {
+    _setTheme(options) {
         const {general} = options;
         const {popupTheme, popupOuterTheme, popupThemeMode, fontFamily, fontSize, lineHeight} = general;
         /** @type {string} */

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -17,6 +17,7 @@
  */
 
 import {ThemeController} from '../app/theme-controller.js';
+import {getThemeById} from '../data/theme-registry.js';
 import {FrameEndpoint} from '../comm/frame-endpoint.js';
 import {extendApiMap, invokeApiMapHandler} from '../core/api-map.js';
 import {DynamicProperty} from '../core/dynamic-property.js';
@@ -459,7 +460,7 @@ export class Display extends EventDispatcher {
 
         this._updateHotkeys(options);
         this._updateDocumentOptions(options);
-        this._setTheme(options);
+        await this._setTheme(options);
         this._setStickyHeader(options);
         this._hotkeyHelpController.setOptions(options);
         this._displayGenerator.updateHotkeys();
@@ -534,7 +535,7 @@ export class Display extends EventDispatcher {
         }
 
         if (this._options) {
-            this._setTheme(this._options);
+            void this._setTheme(this._options);
         }
     }
 
@@ -1277,9 +1278,9 @@ export class Display extends EventDispatcher {
     /**
      * @param {import('settings').ProfileOptions} options
      */
-    _setTheme(options) {
+    async _setTheme(options) {
         const {general} = options;
-        const {popupTheme, popupOuterTheme, fontFamily, fontSize, lineHeight} = general;
+        const {popupTheme, popupOuterTheme, popupThemeMode, fontFamily, fontSize, lineHeight} = general;
         /** @type {string} */
         let pageType = this._pageType;
         try {
@@ -1295,13 +1296,40 @@ export class Display extends EventDispatcher {
         } catch (e) {
             log.error(e);
         }
+        await this._loadThemeStylesheet(popupThemeMode);
         this._themeController.theme = popupTheme;
         this._themeController.outerTheme = popupOuterTheme;
+        this._themeController.themeMode = popupThemeMode;
         this._themeController.siteOverride = pageType === 'search' || pageType === 'popupPreview';
         this._themeController.updateTheme();
         const customCss = this._getCustomCss(options);
         this.setCustomCss(customCss);
         this.setFontOptions(fontFamily, fontSize, lineHeight);
+    }
+
+    /**
+     * Dynamically loads the active theme's CSS file.
+     * @param {string} themeMode
+     */
+    async _loadThemeStylesheet(themeMode) {
+        const theme = getThemeById(themeMode);
+        const existing = document.getElementById('yomitan-theme-stylesheet');
+        if (existing) {
+            existing.remove();
+        }
+        if (theme && theme.css) {
+            const link = document.createElement('link');
+            link.id = 'yomitan-theme-stylesheet';
+            link.rel = 'stylesheet';
+            link.type = 'text/css';
+            link.href = theme.css;
+            document.head.appendChild(link);
+            await new Promise((resolve) => {
+                link.onload = resolve;
+                link.onerror = resolve;
+                setTimeout(resolve, 500);
+            });
+        }
     }
 
     /**

--- a/ext/js/pages/settings/settings-main.js
+++ b/ext/js/pages/settings/settings-main.js
@@ -198,8 +198,9 @@ await Application.main(true, async (application) => {
 
     /**
      * Updates the UI state based on the selected theme mode.
+     * @param {boolean} [dispatchChange] Whether to dispatch a change event on the shadow select.
      */
-    function updateThemeModeUI() {
+    function updateThemeModeUI(dispatchChange = true) {
         const theme = getThemeById(themeModeSelect?.value ?? '');
         const disableShadow = theme?.constraints?.disableShadow ?? false;
         if (shadowSelect) {
@@ -209,18 +210,22 @@ await Application.main(true, async (application) => {
                 }
                 shadowSelect.value = 'none';
                 shadowSelect.disabled = true;
-                shadowSelect.dispatchEvent(new Event('change', {bubbles: true}));
+                if (dispatchChange) {
+                    shadowSelect.dispatchEvent(new Event('change', {bubbles: true}));
+                }
             } else {
                 shadowSelect.disabled = false;
                 if (previousShadowValue && previousShadowValue !== 'none') {
                     shadowSelect.value = previousShadowValue;
                     previousShadowValue = null;
-                    shadowSelect.dispatchEvent(new Event('change', {bubbles: true}));
+                    if (dispatchChange) {
+                        shadowSelect.dispatchEvent(new Event('change', {bubbles: true}));
+                    }
                 }
             }
         }
     }
 
-    themeModeSelect?.addEventListener('change', updateThemeModeUI);
-    updateThemeModeUI();
+    themeModeSelect?.addEventListener('change', () => updateThemeModeUI(true));
+    updateThemeModeUI(false);
 });

--- a/ext/js/pages/settings/settings-main.js
+++ b/ext/js/pages/settings/settings-main.js
@@ -20,7 +20,7 @@ import {Application} from '../../application.js';
 import {DocumentFocusController} from '../../dom/document-focus-controller.js';
 import {querySelectorNotNull} from '../../dom/query-selector.js';
 import {ExtensionContentController} from '../common/extension-content-controller.js';
-import {themes} from '../../data/theme-registry.js';
+import {getThemeById, populateThemeModeSelect} from '../../data/theme-registry.js';
 import {AnkiController} from './anki-controller.js';
 import {AnkiDeckGeneratorController} from './anki-deck-generator-controller.js';
 import {AnkiTemplatesController} from './anki-templates-controller.js';
@@ -119,15 +119,7 @@ await Application.main(true, async (application) => {
 
     // Generate theme mode dropdown options from registry BEFORE controller init
     const themeModeSelect = /** @type {HTMLSelectElement|null} */ (document.getElementById('theme-mode-select'));
-    if (themeModeSelect) {
-        themeModeSelect.innerHTML = '';
-        for (const theme of themes) {
-            const option = document.createElement('option');
-            option.value = theme.id;
-            option.textContent = theme.label;
-            themeModeSelect.appendChild(option);
-        }
-    }
+    populateThemeModeSelect(themeModeSelect);
 
     const audioController = new AudioController(settingsController, modalController);
     preparePromises.push(audioController.prepare());
@@ -201,28 +193,34 @@ await Application.main(true, async (application) => {
 
     // Theme mode UI state management
     const shadowSelect = /** @type {HTMLSelectElement|null} */ (document.getElementById('shadow-theme-select'));
-    const einkWarning = document.getElementById('eink-warning');
-    const customCssInput = /** @type {HTMLTextAreaElement|null} */ (document.querySelector('[data-setting="general.customPopupCss"]'));
+    /** @type {string|null} */
+    let previousShadowValue = null;
 
     /**
      * Updates the UI state based on the selected theme mode.
      */
     function updateThemeModeUI() {
-        const isEink = themeModeSelect?.value === 'eink';
+        const theme = getThemeById(themeModeSelect?.value ?? '');
+        const disableShadow = theme?.constraints?.disableShadow ?? false;
         if (shadowSelect) {
-            shadowSelect.disabled = isEink;
-            if (isEink) {
+            if (disableShadow) {
+                if (shadowSelect.value !== 'none') {
+                    previousShadowValue = shadowSelect.value;
+                }
                 shadowSelect.value = 'none';
+                shadowSelect.disabled = true;
                 shadowSelect.dispatchEvent(new Event('change', {bubbles: true}));
+            } else {
+                shadowSelect.disabled = false;
+                if (previousShadowValue && previousShadowValue !== 'none') {
+                    shadowSelect.value = previousShadowValue;
+                    previousShadowValue = null;
+                    shadowSelect.dispatchEvent(new Event('change', {bubbles: true}));
+                }
             }
-        }
-        if (einkWarning) {
-            const hasCustomCss = (customCssInput?.value?.trim().length ?? 0) > 0;
-            einkWarning.style.display = (isEink && hasCustomCss) ? 'block' : 'none';
         }
     }
 
     themeModeSelect?.addEventListener('change', updateThemeModeUI);
-    customCssInput?.addEventListener('input', updateThemeModeUI);
     updateThemeModeUI();
 });

--- a/ext/js/pages/settings/settings-main.js
+++ b/ext/js/pages/settings/settings-main.js
@@ -185,4 +185,32 @@ await Application.main(true, async (application) => {
     await Promise.all(preparePromises);
 
     document.documentElement.dataset.loaded = 'true';
+
+    // Theme mode UI state management
+    const themeModeSelect = /** @type {HTMLSelectElement|null} */ (document.getElementById('theme-mode-select'));
+    const shadowSelect = /** @type {HTMLSelectElement|null} */ (document.getElementById('shadow-theme-select'));
+    const einkWarning = document.getElementById('eink-warning');
+    const customCssInput = /** @type {HTMLTextAreaElement|null} */ (document.querySelector('[data-setting="general.customPopupCss"]'));
+
+    /**
+     * Updates the UI state based on the selected theme mode.
+     */
+    function updateThemeModeUI() {
+        const isEink = themeModeSelect?.value === 'eink';
+        if (shadowSelect) {
+            shadowSelect.disabled = isEink;
+            if (isEink) {
+                shadowSelect.value = 'none';
+                shadowSelect.dispatchEvent(new Event('change', {bubbles: true}));
+            }
+        }
+        if (einkWarning) {
+            const hasCustomCss = (customCssInput?.value?.trim().length ?? 0) > 0;
+            einkWarning.style.display = (isEink && hasCustomCss) ? 'block' : 'none';
+        }
+    }
+
+    themeModeSelect?.addEventListener('change', updateThemeModeUI);
+    customCssInput?.addEventListener('input', updateThemeModeUI);
+    updateThemeModeUI();
 });

--- a/ext/js/pages/settings/settings-main.js
+++ b/ext/js/pages/settings/settings-main.js
@@ -117,6 +117,18 @@ await Application.main(true, async (application) => {
     const genericSettingController = new GenericSettingController(settingsController);
     preparePromises.push(setupGenericSettingController(genericSettingController));
 
+    // Generate theme mode dropdown options from registry BEFORE controller init
+    const themeModeSelect = /** @type {HTMLSelectElement|null} */ (document.getElementById('theme-mode-select'));
+    if (themeModeSelect) {
+        themeModeSelect.innerHTML = '';
+        for (const theme of themes) {
+            const option = document.createElement('option');
+            option.value = theme.id;
+            option.textContent = theme.label;
+            themeModeSelect.appendChild(option);
+        }
+    }
+
     const audioController = new AudioController(settingsController, modalController);
     preparePromises.push(audioController.prepare());
 
@@ -188,21 +200,9 @@ await Application.main(true, async (application) => {
     document.documentElement.dataset.loaded = 'true';
 
     // Theme mode UI state management
-    const themeModeSelect = /** @type {HTMLSelectElement|null} */ (document.getElementById('theme-mode-select'));
     const shadowSelect = /** @type {HTMLSelectElement|null} */ (document.getElementById('shadow-theme-select'));
     const einkWarning = document.getElementById('eink-warning');
     const customCssInput = /** @type {HTMLTextAreaElement|null} */ (document.querySelector('[data-setting="general.customPopupCss"]'));
-
-    // Generate theme mode dropdown options from registry
-    if (themeModeSelect) {
-        themeModeSelect.innerHTML = '';
-        for (const theme of themes) {
-            const option = document.createElement('option');
-            option.value = theme.id;
-            option.textContent = theme.label;
-            themeModeSelect.appendChild(option);
-        }
-    }
 
     /**
      * Updates the UI state based on the selected theme mode.

--- a/ext/js/pages/settings/settings-main.js
+++ b/ext/js/pages/settings/settings-main.js
@@ -20,6 +20,7 @@ import {Application} from '../../application.js';
 import {DocumentFocusController} from '../../dom/document-focus-controller.js';
 import {querySelectorNotNull} from '../../dom/query-selector.js';
 import {ExtensionContentController} from '../common/extension-content-controller.js';
+import {themes} from '../../data/theme-registry.js';
 import {AnkiController} from './anki-controller.js';
 import {AnkiDeckGeneratorController} from './anki-deck-generator-controller.js';
 import {AnkiTemplatesController} from './anki-templates-controller.js';
@@ -191,6 +192,17 @@ await Application.main(true, async (application) => {
     const shadowSelect = /** @type {HTMLSelectElement|null} */ (document.getElementById('shadow-theme-select'));
     const einkWarning = document.getElementById('eink-warning');
     const customCssInput = /** @type {HTMLTextAreaElement|null} */ (document.querySelector('[data-setting="general.customPopupCss"]'));
+
+    // Generate theme mode dropdown options from registry
+    if (themeModeSelect) {
+        themeModeSelect.innerHTML = '';
+        for (const theme of themes) {
+            const option = document.createElement('option');
+            option.value = theme.id;
+            option.textContent = theme.label;
+            themeModeSelect.appendChild(option);
+        }
+    }
 
     /**
      * Updates the UI state based on the selected theme mode.

--- a/ext/js/pages/welcome-main.js
+++ b/ext/js/pages/welcome-main.js
@@ -20,6 +20,7 @@ import {Application} from '../application.js';
 import {DocumentFocusController} from '../dom/document-focus-controller.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
 import {ExtensionContentController} from './common/extension-content-controller.js';
+import {themes} from '../data/theme-registry.js';
 import {DataTransmissionConsentController} from './settings/data-transmission-consent-controller.js';
 import {DictionaryController} from './settings/dictionary-controller.js';
 import {DictionaryImportController} from './settings/dictionary-import-controller.js';
@@ -116,4 +117,16 @@ await Application.main(true, async (application) => {
     await Promise.all(preparePromises);
 
     document.documentElement.dataset.loaded = 'true';
+
+    // Generate theme mode dropdown options from registry
+    const themeModeSelect = /** @type {HTMLSelectElement|null} */ (document.getElementById('theme-mode-select'));
+    if (themeModeSelect) {
+        themeModeSelect.innerHTML = '';
+        for (const theme of themes) {
+            const option = document.createElement('option');
+            option.value = theme.id;
+            option.textContent = theme.label;
+            themeModeSelect.appendChild(option);
+        }
+    }
 });

--- a/ext/js/pages/welcome-main.js
+++ b/ext/js/pages/welcome-main.js
@@ -20,7 +20,7 @@ import {Application} from '../application.js';
 import {DocumentFocusController} from '../dom/document-focus-controller.js';
 import {querySelectorNotNull} from '../dom/query-selector.js';
 import {ExtensionContentController} from './common/extension-content-controller.js';
-import {themes} from '../data/theme-registry.js';
+import {populateThemeModeSelect} from '../data/theme-registry.js';
 import {DataTransmissionConsentController} from './settings/data-transmission-consent-controller.js';
 import {DictionaryController} from './settings/dictionary-controller.js';
 import {DictionaryImportController} from './settings/dictionary-import-controller.js';
@@ -95,15 +95,7 @@ await Application.main(true, async (application) => {
 
     // Generate theme mode dropdown options from registry BEFORE controller init
     const themeModeSelect = /** @type {HTMLSelectElement|null} */ (document.getElementById('theme-mode-select'));
-    if (themeModeSelect) {
-        themeModeSelect.innerHTML = '';
-        for (const theme of themes) {
-            const option = document.createElement('option');
-            option.value = theme.id;
-            option.textContent = theme.label;
-            themeModeSelect.appendChild(option);
-        }
-    }
+    populateThemeModeSelect(themeModeSelect);
 
     const dictionaryController = new DictionaryController(settingsController, modalController, statusFooter);
     preparePromises.push(dictionaryController.prepare());

--- a/ext/js/pages/welcome-main.js
+++ b/ext/js/pages/welcome-main.js
@@ -93,6 +93,18 @@ await Application.main(true, async (application) => {
     const genericSettingController = new GenericSettingController(settingsController);
     preparePromises.push(setupGenericSettingsController(genericSettingController));
 
+    // Generate theme mode dropdown options from registry BEFORE controller init
+    const themeModeSelect = /** @type {HTMLSelectElement|null} */ (document.getElementById('theme-mode-select'));
+    if (themeModeSelect) {
+        themeModeSelect.innerHTML = '';
+        for (const theme of themes) {
+            const option = document.createElement('option');
+            option.value = theme.id;
+            option.textContent = theme.label;
+            themeModeSelect.appendChild(option);
+        }
+    }
+
     const dictionaryController = new DictionaryController(settingsController, modalController, statusFooter);
     preparePromises.push(dictionaryController.prepare());
 
@@ -117,16 +129,4 @@ await Application.main(true, async (application) => {
     await Promise.all(preparePromises);
 
     document.documentElement.dataset.loaded = 'true';
-
-    // Generate theme mode dropdown options from registry
-    const themeModeSelect = /** @type {HTMLSelectElement|null} */ (document.getElementById('theme-mode-select'));
-    if (themeModeSelect) {
-        themeModeSelect.innerHTML = '';
-        for (const theme of themes) {
-            const option = document.createElement('option');
-            option.value = theme.id;
-            option.textContent = theme.label;
-            themeModeSelect.appendChild(option);
-        }
-    }
 });

--- a/ext/popup-preview.html
+++ b/ext/popup-preview.html
@@ -11,6 +11,9 @@
     <link rel="icon" type="image/png" href="/images/icon48.png" sizes="48x48">
     <link rel="icon" type="image/png" href="/images/icon64.png" sizes="64x64">
     <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
+    <!-- Preload theme CSS to avoid FOUC — actual injection is dynamic -->
+    <link rel="preload" as="style" href="/css/theme-minimal.css">
+    <link rel="preload" as="style" href="/css/theme-eink.css">
     <link rel="stylesheet" type="text/css" href="/css/popup-preview.css">
     <link rel="stylesheet" type="text/css" href="/css/popup-outer.css" id="popup-outer-css">
     <script src="/js/pages/settings/popup-preview-frame-main.js" type="module"></script>

--- a/ext/popup-preview.html
+++ b/ext/popup-preview.html
@@ -11,9 +11,9 @@
     <link rel="icon" type="image/png" href="/images/icon48.png" sizes="48x48">
     <link rel="icon" type="image/png" href="/images/icon64.png" sizes="64x64">
     <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
-    <!-- Preload theme CSS to avoid FOUC — actual injection is dynamic -->
-    <link rel="preload" as="style" href="/css/theme-minimal.css">
-    <link rel="preload" as="style" href="/css/theme-eink.css">
+    <!-- Theme CSS files — data-theme-mode attribute controls which rules apply -->
+    <link rel="stylesheet" type="text/css" href="/css/theme-minimal.css">
+    <link rel="stylesheet" type="text/css" href="/css/theme-eink.css">
     <link rel="stylesheet" type="text/css" href="/css/popup-preview.css">
     <link rel="stylesheet" type="text/css" href="/css/popup-outer.css" id="popup-outer-css">
     <script src="/js/pages/settings/popup-preview-frame-main.js" type="module"></script>

--- a/ext/popup.html
+++ b/ext/popup.html
@@ -11,9 +11,9 @@
     <link rel="icon" type="image/png" href="/images/icon48.png" sizes="48x48">
     <link rel="icon" type="image/png" href="/images/icon64.png" sizes="64x64">
     <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
-    <!-- Preload theme CSS to avoid FOUC — actual injection is dynamic -->
-    <link rel="preload" as="style" href="/css/theme-minimal.css">
-    <link rel="preload" as="style" href="/css/theme-eink.css">
+    <!-- Theme CSS files — data-theme-mode attribute controls which rules apply -->
+    <link rel="stylesheet" type="text/css" href="/css/theme-minimal.css">
+    <link rel="stylesheet" type="text/css" href="/css/theme-eink.css">
     <link rel="stylesheet" type="text/css" href="/css/material.css">
     <link rel="stylesheet" type="text/css" href="/css/display.css">
     <link rel="stylesheet" type="text/css" href="/css/display-pronunciation.css">

--- a/ext/popup.html
+++ b/ext/popup.html
@@ -11,6 +11,9 @@
     <link rel="icon" type="image/png" href="/images/icon48.png" sizes="48x48">
     <link rel="icon" type="image/png" href="/images/icon64.png" sizes="64x64">
     <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
+    <!-- Preload theme CSS to avoid FOUC — actual injection is dynamic -->
+    <link rel="preload" as="style" href="/css/theme-minimal.css">
+    <link rel="preload" as="style" href="/css/theme-eink.css">
     <link rel="stylesheet" type="text/css" href="/css/material.css">
     <link rel="stylesheet" type="text/css" href="/css/display.css">
     <link rel="stylesheet" type="text/css" href="/css/display-pronunciation.css">

--- a/ext/search.html
+++ b/ext/search.html
@@ -11,9 +11,9 @@
     <link rel="icon" type="image/png" href="/images/icon48.png" sizes="48x48">
     <link rel="icon" type="image/png" href="/images/icon64.png" sizes="64x64">
     <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
-    <!-- Preload theme CSS to avoid FOUC — actual injection is dynamic -->
-    <link rel="preload" as="style" href="/css/theme-minimal.css">
-    <link rel="preload" as="style" href="/css/theme-eink.css">
+    <!-- Theme CSS files — data-theme-mode attribute controls which rules apply -->
+    <link rel="stylesheet" type="text/css" href="/css/theme-minimal.css">
+    <link rel="stylesheet" type="text/css" href="/css/theme-eink.css">
     <link rel="stylesheet" type="text/css" href="/css/material.css">
     <link rel="stylesheet" type="text/css" href="/css/display.css">
     <link rel="stylesheet" type="text/css" href="/css/display-pronunciation.css">

--- a/ext/search.html
+++ b/ext/search.html
@@ -11,6 +11,9 @@
     <link rel="icon" type="image/png" href="/images/icon48.png" sizes="48x48">
     <link rel="icon" type="image/png" href="/images/icon64.png" sizes="64x64">
     <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
+    <!-- Preload theme CSS to avoid FOUC — actual injection is dynamic -->
+    <link rel="preload" as="style" href="/css/theme-minimal.css">
+    <link rel="preload" as="style" href="/css/theme-eink.css">
     <link rel="stylesheet" type="text/css" href="/css/material.css">
     <link rel="stylesheet" type="text/css" href="/css/display.css">
     <link rel="stylesheet" type="text/css" href="/css/display-pronunciation.css">

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -838,11 +838,7 @@
                 <div class="settings-item-group">
                     <div class="settings-item-group-item">
                         <div class="settings-item-group-item-label">Mode</div>
-                        <select data-setting="general.popupThemeMode" class="short-width short-height" id="theme-mode-select">
-                            <option value="minimal">Minimal</option>
-                            <option value="classic">Classic</option>
-                            <option value="eink">E-Ink</option>
-                        </select>
+                        <select data-setting="general.popupThemeMode" class="short-width short-height" id="theme-mode-select"></select>
                     </div>
                     <div class="settings-item-group-item">
                         <div class="settings-item-group-item-label">Body</div>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -860,9 +860,7 @@
                         </select>
                     </div>
                 </div>
-                <div id="eink-warning" class="settings-item-warning" style="display: none; color: #c62828; font-size: 0.85em; margin-top: 0.5em;">
-                    E-Ink mode forces pure black/white and disables shadows. Custom CSS may not apply as expected.
-                </div>
+
             </div>
         </div></div>
         <div class="settings-item">

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -837,6 +837,14 @@
             <div class="settings-item-right">
                 <div class="settings-item-group">
                     <div class="settings-item-group-item">
+                        <div class="settings-item-group-item-label">Mode</div>
+                        <select data-setting="general.popupThemeMode" class="short-width short-height" id="theme-mode-select">
+                            <option value="minimal">Minimal</option>
+                            <option value="classic">Classic</option>
+                            <option value="eink">E-Ink</option>
+                        </select>
+                    </div>
+                    <div class="settings-item-group-item">
                         <div class="settings-item-group-item-label">Body</div>
                         <select data-setting="general.popupTheme" class="short-width short-height">
                             <option value="site">Auto</option>
@@ -847,7 +855,7 @@
                     </div>
                     <div class="settings-item-group-item">
                         <div class="settings-item-group-item-label">Shadow</div>
-                        <select data-setting="general.popupOuterTheme" class="short-width short-height">
+                        <select data-setting="general.popupOuterTheme" class="short-width short-height" id="shadow-theme-select">
                             <option value="site">Auto</option>
                             <option value="light">Light</option>
                             <option value="dark">Dark</option>
@@ -855,6 +863,9 @@
                             <option value="none">None</option>
                         </select>
                     </div>
+                </div>
+                <div id="eink-warning" class="settings-item-warning" style="display: none; color: #c62828; font-size: 0.85em; margin-top: 0.5em;">
+                    E-Ink mode forces pure black/white and disables shadows. Custom CSS may not apply as expected.
                 </div>
             </div>
         </div></div>

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -185,11 +185,7 @@
                 <div class="settings-item-group">
                     <div class="settings-item-group-item">
                         <div class="settings-item-group-item-label">Mode</div>
-                        <select data-setting="general.popupThemeMode" class="short-width">
-                            <option value="minimal">Minimal</option>
-                            <option value="classic">Classic</option>
-                            <option value="eink">E-Ink</option>
-                        </select>
+                        <select data-setting="general.popupThemeMode" class="short-width" id="theme-mode-select"></select>
                     </div>
                     <div class="settings-item-group-item">
                         <div class="settings-item-group-item-label">Body</div>

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -182,12 +182,25 @@
                 <div class="settings-item-description">Adjust the style of Yomitan.</div>
             </div>
             <div class="settings-item-right">
-                <select data-setting="general.popupTheme" class="short-width">
-                    <option value="site">Auto</option>
-                    <option value="light">Light</option>
-                    <option value="dark">Dark</option>
-                    <option value="browser">Browser</option>
-                </select>
+                <div class="settings-item-group">
+                    <div class="settings-item-group-item">
+                        <div class="settings-item-group-item-label">Mode</div>
+                        <select data-setting="general.popupThemeMode" class="short-width">
+                            <option value="minimal">Minimal</option>
+                            <option value="classic">Classic</option>
+                            <option value="eink">E-Ink</option>
+                        </select>
+                    </div>
+                    <div class="settings-item-group-item">
+                        <div class="settings-item-group-item-label">Body</div>
+                        <select data-setting="general.popupTheme" class="short-width">
+                            <option value="site">Auto</option>
+                            <option value="light">Light</option>
+                            <option value="dark">Dark</option>
+                            <option value="browser">Browser</option>
+                        </select>
+                    </div>
+                </div>
             </div>
         </div></div>
         <a href="/settings.html" rel="noopener" class="settings-item settings-item-button"><div class="settings-item-inner">

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "test:static-analysis": "npm run test:js && npm run test:ts && npm run test:css && npm run test:html && npm run test:md",
         "test:ts": "npm run test:ts:main && npm run test:ts:dev && npm run test:ts:test && npm run test:ts:bench",
         "//END-WARNING": "",
-        "test:js": "npx eslint . --ignore-pattern '**/*.json'",
+        "test:js": "npx eslint . --ignore-pattern '**/*.json' --ignore-pattern '**/*.jsonc'",
         "test:json": "npm run test:json:format && npm run test:json:types",
         "test:json:format": "npx eslint '**/*.json'",
         "test:json:types": "vitest run --config test/data/vitest.json.config.json",

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -296,6 +296,7 @@ function createProfileOptionsUpdatedTestData1() {
             mainDictionary: '',
             popupTheme: 'light',
             popupOuterTheme: 'light',
+            popupThemeMode: 'classic',
             customPopupCss: '',
             customPopupOuterCss: '',
             enableWanakana: true,
@@ -707,7 +708,7 @@ function createOptionsUpdatedTestData1() {
             },
         ],
         profileCurrent: 0,
-        version: 76,
+        version: 77,
         global: {
             database: {
                 prefixWildcardsSupported: false,

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -135,6 +135,7 @@ export type GeneralOptions = {
     mainDictionary: string;
     popupTheme: PopupTheme;
     popupOuterTheme: PopupOuterTheme;
+    popupThemeMode: PopupThemeMode;
     customPopupCss: string;
     customPopupOuterCss: string;
     enableWanakana: boolean;
@@ -409,6 +410,8 @@ export type GlossaryLayoutMode = 'default' | 'compact' | 'compact-popup-anki';
 export type PopupTheme = 'light' | 'dark' | 'browser' | 'site';
 
 export type PopupOuterTheme = 'light' | 'dark' | 'browser' | 'site' | 'none';
+
+export type PopupThemeMode = 'minimal' | 'classic' | 'eink';
 
 export type PopupCurrentIndicatorMode = 'none' | 'asterisk' | 'triangle' | 'bar-left' | 'bar-right' | 'dot-left' | 'dot-right';
 


### PR DESCRIPTION
## Summary

This PR introduces a **theme mode system** for Yomitan, allowing users to choose between three visual styles for popups and the search page:

- **Classic** — The existing Yomitan appearance (default for existing users)
- **Minimal** — A cleaner, more subdued aesthetic inspired by Hoshi Reader
- **E-Ink** — High-contrast black/white with no animations, optimized for e-ink displays

## Screenshots

| Minimal | Classic | E-Ink |
| --------- | ------- | ------ |
| <img width="909" height="1618" alt="chrome_遠征_-_Yomitan_Search_-_Google_Chrome_2026-05-24_19-09-01" src="https://github.com/user-attachments/assets/0eaff126-90d4-423b-bfd3-f66bc0c7d1a4" /> | <img width="909" height="1618" alt="chrome_遠征_-_Yomitan_Search_-_Google_Chrome_2026-05-24_19-09-05" src="https://github.com/user-attachments/assets/066d4842-cb05-48e2-b05f-13c3ed09a284" /> | <img width="909" height="1618" alt="chrome_遠征_-_Yomitan_Search_-_Google_Chrome_2026-05-24_19-09-10" src="https://github.com/user-attachments/assets/13a7ec78-4413-413b-bd7d-0afbffbe71f9" /> | 


## Architecture

### Additive CSS with `data-theme-mode`

Themes are implemented as **additive CSS overrides** on top of the base Classic theme:

- Base styles live in `display.css`, `material.css`, etc. (Classic is the default)
- Each theme has its own CSS file (`theme-minimal.css`, `theme-eink.css`)
- Theme CSS uses `:root[data-theme-mode='...']` selectors — only the active theme's rules match
- All theme files are loaded statically via `<link>` tags; the `data-theme-mode` attribute on `<html>` controls activation

### Dual-context loading

Each theme CSS file contains selectors for **both** rendering contexts:

- **Inner** (`:root[data-theme-mode='...']`) — styles content inside the popup iframe, loaded statically
- **Outer** (`iframe.yomitan-popup[data-theme-mode='...']`) — styles the iframe element itself (borders, shadows, radius), injected dynamically by `popup.js` into the parent page's shadow DOM

This means one file per theme, loaded in both contexts. Selectors that don't match are harmless no-ops.

### Registry-driven

`ext/js/data/theme-registry.js` is the single source of truth:

```js
export const themes = [
    { id: 'classic', label: 'Classic', css: null },
    { id: 'minimal', label: 'Minimal', css: '/css/theme-minimal.css' },
    { id: 'eink', label: 'E-Ink', css: '/css/theme-eink.css' },
];
```

The registry drives:
- Dropdown `<option>` generation in Settings and Welcome pages
- Outer chrome CSS injection in `popup.js`

**Adding a new theme requires only 4 steps:**
1. Create `theme-new.css` (inner + outer selectors)
2. Add `<link>` to `popup.html`, `search.html`, `popup-preview.html`
3. Add entry to `theme-registry.js`
4. Add to schema enum + TypeScript union type

## Theme Details

### Minimal
- Clean white/black backgrounds with subtle gray accents
- Dictionary name tags converted to text labels
- Inflection chains shown as compact gray pills (no icons)
- Frequency tags use translucent blue accents
- Reduced spacing and visual noise
- No popup shadow, subtle 8em border radius

### E-Ink
- Pure black/white (no grays)
- All transitions and animations stripped
- Tags shown as outlined boxes with no rounding
- No shadows anywhere
- 1px solid borders
- Progress bar animations also disabled

## Settings

New "Mode" selector in **Appearance** settings (and Welcome page):
- Classic / Minimal / E-Ink
- When E-Ink is selected, the Shadow dropdown is disabled (e-ink forces no shadow)

## Migration

Existing users are automatically migrated to **Classic** via options v77 to preserve their current appearance. New installations default to **Minimal**.

## Documentation

Added `docs/theming.md` — a comprehensive guide for creating custom themes.

## Testing

- ✅ `npm run test:fast` — 4,136 tests passed
- ✅ `npm run test:css` — stylelint clean
- ✅ Manual visual verification of all three themes in popup preview
- ✅ Verified theme switching works correctly
- ✅ Verified dropdowns populate correctly from registry

## Files Changed

**Core:**
- `ext/js/data/theme-registry.js` — Theme definitions
- `ext/js/app/theme-controller.js` — `data-theme-mode` attribute management
- `ext/js/app/popup.js` — Outer chrome injection
- `ext/js/display/display.js` — Inner content theme application

**CSS:**
- `ext/css/theme-minimal.css` — Minimal theme overrides
- `ext/css/theme-eink.css` — E-ink theme overrides
- `ext/css/display.css` — CSS variable additions for theming

**Settings:**
- `ext/settings.html` — Theme mode selector
- `ext/welcome.html` — Welcome page theme selector
- `ext/js/pages/settings/settings-main.js` — Dropdown generation, e-ink handling
- `ext/js/pages/welcome-main.js` — Welcome page dropdown generation

**Schema/Types:**
- `ext/data/schemas/options-schema.json` — `popupThemeMode` field
- `types/ext/settings.d.ts` — `PopupThemeMode` type
- `ext/js/data/options-util.js` — v77 migration (default to classic)

**Docs:**
- `docs/theming.md` — Theme creation guide
- `README.md` — Link to theming docs
