### PR TITLE
Optimize batched Anki duplicate searches

### DIFF
--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -309,7 +309,7 @@ export class AnkiConnect {
         if (!this._enabled) { return []; }
         await this._checkVersion();
 
-        const actions = [];
+        const queries = [];
         const actionsTargetsList = [];
         /** @type {Map<string, import('anki').NoteId[][]>} */
         const actionsTargetsMap = new Map();
@@ -323,12 +323,32 @@ export class AnkiConnect {
                 actionsTargets = [];
                 actionsTargetsList.push(actionsTargets);
                 actionsTargetsMap.set(query, actionsTargets);
-                actions.push({action: 'findNotes', params: {query}});
+                queries.push(query);
             }
             /** @type {import('anki').NoteId[]} */
             const noteIds = [];
             allNoteIds.push(noteIds);
             actionsTargets.push(noteIds);
+        }
+
+        if (queries.length === 0) { return allNoteIds; }
+
+        let actions;
+        const hasEmptyQuery = queries.some((query) => query.length === 0);
+        if (queries.length === 1 || hasEmptyQuery) {
+            actions = queries.map((query) => ({action: 'findNotes', params: {query}}));
+        } else {
+            // Find the union once, then constrain each original query to the candidate notes.
+            const unionQuery = queries.map((query) => `(${query})`).join(' or ');
+            const unionResult = await this._invoke('findNotes', {query: unionQuery});
+            const candidateNoteIds = /** @type {number[]} */ (this._normalizeArray(unionResult, -1, 'number'));
+            if (candidateNoteIds.length === 0) { return allNoteIds; }
+
+            const candidateFilter = `nid:${candidateNoteIds.join(',')}`;
+            actions = queries.map((query) => ({
+                action: 'findNotes',
+                params: {query: `${candidateFilter} (${query})`},
+            }));
         }
 
         const result = await this._invokeMulti(actions);


### PR DESCRIPTION
My problem: it's very slow to show the add button when I have a lot of dictionaries and the word has many entries:

<img width="667" height="533" alt="image" src="https://github.com/user-attachments/assets/1a3071f4-e072-4df0-a585-3df27f8d63ae" />

Previously, each candidate triggered a separate full-collection `findNotes` search.

The new approach finds all candidates in one combined query, then performs exact matching within that smaller candidate set.

Here is the performance comparison on my collection:

<img width="2736" height="824" alt="image" src="https://github.com/user-attachments/assets/4319dc8c-91f2-4a2e-8ee9-19ecdbf4ee02" />

