### PR TITLE
Fix broken link checker root paths

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -25,4 +25,4 @@ jobs:
         with:
           fail: true
           jobSummary: false
-          args: --exclude-path 'node_modules' --verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'
+          args: --exclude-path 'node_modules' --root-dir '${{ github.workspace }}/ext' --verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'

--- a/docs/making-yomitan-dictionaries.md
+++ b/docs/making-yomitan-dictionaries.md
@@ -101,4 +101,4 @@ You can view the tag colors [here](https://github.com/yomidevs/yomitan/blob/48f1
 
 # Community Contributions
 
-If you have any questions, need help, or want to share a new dictionary, feel free to pop in the [Yomitan Discord server](/README.md#yomitan). We're happy to help you get started!
+If you have any questions, need help, or want to share a new dictionary, feel free to pop in the [Yomitan Discord server](../README.md#yomitan). We're happy to help you get started!


### PR DESCRIPTION
## Summary
- Configure lychee with the extension root directory so root-relative links in ext/*.html resolve correctly.
- Change the one Markdown root-relative README link to an explicit relative link so it still resolves with the lychee root directory set to ext/.

## Verification
- Ran npm ci
- Ran npm run license-report:html
- Ran lychee v0.23.0 with the workflow args plus --root-dir "/home/rotmi/.paseo/worktrees/0ngo81oy/sharp-warthog/ext": 470 total, 0 errors