### PR TITLE
Speedup pronunciations retrieval for heavy workflows

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1754,7 +1754,15 @@ export class Backend {
                                     if (src.matchType !== 'exact') { continue; }
                                     validSources.push(src);
                                 }
-                                if (validSources.length > 0) { validHeadwords.push({term: headword.term, reading: headword.reading, sources: validSources, frequencies: dictionaryEntry.frequencies.filter((f) => f.headwordIndex === headword.headwordIndex)}); }
+                                if (validSources.length > 0) {
+                                    validHeadwords.push({
+                                        term: headword.term,
+                                        reading: headword.reading,
+                                        sources: validSources,
+                                        frequencies: dictionaryEntry.frequencies.filter((f) => f.headwordIndex === headword.headwordIndex),
+                                        pronunciations: dictionaryEntry.pronunciations.filter((p) => p.headwordIndex === headword.headwordIndex),
+                                    });
+                                }
                             }
                             if (validHeadwords.length > 0) { trimmedHeadwords.push(validHeadwords); }
                         }

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1722,7 +1722,8 @@ export class Backend {
             const codePoint = /** @type {number} */ (text.codePointAt(i));
             const character = String.fromCodePoint(codePoint);
             const substring = text.substring(i, i + scanLength);
-            const cacheKey = `${optionsContext.index}:${substring}`;
+            const metadataMode = useAllFrequencyDictionaries === true ? 1 : 0;
+            const cacheKey = `${optionsContext.index}:${metadataMode}:${substring}`;
             let cached = this._textParseCache.get(cacheKey);
             if (typeof cached === 'undefined') {
                 const {dictionaryEntries, originalTextLength} = await this._translator.findTerms(

--- a/types/ext/api.d.ts
+++ b/types/ext/api.d.ts
@@ -69,6 +69,7 @@ export type ParseTextSegment = {
         reading: string;
         sources: Dictionary.TermSource[];
         frequencies: Dictionary.TermFrequency[];
+        pronunciations: Dictionary.TermPronunciation[];
     }[][];
 };
 


### PR DESCRIPTION
This is a follow up to #2305 but for `pronunciations` as well. This allows getting the pitch accent efficiently without duplicating work when using the `scanning-parser`. This one is very simple since all the ground work has been done already.

Docs PR: yomidevs/yomitan-api/pull/36