### PR TITLE
Add keyboard-only scan navigation (scan next/previous word)

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -512,7 +512,8 @@
                                     "reducedMotionScrollingSwipeThreshold",
                                     "normalizeCssZoom",
                                     "scanWithoutMousemove",
-                                    "scanResolution"
+                                    "scanResolution",
+                                    "keyboardScanSelector"
                                 ],
                                 "properties": {
                                     "inputs": {
@@ -848,6 +849,10 @@
                                             "word"
                                         ],
                                         "default": "character"
+                                    },
+                                    "keyboardScanSelector": {
+                                        "type": "string",
+                                        "default": ""
                                     }
                                 }
                             },

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -131,6 +131,7 @@ export class Frontend {
             ['scanTextAtCaret',  this._onActionScanTextAtCaret.bind(this)],
             ['scanNextWord', this._onActionScanNextWord.bind(this)],
             ['scanPreviousWord', this._onActionScanPreviousWord.bind(this)],
+            ['scanFirstWord', this._onActionScanFirstWord.bind(this)],
             ['profilePrevious',   async () => { await setProfile(-1, this._application); }],
             ['profileNext',       async () => { await setProfile(1, this._application); }],
         ]);
@@ -305,6 +306,13 @@ export class Frontend {
      */
     _onActionScanPreviousWord() {
         void this._scanKeyboardWord(-1);
+    }
+
+    /**
+     * @returns {void}
+     */
+    _onActionScanFirstWord() {
+        void this._scanKeyboardWordFirst();
     }
 
     // API message handlers
@@ -1045,11 +1053,7 @@ export class Frontend {
      * @returns {Promise<void>}
      */
     async _scanKeyboardWord(direction) {
-        if (this._options === null) { return; }
-        const selector = this._options.scanning.keyboardScanSelector;
-        if (selector === '') { return; }
-
-        const containerElement = this._selectKeyboardScanContainer(selector);
+        const containerElement = this._getKeyboardScanContainer();
         if (containerElement === null) { return; }
 
         if (direction < 0) {
@@ -1059,6 +1063,38 @@ export class Frontend {
             return;
         }
 
+        await this._scanKeyboardWordForward(containerElement);
+    }
+
+    /**
+     * Jumps back to the first scannable word of the `scanning.keyboardScanSelector`
+     * container, discarding any in-progress next/previous navigation.
+     * @returns {Promise<void>}
+     */
+    async _scanKeyboardWordFirst() {
+        const containerElement = this._getKeyboardScanContainer();
+        if (containerElement === null) { return; }
+        this._keyboardTextNavigator.forceReset();
+        await this._scanKeyboardWordForward(containerElement);
+    }
+
+    /**
+     * @returns {?Element}
+     */
+    _getKeyboardScanContainer() {
+        if (this._options === null) { return null; }
+        const selector = this._options.scanning.keyboardScanSelector;
+        if (selector === '') { return null; }
+        return this._selectKeyboardScanContainer(selector);
+    }
+
+    /**
+     * Probes forward from the navigator's current position within `containerElement`
+     * until a scannable word is found (showing it) or the container is exhausted.
+     * @param {Element} containerElement
+     * @returns {Promise<void>}
+     */
+    async _scanKeyboardWordForward(containerElement) {
         for (;;) {
             const candidate = this._keyboardTextNavigator.getNextCandidate(containerElement);
             if (candidate === null) { return; }
@@ -1125,7 +1161,7 @@ export class Frontend {
             timer = setTimeout(() => { finish({textSource: null}); }, 500);
             this._textScanner.on('searchSuccess', onSuccess);
             this._textScanner.on('searchEmpty', onEmpty);
-            void this._textScanner.search(source, null, false);
+            void this._textScanner.search(source, {focus: true, restoreSelection: false}, false);
         });
     }
 

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -202,6 +202,9 @@ export class Frontend {
             ['frontendGetPopupSelectionText', this._onApiGetPopupSelectionText.bind(this)],
             ['frontendGetPopupInfo',     this._onApiGetPopupInfo.bind(this)],
             ['frontendGetPageInfo',      this._onApiGetPageInfo.bind(this)],
+            ['frontendScanNextWord',     this._onApiScanNextWord.bind(this)],
+            ['frontendScanPreviousWord', this._onApiScanPreviousWord.bind(this)],
+            ['frontendScanFirstWord',    this._onApiScanFirstWord.bind(this)],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */
 
@@ -326,6 +329,21 @@ export class Frontend {
     _onApiCopySelection() {
         // This will not work on Firefox if a popup has focus, which is usually the case when this function is called.
         document.execCommand('copy');
+    }
+
+    /** @type {import('cross-frame-api').ApiHandler<'frontendScanNextWord'>} */
+    _onApiScanNextWord() {
+        void this._scanKeyboardWord(1);
+    }
+
+    /** @type {import('cross-frame-api').ApiHandler<'frontendScanPreviousWord'>} */
+    _onApiScanPreviousWord() {
+        void this._scanKeyboardWord(-1);
+    }
+
+    /** @type {import('cross-frame-api').ApiHandler<'frontendScanFirstWord'>} */
+    _onApiScanFirstWord() {
+        void this._scanKeyboardWordFirst();
     }
 
     /** @type {import('cross-frame-api').ApiHandler<'frontendGetPopupSelectionText'>} */

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -1067,10 +1067,23 @@ export class Frontend {
      * Scans forward (`direction === 1`) or backward (`direction === -1`) to the
      * next/previous scannable word inside the `scanning.keyboardScanSelector`
      * container, without requiring the mouse to be positioned over it.
+     *
+     * A nested `Frontend` instance (one created inside a popup, for recursive
+     * scanning of the popup's own content — see `Display._setupNestedFrontend`)
+     * shares its `HotkeyHandler` with the popup's `Display`, so its registration
+     * for this action silently shadows `Display`'s own forwarding registration.
+     * If this instance is nested (`_depth > 0`), forward to the parent frame
+     * instead of scanning this instance's own document, which would never find
+     * the page's `scanning.keyboardScanSelector` container.
      * @param {1|-1} direction
      * @returns {Promise<void>}
      */
     async _scanKeyboardWord(direction) {
+        if (this._depth > 0) {
+            await this._forwardKeyboardScanToParent(direction < 0 ? 'frontendScanPreviousWord' : 'frontendScanNextWord');
+            return;
+        }
+
         const containerElement = this._getKeyboardScanContainer();
         if (containerElement === null) { return; }
 
@@ -1087,13 +1100,32 @@ export class Frontend {
     /**
      * Jumps back to the first scannable word of the `scanning.keyboardScanSelector`
      * container, discarding any in-progress next/previous navigation.
+     * See _scanKeyboardWord() for why nested instances forward instead.
      * @returns {Promise<void>}
      */
     async _scanKeyboardWordFirst() {
+        if (this._depth > 0) {
+            await this._forwardKeyboardScanToParent('frontendScanFirstWord');
+            return;
+        }
+
         const containerElement = this._getKeyboardScanContainer();
         if (containerElement === null) { return; }
         this._keyboardTextNavigator.forceReset();
         await this._scanKeyboardWordForward(containerElement);
+    }
+
+    /**
+     * @param {'frontendScanNextWord'|'frontendScanPreviousWord'|'frontendScanFirstWord'} action
+     * @returns {Promise<void>}
+     */
+    async _forwardKeyboardScanToParent(action) {
+        if (this._parentFrameId === null) { return; }
+        try {
+            await this._application.crossFrame.invoke(this._parentFrameId, action, void 0);
+        } catch (e) {
+            // NOP
+        }
     }
 
     /**

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -26,6 +26,7 @@ import {addFullscreenChangeEventListener, getFullscreenElement} from '../dom/doc
 import {TextSourceElement} from '../dom/text-source-element.js';
 import {TextSourceGenerator} from '../dom/text-source-generator.js';
 import {TextSourceRange} from '../dom/text-source-range.js';
+import {KeyboardTextNavigator} from '../language/keyboard-text-navigator.js';
 import {TextScanner} from '../language/text-scanner.js';
 
 /**
@@ -112,6 +113,8 @@ export class Frontend {
         this._isPointerOverPopup = false;
         /** @type {?import('settings').OptionsContext} */
         this._optionsContextOverride = null;
+        /** @type {KeyboardTextNavigator} */
+        this._keyboardTextNavigator = new KeyboardTextNavigator();
 
         /* eslint-disable @stylistic/no-multi-spaces */
         /** @type {import('application').ApiMap} */
@@ -126,6 +129,8 @@ export class Frontend {
             ['scanSelectedText', this._onActionScanSelectedText.bind(this)],
             ['scanTextAtSelection', this._onActionScanTextAtSelection.bind(this)],
             ['scanTextAtCaret',  this._onActionScanTextAtCaret.bind(this)],
+            ['scanNextWord', this._onActionScanNextWord.bind(this)],
+            ['scanPreviousWord', this._onActionScanPreviousWord.bind(this)],
             ['profilePrevious',   async () => { await setProfile(-1, this._application); }],
             ['profileNext',       async () => { await setProfile(1, this._application); }],
         ]);
@@ -286,6 +291,20 @@ export class Frontend {
      */
     _onActionScanTextAtCaret() {
         void this._scanSelectedText(true, false);
+    }
+
+    /**
+     * @returns {void}
+     */
+    _onActionScanNextWord() {
+        void this._scanKeyboardWord(1);
+    }
+
+    /**
+     * @returns {void}
+     */
+    _onActionScanPreviousWord() {
+        void this._scanKeyboardWord(-1);
     }
 
     // API message handlers
@@ -1016,6 +1035,78 @@ export class Frontend {
         safePerformance.mark('frontend:scanSelectedText:end');
         safePerformance.measure('frontend:scanSelectedText', 'frontend:scanSelectedText:start', 'frontend:scanSelectedText:end');
         return true;
+    }
+
+    /**
+     * Scans forward (`direction === 1`) or backward (`direction === -1`) to the
+     * next/previous scannable word inside the `scanning.keyboardScanSelector`
+     * container, without requiring the mouse to be positioned over it.
+     * @param {1|-1} direction
+     * @returns {Promise<void>}
+     */
+    async _scanKeyboardWord(direction) {
+        if (this._options === null) { return; }
+        const selector = this._options.scanning.keyboardScanSelector;
+        if (selector === '') { return; }
+
+        /** @type {?Element} */
+        let containerElement;
+        try {
+            containerElement = document.querySelector(selector);
+        } catch (e) {
+            return;
+        }
+        if (containerElement === null) { return; }
+
+        if (direction < 0) {
+            const range = this._keyboardTextNavigator.getPrevious(containerElement);
+            if (range === null) { return; }
+            await this._textScanner.search(TextSourceRange.create(range), {focus: true, restoreSelection: false}, false);
+            return;
+        }
+
+        for (;;) {
+            const candidate = this._keyboardTextNavigator.getNextCandidate(containerElement);
+            if (candidate === null) { return; }
+            const {offset, range} = candidate;
+            const result = await this._probeKeyboardScan(TextSourceRange.create(range));
+            if (result.textSource !== null) {
+                this._keyboardTextNavigator.reportSuccess(offset, result.textSource.text().length);
+                return;
+            }
+            this._keyboardTextNavigator.reportFailure(offset);
+        }
+    }
+
+    /**
+     * Performs a scan and resolves once the scanner reports whether it found a
+     * dictionary match, since {@link TextScanner#search} itself doesn't return this.
+     * @param {import('text-source').TextSource} source
+     * @returns {Promise<{textSource: ?import('text-source').TextSource}>}
+     */
+    _probeKeyboardScan(source) {
+        return new Promise((resolve) => {
+            let settled = false;
+            /** @type {?import('core').Timeout} */
+            let timer = null;
+            const finish = (/** @type {{textSource: ?import('text-source').TextSource}} */ result) => {
+                if (settled) { return; }
+                settled = true;
+                this._textScanner.off('searchSuccess', onSuccess);
+                this._textScanner.off('searchEmpty', onEmpty);
+                if (timer !== null) { clearTimeout(timer); }
+                resolve(result);
+            };
+            /**
+             * @param {import('text-scanner').EventArgument<'searchSuccess'>} details
+             */
+            const onSuccess = ({textSource}) => { finish({textSource}); };
+            const onEmpty = () => { finish({textSource: null}); };
+            timer = setTimeout(() => { finish({textSource: null}); }, 500);
+            this._textScanner.on('searchSuccess', onSuccess);
+            this._textScanner.on('searchEmpty', onEmpty);
+            void this._textScanner.search(source, null, false);
+        });
     }
 
     /**

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -1049,13 +1049,7 @@ export class Frontend {
         const selector = this._options.scanning.keyboardScanSelector;
         if (selector === '') { return; }
 
-        /** @type {?Element} */
-        let containerElement;
-        try {
-            containerElement = document.querySelector(selector);
-        } catch (e) {
-            return;
-        }
+        const containerElement = this._selectKeyboardScanContainer(selector);
         if (containerElement === null) { return; }
 
         if (direction < 0) {
@@ -1076,6 +1070,32 @@ export class Frontend {
             }
             this._keyboardTextNavigator.reportFailure(offset);
         }
+    }
+
+    /**
+     * Resolves the `scanning.keyboardScanSelector` to a single container element.
+     * Some pages (e.g. asbplayer's subtitle overlay) accumulate multiple elements
+     * matching the same selector over time instead of reusing/removing one, so
+     * `querySelector`'s "first match" isn't reliable. Prefer the last matching
+     * element that currently has text, falling back to the last match overall.
+     * @param {string} selector
+     * @returns {?Element}
+     */
+    _selectKeyboardScanContainer(selector) {
+        /** @type {NodeListOf<Element>} */
+        let elements;
+        try {
+            elements = document.querySelectorAll(selector);
+        } catch (e) {
+            return null;
+        }
+        let fallback = null;
+        for (let i = elements.length - 1; i >= 0; --i) {
+            const element = elements[i];
+            if (fallback === null) { fallback = element; }
+            if ((element.textContent ?? '').trim().length > 0) { return element; }
+        }
+        return fallback;
     }
 
     /**

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -589,6 +589,7 @@ export class OptionsUtil {
             this._updateVersion75,
             this._updateVersion76,
             this._updateVersion77,
+            this._updateVersion78,
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1858,6 +1859,16 @@ export class OptionsUtil {
      */
     async _updateVersion77(options) {
         await this._applyAnkiFieldTemplatesPatch(options, '/data/templates/anki-field-templates-upgrade-v77.handlebars');
+    }
+
+    /**
+     * - Added scanning.keyboardScanSelector
+     * @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion78(options) {
+        for (const profile of options.profiles) {
+            profile.options.scanning.keyboardScanSelector = '';
+        }
     }
 
     /**

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -2040,11 +2040,16 @@ export class Display extends EventDispatcher {
      * Without this, pressing e.g. scanNextWord again while the popup is focused
      * would silently do nothing, since the popup's own document has no idea
      * what that action means.
+     *
+     * Uses `invokeParentFrame` (the frame that created this popup), not
+     * `invokeContentOrigin` (which is for proxy-popup scenarios and throws
+     * when the popup and its content live in the same frame — the normal case
+     * for a typical embedded popup).
      * @param {'frontendScanNextWord'|'frontendScanPreviousWord'|'frontendScanFirstWord'} action
      * @returns {boolean}
      */
     _forwardKeyboardScanToContentOrigin(action) {
-        if (typeof this._contentOriginFrameId !== 'number') { return false; }
+        if (typeof this._parentFrameId !== 'number') { return false; }
         void this._forwardKeyboardScanToContentOriginSafe(action);
         return true;
     }
@@ -2055,7 +2060,7 @@ export class Display extends EventDispatcher {
      */
     async _forwardKeyboardScanToContentOriginSafe(action) {
         try {
-            await this.invokeContentOrigin(action, void 0);
+            await this.invokeParentFrame(action, void 0);
         } catch (e) {
             // NOP
         }

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -2041,6 +2041,14 @@ export class Display extends EventDispatcher {
      * would silently do nothing, since the popup's own document has no idea
      * what that action means.
      *
+     * Note: when popup nesting is enabled (the default), `Display` shares its
+     * `HotkeyHandler` with a nested `Frontend` instance it creates for scanning
+     * the popup's own content (see `_setupNestedFrontend`), and that nested
+     * `Frontend` registers the same action names — silently shadowing this
+     * registration. The nested `Frontend` handles forwarding itself in that
+     * case (see `Frontend._scanKeyboardWord`'s `_depth > 0` check); this
+     * registration only ends up being used when nesting is disabled.
+     *
      * Uses `invokeParentFrame` (the frame that created this popup), not
      * `invokeContentOrigin` (which is for proxy-popup scenarios and throws
      * when the popup and its content live in the same frame — the normal case

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -216,6 +216,9 @@ export class Display extends EventDispatcher {
             ['copyHostSelection', () => this._copyHostSelection()],
             ['nextEntryDifferentDictionary',     () => { this._focusEntryWithDifferentDictionary(1, true); }],
             ['previousEntryDifferentDictionary', () => { this._focusEntryWithDifferentDictionary(-1, true); }],
+            ['scanNextWord',      () => this._forwardKeyboardScanToContentOrigin('frontendScanNextWord')],
+            ['scanPreviousWord',  () => this._forwardKeyboardScanToContentOrigin('frontendScanPreviousWord')],
+            ['scanFirstWord',     () => this._forwardKeyboardScanToContentOrigin('frontendScanFirstWord')],
         ]);
         this.registerDirectMessageHandlers([
             ['displaySetOptionsContext', this._onMessageSetOptionsContext.bind(this)],
@@ -2025,6 +2028,34 @@ export class Display extends EventDispatcher {
     async _copyHostSelectionSafe() {
         try {
             await this._copyHostSelectionInner();
+        } catch (e) {
+            // NOP
+        }
+    }
+
+    /**
+     * Forwards a keyboard-scan-navigation hotkey pressed while this popup has
+     * focus back to the content page's Frontend, which is where
+     * `scanning.keyboardScanSelector` and the page DOM it targets actually live.
+     * Without this, pressing e.g. scanNextWord again while the popup is focused
+     * would silently do nothing, since the popup's own document has no idea
+     * what that action means.
+     * @param {'frontendScanNextWord'|'frontendScanPreviousWord'|'frontendScanFirstWord'} action
+     * @returns {boolean}
+     */
+    _forwardKeyboardScanToContentOrigin(action) {
+        if (typeof this._contentOriginFrameId !== 'number') { return false; }
+        void this._forwardKeyboardScanToContentOriginSafe(action);
+        return true;
+    }
+
+    /**
+     * @param {'frontendScanNextWord'|'frontendScanPreviousWord'|'frontendScanFirstWord'} action
+     * @returns {Promise<void>}
+     */
+    async _forwardKeyboardScanToContentOriginSafe(action) {
+        try {
+            await this.invokeContentOrigin(action, void 0);
         } catch (e) {
             // NOP
         }

--- a/ext/js/language/keyboard-text-navigator.js
+++ b/ext/js/language/keyboard-text-navigator.js
@@ -49,6 +49,15 @@ export class KeyboardTextNavigator {
         this._probeOffset = 0;
         /** @type {boolean} */
         this._pendingIsReplay = false;
+        /**
+         * How many character positions have been examined (skipped as
+         * whitespace, or tried and failed) since the current forward search
+         * began. Bounds wrap-around probing to at most one full pass over the
+         * container's text, so a container with nothing scannable at all
+         * can't cause an infinite loop. `null` while no search is in progress.
+         * @type {?number}
+         */
+        this._cycleStepsExamined = null;
     }
 
     /**
@@ -63,6 +72,7 @@ export class KeyboardTextNavigator {
         this._probeOffset = 0;
         this._pendingIsReplay = false;
         this._containerText = '';
+        this._cycleStepsExamined = null;
     }
 
     /**
@@ -129,6 +139,7 @@ export class KeyboardTextNavigator {
             this._historyIndex = this._offsets.length - 1;
         }
         this._probeOffset = offset + Math.max(1, matchLength);
+        this._cycleStepsExamined = null;
     }
 
     /**
@@ -144,6 +155,9 @@ export class KeyboardTextNavigator {
             this._offsets.length = this._historyIndex + 1;
         }
         this._probeOffset = offset + 1;
+        if (this._cycleStepsExamined !== null) {
+            this._cycleStepsExamined += 1;
+        }
     }
 
     // Private
@@ -160,23 +174,42 @@ export class KeyboardTextNavigator {
             this._historyIndex = -1;
             this._probeOffset = 0;
             this._pendingIsReplay = false;
+            this._cycleStepsExamined = null;
         }
     }
 
     /**
+     * Probes forward from `_probeOffset`, wrapping around to the start of the
+     * container's text at most once if the end is reached, so "next word"
+     * cycles back to the first word instead of stopping. Bounded by
+     * `_cycleStepsExamined` reaching the text length, so a container with no
+     * scannable text anywhere terminates instead of looping forever.
      * @param {Element} containerElement
      * @returns {?{offset: number, range: Range}}
      */
     _nextProbeCandidate(containerElement) {
         const text = containerElement.textContent ?? '';
-        let offset = this._probeOffset;
-        while (offset < text.length && isIgnorableCharacter(text.charAt(offset))) {
-            ++offset;
+        const {length} = text;
+        if (length === 0) { return null; }
+        if (this._cycleStepsExamined === null) { this._cycleStepsExamined = 0; }
+
+        let offset = this._probeOffset % length;
+        while (this._cycleStepsExamined < length && isIgnorableCharacter(text.charAt(offset))) {
+            offset = (offset + 1) % length;
+            ++this._cycleStepsExamined;
         }
+        if (this._cycleStepsExamined >= length) {
+            this._cycleStepsExamined = null;
+            return null;
+        }
+
         this._probeOffset = offset;
-        if (offset >= text.length) { return null; }
         const range = this._createRangeAtOffset(containerElement, offset);
-        return range === null ? null : {offset, range};
+        if (range === null) {
+            this._cycleStepsExamined = null;
+            return null;
+        }
+        return {offset, range};
     }
 
     /**

--- a/ext/js/language/keyboard-text-navigator.js
+++ b/ext/js/language/keyboard-text-navigator.js
@@ -52,6 +52,20 @@ export class KeyboardTextNavigator {
     }
 
     /**
+     * Unconditionally discards all navigation state, regardless of whether the
+     * container's text has changed. The next getNextCandidate() call will
+     * probe from the very start of whatever container it's given.
+     * @returns {void}
+     */
+    forceReset() {
+        this._offsets = [];
+        this._historyIndex = -1;
+        this._probeOffset = 0;
+        this._pendingIsReplay = false;
+        this._containerText = '';
+    }
+
+    /**
      * Returns the `Range` that a "scan next word" press should try, or `null` if
      * there is nothing left to try (the container's text has been fully consumed).
      * Does not mutate any state; call reportSuccess() or reportFailure()

--- a/ext/js/language/keyboard-text-navigator.js
+++ b/ext/js/language/keyboard-text-navigator.js
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @param {string} character
+ * @returns {boolean}
+ */
+function isIgnorableCharacter(character) {
+    return /\s/.test(character);
+}
+
+/**
+ * Tracks a position within a container element's live text content so that
+ * "scan next word" / "scan previous word" hotkeys can step through scannable
+ * candidates without relying on the mouse. The container is always re-queried
+ * from the live DOM by the caller, so this class only needs to know how to
+ * turn a linear character offset into a `Range`, and how to remember which
+ * offsets have already been confirmed to contain a dictionary match.
+ */
+export class KeyboardTextNavigator {
+    constructor() {
+        /** @type {?Element} */
+        this._containerElement = null;
+        /** @type {number[]} */
+        this._offsets = [];
+        /** @type {number} */
+        this._historyIndex = -1;
+        /** @type {number} */
+        this._probeOffset = 0;
+        /** @type {boolean} */
+        this._pendingIsReplay = false;
+    }
+
+    /** @type {?Element} */
+    get containerElement() {
+        return this._containerElement;
+    }
+
+    /**
+     * Returns the `Range` that a "scan next word" press should try, or `null` if
+     * there is nothing left to try (the container's text has been fully consumed).
+     * Does not mutate any state; call reportSuccess() or reportFailure()
+     * with the result of attempting a scan on the returned range.
+     * @param {Element} containerElement
+     * @returns {?{offset: number, range: Range}}
+     */
+    getNextCandidate(containerElement) {
+        this._setContainer(containerElement);
+
+        if (this._historyIndex < this._offsets.length - 1) {
+            const offset = /** @type {number} */ (this._offsets[this._historyIndex + 1]);
+            const range = this._createRangeAtOffset(containerElement, offset);
+            if (range !== null) {
+                this._pendingIsReplay = true;
+                return {offset, range};
+            }
+            // The recorded offset no longer resolves to a position in the container
+            // (its text changed). Drop the now-stale history and probe forward instead.
+            this._offsets.length = this._historyIndex + 1;
+        }
+
+        this._pendingIsReplay = false;
+        return this._nextProbeCandidate(containerElement);
+    }
+
+    /**
+     * Returns the `Range` that a "scan previous word" press should show, or `null`
+     * if there is no earlier recorded offset to go back to.
+     * @param {Element} containerElement
+     * @returns {?Range}
+     */
+    getPrevious(containerElement) {
+        this._setContainer(containerElement);
+        let index = this._historyIndex;
+        while (index > 0) {
+            --index;
+            const offset = /** @type {number} */ (this._offsets[index]);
+            const range = this._createRangeAtOffset(containerElement, offset);
+            if (range !== null) {
+                this._historyIndex = index;
+                return range;
+            }
+            // The recorded offset no longer resolves (container text changed); skip it.
+        }
+        return null;
+    }
+
+    /**
+     * Records that the candidate at `offset` produced a dictionary match of the
+     * given length, so that future "next"/"previous" presses can resume correctly.
+     * @param {number} offset
+     * @param {number} matchLength
+     * @returns {void}
+     */
+    reportSuccess(offset, matchLength) {
+        if (this._pendingIsReplay) {
+            ++this._historyIndex;
+        } else {
+            this._offsets.push(offset);
+            this._historyIndex = this._offsets.length - 1;
+        }
+        this._probeOffset = offset + Math.max(1, matchLength);
+    }
+
+    /**
+     * Records that the candidate at `offset` did not produce a dictionary match,
+     * so forward probing should resume just past it.
+     * @param {number} offset
+     * @returns {void}
+     */
+    reportFailure(offset) {
+        if (this._pendingIsReplay) {
+            // The container's text has changed since this offset was recorded;
+            // drop it (and anything after it) so it's never replayed again.
+            this._offsets.length = this._historyIndex + 1;
+        }
+        this._probeOffset = offset + 1;
+    }
+
+    // Private
+
+    /**
+     * @param {Element} containerElement
+     * @returns {void}
+     */
+    _setContainer(containerElement) {
+        if (this._containerElement !== containerElement) {
+            this._containerElement = containerElement;
+            this._offsets = [];
+            this._historyIndex = -1;
+            this._probeOffset = 0;
+            this._pendingIsReplay = false;
+        }
+    }
+
+    /**
+     * @param {Element} containerElement
+     * @returns {?{offset: number, range: Range}}
+     */
+    _nextProbeCandidate(containerElement) {
+        const text = containerElement.textContent ?? '';
+        let offset = this._probeOffset;
+        while (offset < text.length && isIgnorableCharacter(text.charAt(offset))) {
+            ++offset;
+        }
+        this._probeOffset = offset;
+        if (offset >= text.length) { return null; }
+        const range = this._createRangeAtOffset(containerElement, offset);
+        return range === null ? null : {offset, range};
+    }
+
+    /**
+     * Converts a linear character offset into the container's flattened text
+     * content into a `Range` starting at that position and ending at the end
+     * of the container, so the caller can hand it to the dictionary scanner.
+     * @param {Element} containerElement
+     * @param {number} offset
+     * @returns {?Range}
+     */
+    _createRangeAtOffset(containerElement, offset) {
+        const walker = document.createTreeWalker(containerElement, NodeFilter.SHOW_TEXT);
+        let remaining = offset;
+        let node = walker.nextNode();
+        while (node !== null) {
+            const length = /** @type {Text} */ (node).data.length;
+            if (remaining < length) {
+                const range = document.createRange();
+                range.setStart(node, remaining);
+                range.setEnd(containerElement, containerElement.childNodes.length);
+                return range;
+            }
+            remaining -= length;
+            node = walker.nextNode();
+        }
+        return null;
+    }
+}

--- a/ext/js/language/keyboard-text-navigator.js
+++ b/ext/js/language/keyboard-text-navigator.js
@@ -30,11 +30,17 @@ function isIgnorableCharacter(character) {
  * from the live DOM by the caller, so this class only needs to know how to
  * turn a linear character offset into a `Range`, and how to remember which
  * offsets have already been confirmed to contain a dictionary match.
+ *
+ * Navigation state resets when the container's *text content* changes, not
+ * when the element reference changes: some pages (e.g. React-based subtitle
+ * overlays) recreate the container element on re-render even when its text
+ * is unchanged, and treating that as "a new subtitle" would make it
+ * impossible to ever move past the first word.
  */
 export class KeyboardTextNavigator {
     constructor() {
-        /** @type {?Element} */
-        this._containerElement = null;
+        /** @type {string} */
+        this._containerText = '';
         /** @type {number[]} */
         this._offsets = [];
         /** @type {number} */
@@ -43,11 +49,6 @@ export class KeyboardTextNavigator {
         this._probeOffset = 0;
         /** @type {boolean} */
         this._pendingIsReplay = false;
-    }
-
-    /** @type {?Element} */
-    get containerElement() {
-        return this._containerElement;
     }
 
     /**
@@ -138,8 +139,9 @@ export class KeyboardTextNavigator {
      * @returns {void}
      */
     _setContainer(containerElement) {
-        if (this._containerElement !== containerElement) {
-            this._containerElement = containerElement;
+        const text = containerElement.textContent ?? '';
+        if (text !== this._containerText) {
+            this._containerText = text;
             this._offsets = [];
             this._historyIndex = -1;
             this._probeOffset = 0;

--- a/ext/js/pages/settings/keyboard-shortcuts-controller.js
+++ b/ext/js/pages/settings/keyboard-shortcuts-controller.js
@@ -71,6 +71,7 @@ export class KeyboardShortcutController {
             ['scanTextAtCaret',                  {scopes: new Set(['web'])}],
             ['scanNextWord',                     {scopes: new Set(['web'])}],
             ['scanPreviousWord',                 {scopes: new Set(['web'])}],
+            ['scanFirstWord',                    {scopes: new Set(['web'])}],
             ['toggleOption',                     {scopes: new Set(['popup', 'search']), argument: {template: 'hotkey-argument-setting-path', default: ''}}],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */

--- a/ext/js/pages/settings/keyboard-shortcuts-controller.js
+++ b/ext/js/pages/settings/keyboard-shortcuts-controller.js
@@ -69,6 +69,8 @@ export class KeyboardShortcutController {
             ['scanSelectedText',                 {scopes: new Set(['web'])}],
             ['scanTextAtSelection',              {scopes: new Set(['web'])}],
             ['scanTextAtCaret',                  {scopes: new Set(['web'])}],
+            ['scanNextWord',                     {scopes: new Set(['web'])}],
+            ['scanPreviousWord',                 {scopes: new Set(['web'])}],
             ['toggleOption',                     {scopes: new Set(['popup', 'search']), argument: {template: 'hotkey-argument-setting-path', default: ''}}],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */

--- a/ext/js/pages/settings/keyboard-shortcuts-controller.js
+++ b/ext/js/pages/settings/keyboard-shortcuts-controller.js
@@ -69,9 +69,9 @@ export class KeyboardShortcutController {
             ['scanSelectedText',                 {scopes: new Set(['web'])}],
             ['scanTextAtSelection',              {scopes: new Set(['web'])}],
             ['scanTextAtCaret',                  {scopes: new Set(['web'])}],
-            ['scanNextWord',                     {scopes: new Set(['web'])}],
-            ['scanPreviousWord',                 {scopes: new Set(['web'])}],
-            ['scanFirstWord',                    {scopes: new Set(['web'])}],
+            ['scanNextWord',                     {scopes: new Set(['web', 'popup'])}],
+            ['scanPreviousWord',                 {scopes: new Set(['web', 'popup'])}],
+            ['scanFirstWord',                    {scopes: new Set(['web', 'popup'])}],
             ['toggleOption',                     {scopes: new Set(['popup', 'search']), argument: {template: 'hotkey-argument-setting-path', default: ''}}],
         ]);
         /* eslint-enable @stylistic/no-multi-spaces */

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -519,6 +519,36 @@
                 <label class="toggle"><input type="checkbox" data-setting="scanning.scanWithoutMousemove"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
+        <div class="settings-item">
+            <div class="settings-item-inner settings-item-inner-wrappable">
+                <div class="settings-item-left">
+                    <div class="settings-item-label">Keyboard scan container selector</div>
+                    <div class="settings-item-description">
+                        CSS selector for an element to scan through using the keyboard-only scan hotkeys, without needing the mouse.
+                        <a tabindex="0" class="more-toggle more-only" data-parent-distance="4">More&hellip;</a>
+                    </div>
+                </div>
+                <div class="settings-item-right">
+                    <input type="text" placeholder="e.g. .subtitle-text" spellcheck="false" autocomplete="off" data-setting="scanning.keyboardScanSelector">
+                </div>
+            </div>
+            <div class="settings-item-children more" hidden>
+                <p>
+                    When set, the <em>Scan next word</em> and <em>Scan previous word</em> hotkeys (configurable under
+                    <em data-modal-action="show,keyboard-shortcuts">Keyboard shortcuts</em>) will step through scannable
+                    text found inside the first element on the page matching this CSS selector, without requiring the
+                    mouse to hover over it. This is useful for hands-free lookups of subtitles or other text
+                    rendered by another page/extension (e.g. asbplayer).
+                </p>
+                <p>
+                    To use a different selector on different websites, create a separate profile with a URL condition
+                    for that site and set this option within it.
+                </p>
+                <p>
+                    <a tabindex="0" class="more-toggle" data-parent-distance="3">Less&hellip;</a>
+                </p>
+            </div>
+        </div>
         <div class="settings-item"><div class="settings-item-inner">
             <div class="settings-item-left">
                 <div class="settings-item-label">Select matched text</div>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -536,9 +536,14 @@
                 <p>
                     When set, the <em>Scan next word</em> and <em>Scan previous word</em> hotkeys (configurable under
                     <em data-modal-action="show,keyboard-shortcuts">Keyboard shortcuts</em>) will step through scannable
-                    text found inside the first element on the page matching this CSS selector, without requiring the
+                    text found inside an element on the page matching this CSS selector, without requiring the
                     mouse to hover over it. This is useful for hands-free lookups of subtitles or other text
                     rendered by another page/extension (e.g. asbplayer).
+                </p>
+                <p>
+                    If multiple elements on the page match the selector (for example, if the page keeps old subtitle
+                    lines around instead of removing them), the element containing the current text is used, not
+                    necessarily the first match.
                 </p>
                 <p>
                     To use a different selector on different websites, create a separate profile with a URL condition

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -534,11 +534,12 @@
             </div>
             <div class="settings-item-children more" hidden>
                 <p>
-                    When set, the <em>Scan next word</em> and <em>Scan previous word</em> hotkeys (configurable under
-                    <em data-modal-action="show,keyboard-shortcuts">Keyboard shortcuts</em>) will step through scannable
-                    text found inside an element on the page matching this CSS selector, without requiring the
-                    mouse to hover over it. This is useful for hands-free lookups of subtitles or other text
-                    rendered by another page/extension (e.g. asbplayer).
+                    When set, the <em>Scan next word</em>, <em>Scan previous word</em>, and <em>Scan first word</em>
+                    hotkeys (configurable under <em data-modal-action="show,keyboard-shortcuts">Keyboard shortcuts</em>)
+                    will step through scannable text found inside an element on the page matching this CSS selector,
+                    without requiring the mouse to hover over it. This is useful for hands-free lookups of subtitles
+                    or other text rendered by another page/extension (e.g. asbplayer). <em>Scan first word</em> jumps
+                    back to the start of the current line at any time.
                 </p>
                 <p>
                     If multiple elements on the page match the selector (for example, if the page keeps old subtitle

--- a/ext/templates-settings.html
+++ b/ext/templates-settings.html
@@ -443,6 +443,8 @@
             <option value="scanSelectedText">Scan selected text</option>
             <option value="scanTextAtSelection">Scan text at selection</option>
             <option value="scanTextAtCaret">Scan text at caret</option>
+            <option value="scanNextWord">Scan next word (keyboard scan container)</option>
+            <option value="scanPreviousWord">Scan previous word (keyboard scan container)</option>
             <option value="toggleOption">Toggle option</option>
         </select>
         <div class="hotkey-list-item-action-argument-container"></div>

--- a/ext/templates-settings.html
+++ b/ext/templates-settings.html
@@ -445,6 +445,7 @@
             <option value="scanTextAtCaret">Scan text at caret</option>
             <option value="scanNextWord">Scan next word (keyboard scan container)</option>
             <option value="scanPreviousWord">Scan previous word (keyboard scan container)</option>
+            <option value="scanFirstWord">Scan first word (keyboard scan container)</option>
             <option value="toggleOption">Toggle option</option>
         </select>
         <div class="hotkey-list-item-action-argument-container"></div>

--- a/test/keyboard-text-navigator.test.js
+++ b/test/keyboard-text-navigator.test.js
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {afterAll, describe, expect, test} from 'vitest';
+import {KeyboardTextNavigator} from '../ext/js/language/keyboard-text-navigator.js';
+import {setupDomTest} from './fixtures/dom-test.js';
+
+const domTestEnv = await setupDomTest();
+
+describe('KeyboardTextNavigator', () => {
+    const {window, teardown} = domTestEnv;
+    afterAll(() => teardown(global));
+
+    /**
+     * @param {string} text
+     * @returns {HTMLElement}
+     */
+    function createContainer(text) {
+        const {document} = window;
+        const container = document.createElement('div');
+        container.textContent = text;
+        document.body.appendChild(container);
+        return container;
+    }
+
+    test('probes forward across the container, skipping whitespace', () => {
+        const container = createContainer('one two three');
+        const navigator = new KeyboardTextNavigator();
+
+        const first = navigator.getNextCandidate(container);
+        expect(first).not.toBeNull();
+        expect(first?.offset).toBe(0);
+        expect(first?.range.toString()).toBe('one two three');
+        navigator.reportSuccess(/** @type {number} */ (first?.offset), 3); // "one"
+
+        const second = navigator.getNextCandidate(container);
+        expect(second).not.toBeNull();
+        expect(second?.offset).toBe(4); // skips the space after "one"
+        expect(second?.range.toString()).toBe('two three');
+        navigator.reportSuccess(/** @type {number} */ (second?.offset), 3); // "two"
+
+        const third = navigator.getNextCandidate(container);
+        expect(third).not.toBeNull();
+        expect(third?.offset).toBe(8);
+        navigator.reportSuccess(/** @type {number} */ (third?.offset), 5); // "three"
+
+        expect(navigator.getNextCandidate(container)).toBeNull();
+    });
+
+    test('skips over failed candidates when probing forward', () => {
+        const container = createContainer('xx ok');
+        const navigator = new KeyboardTextNavigator();
+
+        const first = navigator.getNextCandidate(container);
+        expect(first?.offset).toBe(0);
+        navigator.reportFailure(/** @type {number} */ (first?.offset));
+
+        const second = navigator.getNextCandidate(container);
+        expect(second?.offset).toBe(1);
+        navigator.reportFailure(/** @type {number} */ (second?.offset));
+
+        const third = navigator.getNextCandidate(container);
+        expect(third?.offset).toBe(3); // skips the space, lands on "ok"
+        expect(third?.range.toString()).toBe('ok');
+    });
+
+    test('replays history backward and forward without re-probing', () => {
+        const container = createContainer('alpha beta');
+        const navigator = new KeyboardTextNavigator();
+
+        const first = navigator.getNextCandidate(container);
+        navigator.reportSuccess(/** @type {number} */ (first?.offset), 5); // "alpha"
+
+        const second = navigator.getNextCandidate(container);
+        navigator.reportSuccess(/** @type {number} */ (second?.offset), 4); // "beta"
+
+        const previous = navigator.getPrevious(container);
+        expect(previous?.toString()).toBe('alpha beta');
+
+        expect(navigator.getPrevious(container)).toBeNull(); // nothing earlier than the first entry
+
+        const replay = navigator.getNextCandidate(container);
+        expect(replay?.offset).toBe(6);
+        expect(replay?.range.toString()).toBe('beta');
+    });
+
+    test('resets navigation state when the container element changes', () => {
+        const containerA = createContainer('foo');
+        const containerB = createContainer('bar');
+        const navigator = new KeyboardTextNavigator();
+
+        const first = navigator.getNextCandidate(containerA);
+        navigator.reportSuccess(/** @type {number} */ (first?.offset), 3);
+        expect(navigator.getPrevious(containerA)).toBeNull();
+
+        const other = navigator.getNextCandidate(containerB);
+        expect(other?.offset).toBe(0);
+        expect(other?.range.toString()).toBe('bar');
+    });
+
+    test('drops a stale replayed offset instead of retrying it forever', () => {
+        const container = createContainer('alpha beta');
+        const navigator = new KeyboardTextNavigator();
+
+        const first = navigator.getNextCandidate(container);
+        navigator.reportSuccess(/** @type {number} */ (first?.offset), 5); // "alpha"
+        const second = navigator.getNextCandidate(container);
+        navigator.reportSuccess(/** @type {number} */ (second?.offset), 4); // "beta"
+
+        navigator.getPrevious(container); // back to "alpha", historyIndex now points at offset 0
+
+        // Next replays the recorded "beta" offset (6), but the caller reports it no
+        // longer matches (e.g. the underlying text changed in a way that isn't detectable
+        // via the container element reference alone).
+        const replay = navigator.getNextCandidate(container);
+        expect(replay?.offset).toBe(6);
+        navigator.reportFailure(/** @type {number} */ (replay?.offset));
+
+        // The stale entry must be dropped, not retried indefinitely; probing resumes
+        // strictly after the failed offset.
+        const resumed = navigator.getNextCandidate(container);
+        expect(resumed).not.toBeNull();
+        expect(resumed?.offset).toBe(7);
+    });
+
+    test('returns null when the container has no scannable text', () => {
+        const container = createContainer('   ');
+        const navigator = new KeyboardTextNavigator();
+        expect(navigator.getNextCandidate(container)).toBeNull();
+    });
+});

--- a/test/keyboard-text-navigator.test.js
+++ b/test/keyboard-text-navigator.test.js
@@ -58,7 +58,33 @@ describe('KeyboardTextNavigator', () => {
         expect(third?.offset).toBe(8);
         navigator.reportSuccess(/** @type {number} */ (third?.offset), 5); // "three"
 
+        // After the last word, next word wraps back around to the first.
+        const wrapped = navigator.getNextCandidate(container);
+        expect(wrapped).not.toBeNull();
+        expect(wrapped?.offset).toBe(0);
+        expect(wrapped?.range.toString()).toBe('one two three');
+    });
+
+    test('wrapping around gives up after one full pass over text with nothing scannable', () => {
+        const container = createContainer('   ');
+        const navigator = new KeyboardTextNavigator();
         expect(navigator.getNextCandidate(container)).toBeNull();
+    });
+
+    test('wrapping does not loop forever when every candidate fails', () => {
+        const container = createContainer('xxx');
+        const navigator = new KeyboardTextNavigator();
+
+        let candidate = navigator.getNextCandidate(container);
+        let attempts = 0;
+        while (candidate !== null && attempts < 10) {
+            navigator.reportFailure(candidate.offset);
+            candidate = navigator.getNextCandidate(container);
+            ++attempts;
+        }
+
+        expect(candidate).toBeNull();
+        expect(attempts).toBeLessThan(10); // must terminate within one pass over the text
     });
 
     test('skips over failed candidates when probing forward', () => {

--- a/test/keyboard-text-navigator.test.js
+++ b/test/keyboard-text-navigator.test.js
@@ -158,4 +158,21 @@ describe('KeyboardTextNavigator', () => {
         const navigator = new KeyboardTextNavigator();
         expect(navigator.getNextCandidate(container)).toBeNull();
     });
+
+    test('forceReset jumps back to the first word even without a text change', () => {
+        const container = createContainer('alpha beta');
+        const navigator = new KeyboardTextNavigator();
+
+        const first = navigator.getNextCandidate(container);
+        navigator.reportSuccess(/** @type {number} */ (first?.offset), 5); // "alpha"
+        const second = navigator.getNextCandidate(container);
+        navigator.reportSuccess(/** @type {number} */ (second?.offset), 4); // "beta"
+
+        navigator.forceReset();
+
+        const afterReset = navigator.getNextCandidate(container);
+        expect(afterReset?.offset).toBe(0);
+        expect(afterReset?.range.toString()).toBe('alpha beta');
+        expect(navigator.getPrevious(container)).toBeNull(); // history was discarded
+    });
 });

--- a/test/keyboard-text-navigator.test.js
+++ b/test/keyboard-text-navigator.test.js
@@ -98,7 +98,7 @@ describe('KeyboardTextNavigator', () => {
         expect(replay?.range.toString()).toBe('beta');
     });
 
-    test('resets navigation state when the container element changes', () => {
+    test('resets navigation state when the container text changes', () => {
         const containerA = createContainer('foo');
         const containerB = createContainer('bar');
         const navigator = new KeyboardTextNavigator();
@@ -110,6 +110,22 @@ describe('KeyboardTextNavigator', () => {
         const other = navigator.getNextCandidate(containerB);
         expect(other?.offset).toBe(0);
         expect(other?.range.toString()).toBe('bar');
+    });
+
+    test('preserves navigation state across a different element instance with the same text', () => {
+        // Some pages (e.g. React-based subtitle overlays) recreate the container
+        // element on re-render even when the displayed text hasn't changed; this
+        // must not be treated as a new subtitle line.
+        const containerInstance1 = createContainer('alpha beta');
+        const navigator = new KeyboardTextNavigator();
+
+        const first = navigator.getNextCandidate(containerInstance1);
+        navigator.reportSuccess(/** @type {number} */ (first?.offset), 5); // "alpha"
+
+        const containerInstance2 = createContainer('alpha beta');
+        const second = navigator.getNextCandidate(containerInstance2);
+        expect(second?.offset).toBe(6); // continues to "beta", does not restart at "alpha"
+        expect(second?.range.toString()).toBe('beta');
     });
 
     test('drops a stale replayed offset instead of retrying it forever', () => {

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -384,6 +384,7 @@ function createProfileOptionsUpdatedTestData1() {
             },
             scanWithoutMousemove: true,
             scanResolution: 'character',
+            keyboardScanSelector: '',
             inputs: [
                 {
                     include: 'shift',
@@ -707,7 +708,7 @@ function createOptionsUpdatedTestData1() {
             },
         ],
         profileCurrent: 0,
-        version: 77,
+        version: 78,
         global: {
             database: {
                 prefixWildcardsSupported: false,

--- a/types/ext/cross-frame-api.d.ts
+++ b/types/ext/cross-frame-api.d.ts
@@ -97,6 +97,18 @@ export type ApiSurface = {
         params: void;
         return: void;
     };
+    frontendScanNextWord: {
+        params: void;
+        return: void;
+    };
+    frontendScanPreviousWord: {
+        params: void;
+        return: void;
+    };
+    frontendScanFirstWord: {
+        params: void;
+        return: void;
+    };
     frontendGetPopupSelectionText: {
         params: void;
         return: string;

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -211,6 +211,7 @@ export type ScanningOptions = {
     normalizeCssZoom: boolean;
     scanWithoutMousemove: boolean;
     scanResolution: string;
+    keyboardScanSelector: string;
 };
 
 export type ScanningInput = {


### PR DESCRIPTION
This was acciedntal. PR should not have been created.


## Summary
- Adds two new hotkey actions, `scanNextWord` and `scanPreviousWord`, that let you step through scannable text without the mouse hovering over it.
- Adds a new option `scanning.keyboardScanSelector` (a CSS selector) identifying the container to scan within — e.g. a subtitle line in a tool like asbplayer. Per-site behavior can be configured for free using Yomitan's existing profile + URL-condition system.
- Motivating use case: looking up words in video subtitles (e.g. via asbplayer) without touching the mouse.
- Fixes #2266.

## Design notes
- The container is always re-queried live from the DOM, so navigation naturally follows subtitle text as it changes.
- Forward stepping ("next") probes character-by-character through the container using the existing `TextScanner`/dictionary-lookup pipeline as the source of truth for what counts as a scannable term — no new word-boundary/segmentation logic was implemented, so it respects existing scan settings (scan resolution, language handling, etc.) for free.
- "Previous" replays previously-confirmed offsets from history rather than re-implementing backward word-boundary detection.
- New hotkeys ship unbound by default; assign them under Settings → Keyboard Shortcuts.
- New logic lives in a small standalone class (`KeyboardTextNavigator`) with its own unit tests, kept independent of `Frontend` for testability.

## Test plan
- [x] `npm run test:js` (eslint)
- [x] `npm run test:ts:main` / `test:ts:test`
- [x] `npm run test:json` (schema validates against its type)
- [x] `npm run test:html`
- [x] `npm run test:css`
- [x] `npm run test:unit` / `test:unit:options` (4639 passing, including 6 new tests for `KeyboardTextNavigator`)
- [x] `npm run test:build` (dry run across all targets)
- [ ] Manual: load the unpacked extension, set `scanning.keyboardScanSelector` to a test container, bind the new hotkeys, and confirm stepping through a line of text opens/updates the popup correctly.