### PR TITLE
Fix LNA issues when using local audio

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -189,6 +189,7 @@ export class Backend {
             ['getLanguageSummaries',         this._onApiGetLanguageSummaries.bind(this)],
             ['heartbeat',                    this._onApiHeartbeat.bind(this)],
             ['forceSync',                    this._onApiForceSync.bind(this)],
+            ['fetchLocalAudioData',          this._onApiFetchLocalAudioData.bind(this)],
         ]);
 
         /** @type {import('api').PmApiMap} */
@@ -1165,6 +1166,29 @@ export class Backend {
             throw e;
         }
         return void 0;
+    }
+
+    /** @type {import('api').ApiHandler<'fetchLocalAudioData'>} */
+    async _onApiFetchLocalAudioData({url}) {
+        const response = await fetch(url);
+        if (!response.ok) {
+            log.error(`Local server responded with HTTP status code ${response.status}`);
+            return null;
+        }
+
+        const contentType = response.headers.get('content-type') || 'audio/mpeg';
+        const arrayBuffer = await response.arrayBuffer();
+
+        let binary = '';
+        const bytes = new Uint8Array(arrayBuffer);
+        for (let i = 0; i < bytes.byteLength; i++) {
+            binary += String.fromCharCode(bytes[i]);
+        }
+
+        return {
+            data: btoa(binary),
+            contentType: contentType,
+        };
     }
 
     // Command handlers

--- a/ext/js/background/background-main.js
+++ b/ext/js/background/background-main.js
@@ -17,6 +17,7 @@
  */
 
 import {log} from '../core/log.js';
+import {toError} from '../core/to-error.js';
 import {WebExtension} from '../extension/web-extension.js';
 import {Backend} from './backend.js';
 
@@ -47,10 +48,14 @@ async function fetchLocalAudioData(url) {
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     if (message.type === 'FETCH_LOCAL_AUDIO_DATA') {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        fetchLocalAudioData(message.url)
+        const url = /** @type {unknown} */ (message.url);
+        if (typeof url !== 'string') {
+            sendResponse({success: false, error: 'Invalid or missing URL parameter'});
+            return false;
+        }
+        fetchLocalAudioData(url)
             .then((result) => sendResponse({success: true, data: result.data, contentType: result.contentType}))
-            .catch((error) => sendResponse({success: false, error: /** @type {Error} */ (error).message}));
+            .catch((error) => sendResponse({success: false, error: toError(error).message}));
         return true;
     }
 });

--- a/ext/js/background/background-main.js
+++ b/ext/js/background/background-main.js
@@ -20,6 +20,41 @@ import {log} from '../core/log.js';
 import {WebExtension} from '../extension/web-extension.js';
 import {Backend} from './backend.js';
 
