### PR TITLE
Add remaining Celtic languages (br, gv, kw)

### DIFF
--- a/ext/js/language/language-descriptors.js
+++ b/ext/js/language/language-descriptors.js
@@ -138,6 +138,13 @@ const languageDescriptors = [
         textPreprocessors: capitalizationPreprocessors,
     },
     {
+        iso: 'br',
+        iso639_3: 'bre',
+        name: 'Breton',
+        exampleText: 'lenn',
+        textPreprocessors: capitalizationPreprocessors,
+    },
+    {
         iso: 'cs',
         iso639_3: 'ces',
         name: 'Czech',
@@ -269,6 +276,13 @@ const languageDescriptors = [
         languageTransforms: ancientGreekTransforms,
     },
     {
+        iso: 'gv',
+        iso639_3: 'glv',
+        name: 'Manx',
+        exampleText: 'lhaih',
+        textPreprocessors: capitalizationPreprocessors,
+    },
+    {
         // no 2 letter iso for hawaiian
         iso: 'haw',
         iso639_3: 'haw',
@@ -391,6 +405,13 @@ const languageDescriptors = [
             reassembleHangul,
         },
         languageTransforms: koreanTransforms,
+    },
+    {
+        iso: 'kw',
+        iso639_3: 'cor',
+        name: 'Cornish',
+        exampleText: 'lenna',
+        textPreprocessors: capitalizationPreprocessors,
     },
     {
         iso: 'mn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -7179,6 +7179,8 @@
         },
         "node_modules/jszip": {
             "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+            "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
             "dev": true,
             "license": "(MIT OR GPL-3.0-or-later)",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -118,9 +118,9 @@
         "dexie-export-import": "^4.1.4",
         "hangul-js": "^0.2.6",
         "kanji-processor": "^1.0.2",
+        "linkedom": "^0.18.10",
         "parse5": "^7.2.1",
-        "yomitan-handlebars": "git+https://github.com/yomidevs/yomitan-handlebars.git#12aff5e3550954d7d3a98a5917ff7d579f3cce25",
-        "linkedom": "^0.18.10"
+        "yomitan-handlebars": "git+https://github.com/yomidevs/yomitan-handlebars.git#12aff5e3550954d7d3a98a5917ff7d579f3cce25"
     },
     "lint-staged": {
         "*.md": "prettier --write"

--- a/types/ext/language-descriptors.d.ts
+++ b/types/ext/language-descriptors.d.ts
@@ -103,6 +103,9 @@ type AllTextProcessors = {
     bg: {
         pre: CapitalizationPreprocessors;
     };
+    br: {
+        pre: CapitalizationPreprocessors;
+    };
     cs: {
         pre: CapitalizationPreprocessors;
     };
@@ -158,6 +161,9 @@ type AllTextProcessors = {
             convertLatinToGreek: TextProcessor;
         };
     };
+    gv: {
+        pre: CapitalizationPreprocessors;
+    };
     haw: {
         pre: CapitalizationPreprocessors;
     };
@@ -207,6 +213,9 @@ type AllTextProcessors = {
     };
     km: Record<string, never>;
     kn: Record<string, never>;
+    kw: {
+        pre: CapitalizationPreprocessors;
+    };
     mn: {
         pre: CapitalizationPreprocessors;
     };


### PR DESCRIPTION
This pull request adds basic support for the 3 missing Celtic languages, Breton, Cornish and Manx. Checked to make sure this builds and works in Firefox.