### PR TITLE
Fix profile index update to prevent refresh loop

### DIFF
--- a/ext/js/pages/settings/profile-controller.js
+++ b/ext/js/pages/settings/profile-controller.js
@@ -433,7 +433,7 @@ export class ProfileController {
         this._updateProfileSelectOptions();
 
         if (this._settingsController.profileIndex !== profileCurrent) {
-            this._settingsController.profileIndex = profileCurrent;
+            void this.setDefaultProfile(profileCurrent);
         }
 
         /** @type {HTMLSelectElement} */ (this._profileActiveSelect).value = `${profileCurrent}`;

--- a/ext/js/pages/settings/profile-controller.js
+++ b/ext/js/pages/settings/profile-controller.js
@@ -431,7 +431,10 @@ export class ProfileController {
 
         // Update UI
         this._updateProfileSelectOptions();
-        void this.setDefaultProfile(profileCurrent);
+
+        if (this._settingsController.profileIndex !== profileCurrent) {
+            this._settingsController.profileIndex = profileCurrent;
+        }
 
         /** @type {HTMLSelectElement} */ (this._profileActiveSelect).value = `${profileCurrent}`;
 


### PR DESCRIPTION
This fixes https://github.com/yomidevs/yomitan/issues/2415. 

`setDefaultProfile(profileCurrent)` call in `profile-controller.js` was writing `profileCurrent` back to global settings even when it was already the active profile. This seemed to cause a loop when two tabs were open. Fixed by removing the call and instead updating the index variable. Works on Chrome and Firefox.