+/**
+ * @param {string} url
+ * @returns {Promise<{data: string, contentType: string}>}
+ */
+async function fetchLocalAudioData(url) {
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`Local server responded with HTTP status code ${response.status}`);
+    }
+
+    const contentType = response.headers.get('content-type') || 'audio/mpeg';
+    const arrayBuffer = await response.arrayBuffer();
+
+    let binary = '';
+    const bytes = new Uint8Array(arrayBuffer);
+    for (let i = 0; i < bytes.byteLength; i++) {
+        binary += String.fromCharCode(bytes[i]);
+    }
+
+    return {
+        data: btoa(binary),
+        contentType: contentType,
+    };
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message.type === 'FETCH_LOCAL_AUDIO_DATA') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        fetchLocalAudioData(message.url)
+            .then((result) => sendResponse({success: true, data: result.data, contentType: result.contentType}))
+            .catch((error) => sendResponse({success: false, error: /** @type {Error} */ (error).message}));
+        return true;
+    }
+});
+
 /** Entry point. */
 async function main() {
     const webExtension = new WebExtension();

--- a/ext/js/background/background-main.js
+++ b/ext/js/background/background-main.js
@@ -17,48 +17,8 @@
  */
 
 import {log} from '../core/log.js';
-import {toError} from '../core/to-error.js';
 import {WebExtension} from '../extension/web-extension.js';
 import {Backend} from './backend.js';
-
-/**
- * @param {string} url
- * @returns {Promise<{data: string, contentType: string}>}
- */
-async function fetchLocalAudioData(url) {
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Local server responded with HTTP status code ${response.status}`);
-    }
-
-    const contentType = response.headers.get('content-type') || 'audio/mpeg';
-    const arrayBuffer = await response.arrayBuffer();
-
-    let binary = '';
-    const bytes = new Uint8Array(arrayBuffer);
-    for (let i = 0; i < bytes.byteLength; i++) {
-        binary += String.fromCharCode(bytes[i]);
-    }
-
-    return {
-        data: btoa(binary),
-        contentType: contentType,
-    };
-}
-
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-    if (message.type === 'FETCH_LOCAL_AUDIO_DATA') {
-        const url = /** @type {unknown} */ (message.url);
-        if (typeof url !== 'string') {
-            sendResponse({success: false, error: 'Invalid or missing URL parameter'});
-            return false;
-        }
-        fetchLocalAudioData(url)
-            .then((result) => sendResponse({success: true, data: result.data, contentType: result.contentType}))
-            .catch((error) => sendResponse({success: false, error: toError(error).message}));
-        return true;
-    }
-});
 
 /** Entry point. */
 async function main() {

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -435,6 +435,14 @@ export class API {
         return this._invoke('forceSync', void 0);
     }
 
+    /**
+     * @param {string} url
+     * @returns {Promise<{data: string, contentType: string}|null>}
+     */
+    fetchLocalAudioData(url) {
+        return this._invoke('fetchLocalAudioData', {url});
+    }
+
     // Utilities
 
     /**

--- a/ext/js/core/utilities.js
+++ b/ext/js/core/utilities.js
@@ -344,3 +344,27 @@ export async function unsafeArrayBufferDigest(algorithm, arrayBuffer) {
     // @ts-expect-error - Allow SHA-1 here
     return arrayBufferDigest(algorithm, arrayBuffer);
 }
+
+/**
+ * @param {string} urlString
+ * @returns {boolean}
+ */
+export function isLocalhostUrl(urlString) {
+    try {
+        const url = new URL(urlString);
+        switch (url.hostname.toLowerCase()) {
+            case 'localhost':
+            case '127.0.0.1':
+            case '[::1]':
+                switch (url.protocol.toLowerCase()) {
+                    case 'http:':
+                    case 'https:':
+                        return true;
+                }
+                break;
+        }
+    } catch (e) {
+        // NOP
+    }
+    return false;
+}

--- a/ext/js/display/display-audio.js
+++ b/ext/js/display/display-audio.js
@@ -32,7 +32,7 @@ export class DisplayAudio {
         /** @type {?import('display-audio').GenericAudio} */
         this._audioPlaying = null;
         /** @type {AudioSystem} */
-        this._audioSystem = new AudioSystem();
+        this._audioSystem = new AudioSystem(this._display.application.api);
         /** @type {number} */
         this._playbackVolume = 1;
         /** @type {boolean} */

--- a/ext/js/media/audio-system.js
+++ b/ext/js/media/audio-system.js
@@ -74,7 +74,7 @@ export class AudioSystem extends EventDispatcher {
      * @returns {Promise<HTMLAudioElement|WebAudioLocalAudio>}
      */
     async createAudio(url, sourceType) {
-        if (url.startsWith('http://localhost') || url.startsWith('http://127.0.0.1')) {
+        if (this._isLocalUrl(url)) {
             /** @type {{success: boolean, data?: string, contentType?: string, error?: string}|undefined} */
             const response = await chrome.runtime.sendMessage({
                 type: 'FETCH_LOCAL_AUDIO_DATA',
@@ -149,6 +149,19 @@ export class AudioSystem extends EventDispatcher {
             }
             default:
                 return true;
+        }
+    }
+
+    /**
+     * @param {string} url
+     * @returns {boolean}
+     */
+    _isLocalUrl(url) {
+        try {
+            const {hostname} = new URL(url);
+            return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+        } catch (e) {
+            return false;
         }
     }
 

--- a/ext/js/media/audio-system.js
+++ b/ext/js/media/audio-system.js
@@ -18,6 +18,7 @@
 
 import {EventDispatcher} from '../core/event-dispatcher.js';
 import {TextToSpeechAudio} from './text-to-speech-audio.js';
+import {WebAudioLocalAudio} from './web-audio-local-audio.js';
 
 /**
  * @augments EventDispatcher<import('audio-system').Events>
@@ -70,9 +71,25 @@ export class AudioSystem extends EventDispatcher {
     /**
      * @param {string} url
      * @param {import('settings').AudioSourceType} sourceType
-     * @returns {Promise<HTMLAudioElement>}
+     * @returns {Promise<HTMLAudioElement|WebAudioLocalAudio>}
      */
     async createAudio(url, sourceType) {
+        if (url.startsWith('http://localhost') || url.startsWith('http://127.0.0.1')) {
+            /** @type {{success: boolean, data?: string, contentType?: string, error?: string}|undefined} */
+            const response = await chrome.runtime.sendMessage({
+                type: 'FETCH_LOCAL_AUDIO_DATA',
+                url: url,
+            });
+
+            if (!response || !response.success || !response.data) {
+                throw new Error(response?.error || 'Failed to fetch local audio from background context');
+            }
+
+            const audio = new WebAudioLocalAudio(response.data, response.contentType || 'audio/mpeg');
+            await this._waitForData(audio);
+            return audio;
+        }
+
         const audio = new Audio(url);
         await this._waitForData(audio);
         if (!this._isAudioValid(audio, sourceType)) {
@@ -105,7 +122,7 @@ export class AudioSystem extends EventDispatcher {
     }
 
     /**
-     * @param {HTMLAudioElement} audio
+     * @param {HTMLAudioElement|WebAudioLocalAudio} audio
      * @returns {Promise<void>}
      */
     _waitForData(audio) {

--- a/ext/js/media/audio-system.js
+++ b/ext/js/media/audio-system.js
@@ -17,6 +17,7 @@
  */
 
 import {EventDispatcher} from '../core/event-dispatcher.js';
+import {isLocalhostUrl} from '../core/utilities.js';
 import {TextToSpeechAudio} from './text-to-speech-audio.js';
 import {WebAudioLocalAudio} from './web-audio-local-audio.js';
 
@@ -74,7 +75,7 @@ export class AudioSystem extends EventDispatcher {
      * @returns {Promise<HTMLAudioElement|WebAudioLocalAudio>}
      */
     async createAudio(url, sourceType) {
-        if (this._isLocalUrl(url)) {
+        if (isLocalhostUrl(url)) {
             /** @type {{success: boolean, data?: string, contentType?: string, error?: string}|undefined} */
             const response = await chrome.runtime.sendMessage({
                 type: 'FETCH_LOCAL_AUDIO_DATA',
@@ -149,19 +150,6 @@ export class AudioSystem extends EventDispatcher {
             }
             default:
                 return true;
-        }
-    }
-
-    /**
-     * @param {string} url
-     * @returns {boolean}
-     */
-    _isLocalUrl(url) {
-        try {
-            const {hostname} = new URL(url);
-            return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
-        } catch (e) {
-            return false;
         }
     }
 

--- a/ext/js/media/audio-system.js
+++ b/ext/js/media/audio-system.js
@@ -27,7 +27,7 @@ import {WebAudioLocalAudio} from './web-audio-local-audio.js';
  */
 export class AudioSystem extends EventDispatcher {
     /**
-     * @param {API} api
+     * @param {API?} api
      */
     constructor(api) {
         super();
@@ -35,7 +35,7 @@ export class AudioSystem extends EventDispatcher {
         this._fallbackAudio = null;
         /** @type {?import('settings').FallbackSoundType} */
         this._fallbackSoundType = null;
-        /** @type {API} */
+        /** @type {API?} */
         this._api = api;
     }
 
@@ -82,6 +82,7 @@ export class AudioSystem extends EventDispatcher {
      */
     async createAudio(url, sourceType) {
         if (isLocalhostUrl(url)) {
+            if (!this._api) { throw new Error('Backend API not available'); }
             /** @type {{data: string, contentType: string}|null} */
             const response = await this._api.fetchLocalAudioData(url);
 

--- a/ext/js/media/audio-system.js
+++ b/ext/js/media/audio-system.js
@@ -89,9 +89,9 @@ export class AudioSystem extends EventDispatcher {
                 throw new Error('Failed to fetch local audio from background context');
             }
 
-            const audio = new WebAudioLocalAudio(response.data, response.contentType || 'audio/mpeg');
-            await this._waitForData(audio);
-            return audio;
+            const localAudio = new WebAudioLocalAudio(response.data, response.contentType || 'audio/mpeg');
+            await localAudio.prepare();
+            return localAudio;
         }
 
         const audio = new Audio(url);
@@ -126,7 +126,7 @@ export class AudioSystem extends EventDispatcher {
     }
 
     /**
-     * @param {HTMLAudioElement|WebAudioLocalAudio} audio
+     * @param {HTMLAudioElement} audio
      * @returns {Promise<void>}
      */
     _waitForData(audio) {

--- a/ext/js/media/audio-system.js
+++ b/ext/js/media/audio-system.js
@@ -81,8 +81,7 @@ export class AudioSystem extends EventDispatcher {
      * @returns {Promise<HTMLAudioElement|WebAudioLocalAudio>}
      */
     async createAudio(url, sourceType) {
-        if (isLocalhostUrl(url)) {
-            if (!this._api) { throw new Error('Backend API not available'); }
+        if (isLocalhostUrl(url) && this._api) {
             /** @type {{data: string, contentType: string}|null} */
             const response = await this._api.fetchLocalAudioData(url);
 

--- a/ext/js/media/audio-system.js
+++ b/ext/js/media/audio-system.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import {API} from '../comm/api.js';
 import {EventDispatcher} from '../core/event-dispatcher.js';
 import {isLocalhostUrl} from '../core/utilities.js';
 import {TextToSpeechAudio} from './text-to-speech-audio.js';
@@ -25,12 +26,17 @@ import {WebAudioLocalAudio} from './web-audio-local-audio.js';
  * @augments EventDispatcher<import('audio-system').Events>
  */
 export class AudioSystem extends EventDispatcher {
-    constructor() {
+    /**
+     * @param {API} api
+     */
+    constructor(api) {
         super();
         /** @type {?HTMLAudioElement} */
         this._fallbackAudio = null;
         /** @type {?import('settings').FallbackSoundType} */
         this._fallbackSoundType = null;
+        /** @type {API} */
+        this._api = api;
     }
 
     /**
@@ -76,14 +82,11 @@ export class AudioSystem extends EventDispatcher {
      */
     async createAudio(url, sourceType) {
         if (isLocalhostUrl(url)) {
-            /** @type {{success: boolean, data?: string, contentType?: string, error?: string}|undefined} */
-            const response = await chrome.runtime.sendMessage({
-                type: 'FETCH_LOCAL_AUDIO_DATA',
-                url: url,
-            });
+            /** @type {{data: string, contentType: string}|null} */
+            const response = await this._api.fetchLocalAudioData(url);
 
-            if (!response || !response.success || !response.data) {
-                throw new Error(response?.error || 'Failed to fetch local audio from background context');
+            if (!response) {
+                throw new Error('Failed to fetch local audio from background context');
             }
 
             const audio = new WebAudioLocalAudio(response.data, response.contentType || 'audio/mpeg');

--- a/ext/js/media/web-audio-local-audio.js
+++ b/ext/js/media/web-audio-local-audio.js
@@ -15,6 +15,21 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import {toError} from '../core/to-error.js';
+
+/** @type {?AudioContext} */
+let sharedAudioContext = null;
+
+/**
+ * @returns {AudioContext}
+ */
+function getSharedAudioContext() {
+    if (!sharedAudioContext || sharedAudioContext.state === 'closed') {
+        sharedAudioContext = new AudioContext();
+    }
+    return sharedAudioContext;
+}
+
 export class WebAudioLocalAudio {
     /**
      * @param {string} base64Data
@@ -69,7 +84,7 @@ export class WebAudioLocalAudio {
     addEventListener(event, callback) {
         if (event === 'loadeddata') {
             try {
-                this._audioContext = new AudioContext();
+                this._audioContext = getSharedAudioContext();
 
                 const byteCharacters = atob(this._base64Data);
                 const byteNumbers = new Array(byteCharacters.length);
@@ -85,12 +100,12 @@ export class WebAudioLocalAudio {
                         callback();
                     },
                     (err) => {
-                        this._error = err instanceof Error ? err : new Error('Failed to decode local audio data');
+                        this._error = toError(err);
                         if (this._errorCallback) { this._errorCallback(); }
                     },
                 );
             } catch (e) {
-                this._error = e instanceof Error ? e : new Error('Failed to initialize audio context');
+                this._error = toError(e);
                 if (this._errorCallback) { this._errorCallback(); }
             }
         } else if (event === 'error') {

--- a/ext/js/media/web-audio-local-audio.js
+++ b/ext/js/media/web-audio-local-audio.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2026  Yomitan Authors
+ * Copyright (C) 2026  Yomitan Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/ext/js/media/web-audio-local-audio.js
+++ b/ext/js/media/web-audio-local-audio.js
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export class WebAudioLocalAudio {
+    /**
+     * @param {string} base64Data
+     * @param {string} contentType
+     */
+    constructor(base64Data, contentType) {
+        /** @type {string} */
+        this._base64Data = base64Data;
+        /** @type {string} */
+        this._contentType = contentType;
+        /** @type {number} */
+        this._volume = 1;
+        /** @type {number} */
+        this._currentTime = 0;
+        /** @type {?AudioContext} */
+        this._audioContext = null;
+        /** @type {?AudioBufferSourceNode} */
+        this._bufferSource = null;
+        /** @type {?GainNode} */
+        this._gainNode = null;
+        /** @type {?AudioBuffer} */
+        this._decodedBuffer = null;
+        /** @type {?Error} */
+        this._error = null;
+        /** @type {?(() => void)} */
+        this._errorCallback = null;
+    }
+
+    /** @type {number} */
+    get currentTime() { return this._currentTime; }
+
+    set currentTime(value) { this._currentTime = value; }
+
+    /** @type {number} */
+    get volume() { return this._volume; }
+
+    set volume(value) {
+        this._volume = value;
+        if (this._gainNode) { this._gainNode.gain.value = value; }
+    }
+
+    /** @type {number} */
+    get duration() { return this._decodedBuffer ? this._decodedBuffer.duration : 0; }
+
+    /** @type {?Error} */
+    get error() { return this._error; }
+
+    /**
+     * @param {string} event
+     * @param {() => void} callback
+     */
+    addEventListener(event, callback) {
+        if (event === 'loadeddata') {
+            try {
+                this._audioContext = new AudioContext();
+
+                const byteCharacters = atob(this._base64Data);
+                const byteNumbers = new Array(byteCharacters.length);
+                for (let i = 0; i < byteCharacters.length; i++) {
+                    byteNumbers[i] = byteCharacters.charCodeAt(i);
+                }
+                const byteArray = new Uint8Array(byteNumbers);
+
+                void this._audioContext.decodeAudioData(
+                    /** @type {ArrayBuffer} */ (byteArray.buffer),
+                    (buffer) => {
+                        this._decodedBuffer = buffer;
+                        callback();
+                    },
+                    (err) => {
+                        this._error = err instanceof Error ? err : new Error('Failed to decode local audio data');
+                        if (this._errorCallback) { this._errorCallback(); }
+                    },
+                );
+            } catch (e) {
+                this._error = e instanceof Error ? e : new Error('Failed to initialize audio context');
+                if (this._errorCallback) { this._errorCallback(); }
+            }
+        } else if (event === 'error') {
+            this._errorCallback = callback;
+            if (this._error) { callback(); }
+        }
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async play() {
+        if (!this._decodedBuffer || !this._audioContext) { return; }
+        if (this._audioContext.state === 'suspended') {
+            await this._audioContext.resume();
+        }
+        this.pause();
+
+        this._bufferSource = this._audioContext.createBufferSource();
+        this._bufferSource.buffer = this._decodedBuffer;
+
+        this._gainNode = this._audioContext.createGain();
+        this._gainNode.gain.value = this._volume;
+
+        this._bufferSource.connect(this._gainNode);
+        this._gainNode.connect(this._audioContext.destination);
+        this._bufferSource.start(0, this._currentTime);
+    }
+
+    /**
+     * @returns {void}
+     */
+    pause() {
+        if (this._bufferSource) {
+            try { this._bufferSource.stop(); } catch (e) { /* NOP */ }
+            this._bufferSource = null;
+        }
+    }
+}

--- a/ext/js/media/web-audio-local-audio.js
+++ b/ext/js/media/web-audio-local-audio.js
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {toError} from '../core/to-error.js';
 
 /** @type {?AudioContext} */
 let sharedAudioContext = null;
@@ -44,8 +43,8 @@ export class WebAudioLocalAudio {
         this._volume = 1;
         /** @type {number} */
         this._currentTime = 0;
-        /** @type {?AudioContext} */
-        this._audioContext = null;
+        /** @type {AudioContext} */
+        this._audioContext = getSharedAudioContext();
         /** @type {?AudioBufferSourceNode} */
         this._bufferSource = null;
         /** @type {?GainNode} */
@@ -77,41 +76,16 @@ export class WebAudioLocalAudio {
     /** @type {?Error} */
     get error() { return this._error; }
 
-    /**
-     * @param {string} event
-     * @param {() => void} callback
-     */
-    addEventListener(event, callback) {
-        if (event === 'loadeddata') {
-            try {
-                this._audioContext = getSharedAudioContext();
-
-                const byteCharacters = atob(this._base64Data);
-                const byteNumbers = new Array(byteCharacters.length);
-                for (let i = 0; i < byteCharacters.length; i++) {
-                    byteNumbers[i] = byteCharacters.charCodeAt(i);
-                }
-                const byteArray = new Uint8Array(byteNumbers);
-
-                void this._audioContext.decodeAudioData(
-                    /** @type {ArrayBuffer} */ (byteArray.buffer),
-                    (buffer) => {
-                        this._decodedBuffer = buffer;
-                        callback();
-                    },
-                    (err) => {
-                        this._error = toError(err);
-                        if (this._errorCallback) { this._errorCallback(); }
-                    },
-                );
-            } catch (e) {
-                this._error = toError(e);
-                if (this._errorCallback) { this._errorCallback(); }
-            }
-        } else if (event === 'error') {
-            this._errorCallback = callback;
-            if (this._error) { callback(); }
+    /** */
+    async prepare() {
+        const byteCharacters = atob(this._base64Data);
+        const byteNumbers = new Array(byteCharacters.length);
+        for (let i = 0; i < byteCharacters.length; i++) {
+            byteNumbers[i] = byteCharacters.charCodeAt(i);
         }
+        const byteArray = new Uint8Array(byteNumbers);
+
+        this._decodedBuffer = await this._audioContext.decodeAudioData(byteArray.buffer);
     }
 
     /**

--- a/ext/js/media/web-audio-local-audio.js
+++ b/ext/js/media/web-audio-local-audio.js
@@ -51,10 +51,6 @@ export class WebAudioLocalAudio {
         this._gainNode = null;
         /** @type {?AudioBuffer} */
         this._decodedBuffer = null;
-        /** @type {?Error} */
-        this._error = null;
-        /** @type {?(() => void)} */
-        this._errorCallback = null;
     }
 
     /** @type {number} */
@@ -72,9 +68,6 @@ export class WebAudioLocalAudio {
 
     /** @type {number} */
     get duration() { return this._decodedBuffer ? this._decodedBuffer.duration : 0; }
-
-    /** @type {?Error} */
-    get error() { return this._error; }
 
     /** */
     async prepare() {

--- a/ext/js/pages/settings/audio-controller.js
+++ b/ext/js/pages/settings/audio-controller.js
@@ -36,7 +36,7 @@ export class AudioController extends EventDispatcher {
         /** @type {import('./modal-controller.js').ModalController} */
         this._modalController = modalController;
         /** @type {AudioSystem} */
-        this._audioSystem = new AudioSystem();
+        this._audioSystem = new AudioSystem(null);
         /** @type {HTMLElement} */
         this._audioSourceContainer = querySelectorNotNull(document, '#audio-source-list');
         /** @type {HTMLButtonElement} */

--- a/ext/js/pages/settings/backup-controller.js
+++ b/ext/js/pages/settings/backup-controller.js
@@ -22,6 +22,7 @@ import {parseJson} from '../../core/json.js';
 import {log} from '../../core/log.js';
 import {isObjectNotArray} from '../../core/object-utilities.js';
 import {toError} from '../../core/to-error.js';
+import {isLocalhostUrl} from '../../core/utilities.js';
 import {arrayBufferUtf8Decode} from '../../data/array-buffer-util.js';
 import {OptionsUtil} from '../../data/options-util.js';
 import {getAllPermissions} from '../../data/permissions-util.js';
@@ -326,30 +327,6 @@ export class BackupController {
     }
 
     /**
-     * @param {string} urlString
-     * @returns {boolean}
-     */
-    _isLocalhostUrl(urlString) {
-        try {
-            const url = new URL(urlString);
-            switch (url.hostname.toLowerCase()) {
-                case 'localhost':
-                case '127.0.0.1':
-                case '[::1]':
-                    switch (url.protocol.toLowerCase()) {
-                        case 'http:':
-                        case 'https:':
-                            return true;
-                    }
-                    break;
-            }
-        } catch (e) {
-            // NOP
-        }
-        return false;
-    }
-
-    /**
      * @param {import('settings').ProfileOptions} options
      * @param {boolean} dryRun
      * @returns {string[]}
@@ -367,7 +344,7 @@ export class BackupController {
                 }
             }
             const server = anki.server;
-            if (typeof server === 'string' && server.length > 0 && !this._isLocalhostUrl(server)) {
+            if (typeof server === 'string' && server.length > 0 && !isLocalhostUrl(server)) {
                 warnings.push('anki.server uses a non-localhost URL');
                 if (!dryRun) {
                     anki.server = 'http://127.0.0.1:8765';
@@ -383,7 +360,7 @@ export class BackupController {
                     const source = sources[i];
                     if (!isObjectNotArray(source)) { continue; }
                     const {url} = source;
-                    if (typeof url === 'string' && url.length > 0 && !this._isLocalhostUrl(url)) {
+                    if (typeof url === 'string' && url.length > 0 && !isLocalhostUrl(url)) {
                         warnings.push(`audio.sources[${i}].url uses a non-localhost URL`);
                         if (!dryRun) {
                             sources[i].url = '';

--- a/types/ext/api.d.ts
+++ b/types/ext/api.d.ts
@@ -414,6 +414,12 @@ type ApiSurface = {
         params: void;
         return: void;
     };
+    fetchLocalAudioData: {
+        params: {
+            url: string;
+        };
+        return: {data: string, contentType: string} | null;
+    };
 };
 
 type ApiExtraArgs = [sender: chrome.runtime.MessageSender];

--- a/types/ext/display-audio.d.ts
+++ b/types/ext/display-audio.d.ts
@@ -16,6 +16,7 @@
  */
 
 import type {TextToSpeechAudio} from '../../ext/js/media/text-to-speech-audio';
+import type {WebAudioLocalAudio} from '../../ext/js/media/web-audio-local-audio';
 import type * as Audio from './audio';
 import type * as AudioDownloader from './audio-downloader';
 import type * as Settings from './settings';
@@ -92,7 +93,7 @@ export type CreateAudioResult = {
     cacheUpdated: boolean;
 };
 
-export type GenericAudio = HTMLAudioElement | TextToSpeechAudio;
+export type GenericAudio = HTMLAudioElement | TextToSpeechAudio | WebAudioLocalAudio;
 
 export type MenuItemEntry = {
     valid: boolean | null;


### PR DESCRIPTION
Fixes #2310 

Mimics the setup for `TextToSpeechAudio` when it encounters local target urls for the audio server. It offloads the fetching of the audio data to the background, which causes it to be recognized by the extension and allowed through. Only applies to local URLs, global URLs are still going through the flow as before.

By doing this it can circumvent the constant, very annoying LNA prompts. (see example below)

<img width="411" height="167" alt="image" src="https://github.com/user-attachments/assets/62bf8ac2-4f33-4151-9dba-9dd7e1159844" />

Note: to replicate this issue, go to `about:config` and set `network.lna.blocking` to true.