### PR TITLE
Make rule names consistent + rename conflicting identifier

### DIFF
--- a/ext/js/language/de/german-transforms.js
+++ b/ext/js/language/de/german-transforms.js
@@ -89,13 +89,13 @@ const conditions = {
     v: {
         name: 'Verb',
         isDictionaryForm: true,
-        subConditions: ['vw', 'vs'],
+        subConditions: ['vw', 'vst'],
     },
     vw: {
         name: 'Weak verb',
         isDictionaryForm: true,
     },
-    vs: {
+    vst: {
         name: 'Strong verb',
         isDictionaryForm: true,
     },

--- a/ext/js/language/ko/korean-transforms.js
+++ b/ext/js/language/ko/korean-transforms.js
@@ -19,7 +19,7 @@ import {suffixInflection} from '../language-transforms.js';
 
 const conditions = {
     v: {
-        name: 'Verb or Auxiliary Verb',
+        name: 'Verb',
         isDictionaryForm: true,
         i18n: [
             {
@@ -29,7 +29,7 @@ const conditions = {
         ],
     },
     adj: {
-        name: 'Adjective or Auxiliary Adjective',
+        name: 'Adjective',
         isDictionaryForm: true,
         i18n: [
             {

--- a/ext/js/language/la/latin-transforms.js
+++ b/ext/js/language/la/latin-transforms.js
@@ -30,12 +30,12 @@ const conditions = {
         subConditions: ['ns', 'np'],
     },
     ns: {
-        name: 'Noun, singular',
+        name: 'Noun singular',
         isDictionaryForm: true,
         subConditions: ['n1s', 'n2s', 'n3s', 'n4s', 'n5s'],
     },
     np: {
-        name: 'Noun, plural',
+        name: 'Noun plural',
         isDictionaryForm: true,
         subConditions: ['n1p', 'n2p', 'n3p', 'n4p', 'n5p'],
     },

--- a/ext/js/language/yi/yiddish-transforms.js
+++ b/ext/js/language/yi/yiddish-transforms.js
@@ -72,11 +72,11 @@ const conditions = {
         subConditions: ['np', 'ns'],
     },
     np: {
-        name: 'Noun, plural',
+        name: 'Noun plural',
         isDictionaryForm: false,
     },
     ns: {
-        name: 'Noun, singular',
+        name: 'Noun singular',
         isDictionaryForm: true,
     },
     adj: {


### PR DESCRIPTION
Fixes #2427

I have to admit that I'm not particularly fond of removing the commas, specially for Latin that uses them for other conditions, but it makes sense overall. This I can perfectly revert. The other changes are more relevant.

I can see why you wouldn't want to merge this. Please let me know what you think, I have no issues in closing it.

And I should add that these changes are intended to do a better job with rule identifiers in wty, but that they are definitely not required, and we could do without. It just makes sense to have them in sync.